### PR TITLE
Enable Windows in CI, upgrade to Swift 6.2, add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/tothambrus11/hylo-compiler-dev-env:v1.0.10

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,54 @@
+{
+    "name": "Hylo LLVM",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "SWIFT_VERSION" : "6.2",
+            "HYLO_LLVM_BUILD_TYPE": "${localEnv:HYLO_LLVM_BUILD_TYPE:MinSizeRel}"
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "false",
+            "username": "ubuntu",
+            "userUid": "automatic",
+            "userGid": "automatic",
+            "upgradePackages": "false"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided",
+            "ppa": "false"
+        }
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined",
+        "--network=host"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "swiftlang.swift-vscode"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    "containerEnv": {
+        "HYLO_LLVM_BUILD_TYPE": "${localEnv:HYLO_LLVM_BUILD_TYPE:MinSizeRel}"
+    },
+    "remoteEnv": {
+        "PATH": "/python-venv/bin:/opt/llvm-${containerEnv:HYLO_LLVM_BUILD_TYPE}/bin:${containerEnv:PATH}"
+    },
+    // "postCreateCommand": "sudo ./.devcontainer/postCreateCommand.sh",
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "ubuntu"
+}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,17 @@
 name: Build and Test
-on: push
+on: 
+  push:
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+      - ".editorconfig"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+      - ".editorconfig"
 
 jobs:
   test:
@@ -7,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         # Note: all combinations of the following will be run independently
-        os: [macos-14, ubuntu-24.04]
-        swift: ["6.0"]
+        os: [macos-15, ubuntu-24.04, windows-2025]
+        swift: ["6.2"]
         config: [release, debug]
 
     steps:
@@ -19,10 +31,20 @@ jobs:
         with:
           swift-version: ${{ matrix.swift }}
 
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
+          # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
+          # The Swift compiler team is aware of the issue and they are going to release a fix some time.
+
+      - name: Verify swift version
+        run: swift --version && swift --version | grep -q ${{ matrix.swift }}
+        shell: bash
+
       # We disabled the separate build step, as it consumes extra CI time - building for testing apparently doesn't
       # reuse the build cache from here, doubling the CI time.
 
       - name: Build and test for ${{ matrix.swift }} on ${{ matrix.os }} in ${{ matrix.config }} mode
-        run: swift test -c ${{ matrix.config }}
+        run: swift test -c ${{ matrix.config }} --verbose
 
     runs-on: ${{ matrix.os }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import PackageDescription
 
 #if os(Windows)

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -1562,7 +1562,7 @@ private func + <A, B>(
 
 /// Returns a parser that returns an instance of `T` if it can be built by consuming the next
 /// element in the stream.
-private func take<T: RawRepresentable>(
+private func take<T: RawRepresentable & SendableMetatype>(
   _: T.Type
 ) -> BuiltinFunctionParser<T> where T.RawValue == String {
   { (stream: inout ArraySlice<Substring>) -> T? in


### PR DESCRIPTION
Now Swift 6.2 is officially released, so we can use it here.