### PR TITLE
Language server support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,9 @@ let package = Package(
     .macOS(.v13)
   ],
   products: [
-    .executable(name: "hc", targets: ["hc"])
+    .executable(name: "hc", targets: ["hc"]),
+    .library(name: "HyloStandardLibrary", targets: ["StandardLibrary"]),
+    .library(name: "HyloFrontEnd", targets: ["FrontEnd"]),
   ],
   dependencies: [
     .package(

--- a/Sources/FrontEnd/Files/FileName.swift
+++ b/Sources/FrontEnd/Files/FileName.swift
@@ -8,26 +8,44 @@ public enum FileName: Hashable, Sendable {
   case local(URL)
 
   /// A unique identifier for a file that only exists in memory.
-  case virtual(Int)
+  ///
+  /// The payload can be any URL that uniquely identifies the source file within the Program.
+  case virtual(URL)
 
-  /// Returns `true` iff `self` is ordered before `other` in a dictionary.
-  public func lexicographicallyPrecedes(_ other: Self) -> Bool {
-    switch (self, other) {
-    case (.local(let a), .local(let b)):
-      return a.standardizedFileURL.path().lexicographicallyPrecedes(b.standardizedFileURL.path())
-    case (.virtual(let a), .virtual(let b)):
-      return a < b
-    case (.virtual, _):
-      return false
-    case (.local, _):
-      return true
+  /// The associated URL.
+  public var url: URL {
+    switch self {
+    case .local(let url):
+      return url
+    case .virtual(let url):
+      return url
     }
   }
 
-  /// Returns a textual description of `self`'s path relative to `base`.
+  /// `self` with absolute URLs.
+  public var absolute: Self {
+    switch self {
+    case .local(let url):
+      return .local(url.absoluteURL)
+    case .virtual(let url):
+      return .virtual(url.absoluteURL)
+    }
+  }
+  
+  /// Returns `true` iff `self` is ordered before `other` in a dictionary.
+  public func lexicographicallyPrecedes(_ other: Self) -> Bool {
+    let s = self.url.standardizedFileURL.absoluteString
+    let o = other.url.standardizedFileURL.absoluteString
+    return s.lexicographicallyPrecedes(o)
+  }
+
+  /// Returns the `/`-separated path of `self` relative to `base`, if reachable.
   public func gnuPath(relativeTo base: URL) -> String? {
-    guard base.isFileURL, case .local(let path) = self else { return nil }
-    let source = path.standardized.pathComponents
+    let p = self.url
+    guard p.scheme == base.scheme,
+      p.windowsDriveLetter == base.windowsDriveLetter else { return nil }
+
+    let source = p.standardized.pathComponents
     let prefix = base.standardized.pathComponents
 
     // Identify the end of the common prefix.
@@ -58,15 +76,26 @@ public enum FileName: Hashable, Sendable {
 
 }
 
+extension URL {
+  
+  /// Returns the drive letter of an absolute file URL on Windows, nil otherwise.
+  fileprivate var windowsDriveLetter: Character? {
+    #if os(Windows)
+      guard isFileURL, let firstChar = path.first, firstChar.isLetter, path.dropFirst().first == ":" 
+      else { return nil }
+
+      return Character(firstChar.uppercased())
+    #else
+      return nil
+    #endif
+  }
+
+}
+
 extension FileName: CustomStringConvertible {
 
   public var description: String {
-    switch self {
-    case .local(let p):
-      return p.relativePath
-    case .virtual(let i):
-      return "virtual://\(String(UInt(bitPattern: i), radix: 36))"
-    }
+    url.isFileURL ? url.path : url.absoluteString
   }
 
 }
@@ -78,7 +107,7 @@ extension FileName: Archivable {
     case 0:
       self = try .local(.init(string: archive.read(String.self))!)
     case 1:
-      self = try .virtual(archive.read(Int.self))
+      self = try .virtual(.init(string: archive.read(String.self))!)
     default:
       throw ArchiveError.invalidInput
     }
@@ -91,7 +120,7 @@ extension FileName: Archivable {
       try archive.write(p.absoluteString)
     case .virtual(let i):
       archive.write(byte: 1)
-      try archive.write(i)
+      try archive.write(i.absoluteString)
     }
   }
 

--- a/Sources/FrontEnd/Files/SourceFile.swift
+++ b/Sources/FrontEnd/Files/SourceFile.swift
@@ -47,7 +47,18 @@ public struct SourceFile: Hashable, Sendable {
 
   /// Creates a source file with the contents of the file at `path`.
   public init(contentsOf path: URL) throws {
-    try self.init(name: .local(path), contents: .init(contentsOf: path, encoding: .utf8))
+    let contents = try String(contentsOf: path, encoding: .utf8)
+    self.init(localPath: path, contents: contents)
+  }
+
+  /// Creates a source file with given `contents`, representing a local file at `p`.
+  ///
+  /// - Note: `p` can be non-existent or contain different contents on disk,
+  ///   e.g. when called by the LSP.
+  /// - Requires: `p` has a file name component.
+  public init(localPath p: URL, contents: String) {
+    precondition(!p.pathComponents.isEmpty)
+    self.init(name: .local(p), contents: contents)
   }
 
   /// Creates a virtual source file with the given contents.

--- a/Sources/FrontEnd/Files/SourceFile.swift
+++ b/Sources/FrontEnd/Files/SourceFile.swift
@@ -143,6 +143,11 @@ public struct SourceFile: Hashable, Sendable {
     return (lineNumber, columnNumber)
   }
 
+  /// Returns the index in `text` corresponding to the 1-based `line` and `column`.
+  public func index(line: Int, column: Int) -> Index {
+    text.index(properties.lineStarts[line - 1], offsetBy: column - 1)
+  }
+
   /// Calls `action` on each source file URL in `directory` having the extension `pathExtension`.
   public static func forEachURL(
     in directory: URL, withPathExtension pathExtension: String = "hylo",

--- a/Sources/FrontEnd/Files/SourceFile.swift
+++ b/Sources/FrontEnd/Files/SourceFile.swift
@@ -4,12 +4,16 @@ import Foundation
 import Utilities
 
 /// A source file.
+/// 
+/// - Invariant: `name` contains an absolute path.
+/// - Note: A local file name doesn't imply that the file actually exists on disk or that we can 
+///   re-read its contents. It might be supplied by the LSP without having the file saved.
 public struct SourceFile: Hashable, Sendable {
 
   /// The internal representation of a source file.
   private final class Properties: Hashable, Sendable {
 
-    /// The name of the file that the source came from.
+    /// The absolute name of the file that the source came from.
     let name: FileName
 
     /// The contents of the file.
@@ -40,32 +44,27 @@ public struct SourceFile: Hashable, Sendable {
   /// The properties of `self`.
   private let properties: Properties
 
-  /// Creates a source file with the given name and contents.
-  private init(name: FileName, contents: String) {
-    self.properties = .init(name: name, text: contents)
+  /// Creates a source file with given `contents`, associated with the file `n`.
+  ///
+  /// - Requires: `n` has a file name component.
+  public init(name n: FileName, contents: String) {
+    precondition(n.url.pathComponents.count >= 2) // The 0th component is `/`, followed by the real components.
+    self.properties = .init(name: n.absolute, text: contents)
   }
 
-  /// Creates a source file with the contents of the file at `path`.
+  /// Creates a local source file with the contents of the file at `path`.
   public init(contentsOf path: URL) throws {
     let contents = try String(contentsOf: path, encoding: .utf8)
-    self.init(localPath: path, contents: contents)
+    self.init(name: .local(path), contents: contents)
   }
 
-  /// Creates a source file with given `contents`, representing a local file at `p`.
-  ///
-  /// - Note: `p` can be non-existent or contain different contents on disk,
-  ///   e.g. when called by the LSP.
-  /// - Requires: `p` has a file name component.
-  public init(localPath p: URL, contents: String) {
-    precondition(!p.pathComponents.isEmpty)
-    self.init(name: .local(p), contents: contents)
-  }
-
-  /// Creates a virtual source file with the given contents.
+  /// Creates a virtual source file with the given `contents`.
   public init(contents: String) {
     var hasher = FNV()
     hasher.combine(contents)
-    self.init(name: .virtual(hasher.state), contents: contents)
+    self.init(
+      name: .virtual(URL(string: "virtual:///\(String(UInt(bitPattern: hasher.state), radix: 36))")!),
+      contents: contents)
   }
 
   /// The name of the file that the source came from.
@@ -75,12 +74,7 @@ public struct SourceFile: Hashable, Sendable {
 
   /// The name of the source file, sans path qualification or extension.
   public var baseName: String {
-    switch name {
-    case .local(let u):
-      return u.deletingPathExtension().lastPathComponent
-    case .virtual(let i):
-      return String(UInt(bitPattern: i), radix: 36)
-    }
+    name.url.deletingPathExtension().lastPathComponent
   }
 
   /// The contents of the file.

--- a/Sources/FrontEnd/Module.swift
+++ b/Sources/FrontEnd/Module.swift
@@ -347,6 +347,13 @@ public struct Module: Sendable {
     sources.values.map(\.topLevelDeclarations).joined()
   }
 
+  /// Returns the identity of a contained source file named `f`, if any.
+  public func sourceFile(named f: FileName) -> SourceFile.ID? {
+    if let i = sources.index(forKey: f) {
+      SourceFile.ID(module: identity, offset: i)
+    } else { nil }
+  }
+
   /// Projects the source file identified by `f`.
   internal subscript(f: SourceFile.ID) -> SourceContainer {
     _read {

--- a/Sources/FrontEnd/Module.swift
+++ b/Sources/FrontEnd/Module.swift
@@ -269,6 +269,8 @@ public struct Module: Sendable {
   }
 
   /// Adds a source file to this module.
+  /// 
+  /// - Requires: File name `s.name` is not already present in the program.
   @discardableResult
   public mutating func addSource(_ s: SourceFile) -> (inserted: Bool, identity: SourceFile.ID) {
     if let f = sources.index(forKey: s.name) {

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -3,6 +3,8 @@ import OrderedCollections
 import Utilities
 
 /// A Hylo program.
+/// 
+/// - Invariant: The FileName of source files in `self` are unique.
 public struct Program: Sendable {
 
   /// The modules loaded in this program.
@@ -1642,6 +1644,44 @@ fileprivate struct ChildrenEnumerator: SyntaxVisitor {
   fileprivate mutating func willEnter(_ n: AnySyntaxIdentity, in program: Program) -> Bool {
     if n != parent { children.append(n) }
     return n == parent
+  }
+
+}
+
+
+extension Program {
+
+  /// Returns the identity of source file named `f`, if any.
+  public func sourceFile(named f: FileName) -> SourceFile.ID? {
+    modules.values.indices.firstNonNil { (m) in
+      if let i = self[m].sources.index(forKey: f) {
+        SourceFile.ID(module: m, offset: i)
+      } else { nil }
+    }
+  }
+
+  /// Returns the source file identified by `f`.
+  public subscript(sourceFile f: SourceFile.ID) -> SourceFile {
+    self[f].source
+  }
+
+  /// Returns the diagnostics in source file `f`.
+  public func diagnostics(in f: SourceFile.ID) -> DiagnosticSet {
+    self[f].diagnostics
+  }
+
+  /// Returns the top-level declarations in source file `f`.
+  public func topLevelDeclarations(in f: SourceFile.ID) -> some Sequence<DeclarationIdentity> {
+    self[f].topLevelDeclarations
+  }
+
+  /// Returns the givens whose definitions are visible from `scopeOfUse`.
+  ///
+  /// - Requires: `m` has been type checked.
+  public mutating func givens(in m: Module.ID, visibleFrom scopeOfUse: ScopeIdentity) -> [Given] {
+    withTyper(typing: m, { (t) in
+      t.givens(visibleFrom: scopeOfUse).flatMap({ $0 }) 
+    })
   }
 
 }

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1651,12 +1651,10 @@ fileprivate struct ChildrenEnumerator: SyntaxVisitor {
 
 extension Program {
 
-  /// Returns the identity of source file named `f`, if any.
+  /// Returns the identity of a contained source file named `f`, if any.
   public func sourceFile(named f: FileName) -> SourceFile.ID? {
     modules.values.indices.firstNonNil { (m) in
-      if let i = self[m].sources.index(forKey: f) {
-        SourceFile.ID(module: m, offset: i)
-      } else { nil }
+      self[m].sourceFile(named: f)
     }
   }
 
@@ -1680,7 +1678,7 @@ extension Program {
   /// - Requires: `m` has been type checked.
   public mutating func givens(in m: Module.ID, visibleFrom scopeOfUse: ScopeIdentity) -> [Given] {
     withTyper(typing: m, { (t) in
-      t.givens(visibleFrom: scopeOfUse).flatMap({ $0 }) 
+      t.givens(visibleFrom: scopeOfUse).flatMap({ $0 })
     })
   }
 

--- a/Sources/FrontEnd/Syntax/SyntaxVisitor.swift
+++ b/Sources/FrontEnd/Syntax/SyntaxVisitor.swift
@@ -155,7 +155,7 @@ extension Program {
   }
 
   /// Visits `ns` and their children in pre-order, calling back `v` when a node is entered or left.
-  public func visit<T: SyntaxVisitor, U: Collection>(
+  public func visit<T: SyntaxVisitor, U: Sequence>(
     _ ns: U, calling v: inout T
   ) where U.Element: SyntaxIdentity {
     for n in ns {

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -3711,7 +3711,7 @@ public struct Typer {
   /// type is being computed.
   ///
   /// The result does not include built-in givens.
-  private mutating func givens(visibleFrom scopeOfUse: ScopeIdentity) -> [[Given]] {
+  internal mutating func givens(visibleFrom scopeOfUse: ScopeIdentity) -> [[Given]] {
     var gs: [[Given]] = []
 
     // Gather the givens in the current file.

--- a/Tests/FrontEndTests/DiagnosticTests.swift
+++ b/Tests/FrontEndTests/DiagnosticTests.swift
@@ -6,7 +6,7 @@ final class DiagnosticTests: XCTestCase {
   func testDescription() {
     let f: SourceFile = "Hello."
     let e = Diagnostic(.error, "bang", at: f.span)
-    XCTAssertEqual(e.description, "virtual://1ssiyy33rbj6z:1.1-7: error: bang")
+    XCTAssertEqual(e.description, "virtual:///1ssiyy33rbj6z:1.1-7: error: bang")
   }
 
   func testRender() {
@@ -19,7 +19,7 @@ final class DiagnosticTests: XCTestCase {
     XCTAssertEqual(
       rendered,
       """
-      virtual://1ssiyy33rbj6z:1.1-3: error: bang
+      virtual:///1ssiyy33rbj6z:1.1-3: error: bang
       Hello.
       ~~
 
@@ -41,13 +41,13 @@ final class DiagnosticTests: XCTestCase {
     XCTAssertEqual(
       rendered,
       """
-      virtual://1ssiyy33rbj6z:1.1-3: error: bang
+      virtual:///1ssiyy33rbj6z:1.1-3: error: bang
       Hello.
       ~~
-      virtual://1ssiyy33rbj6z:1.1: note: see this
+      virtual:///1ssiyy33rbj6z:1.1: note: see this
       Hello.
       ^
-      virtual://1ssiyy33rbj6z:1.2: note: and that
+      virtual:///1ssiyy33rbj6z:1.2: note: and that
       Hello.
        ^
 
@@ -64,7 +64,7 @@ final class DiagnosticTests: XCTestCase {
     XCTAssertEqual(
       rendered,
       """
-      \u{001B}[1mvirtual://1ssiyy33rbj6z:1.1-3\u{001B}[0m: \u{001B}[1m\u{001B}[31merror\u{001B}[0m: \u{001B}[1mbang\u{001B}[0m
+      \u{001B}[1mvirtual:///1ssiyy33rbj6z:1.1-3\u{001B}[0m: \u{001B}[1m\u{001B}[31merror\u{001B}[0m: \u{001B}[1mbang\u{001B}[0m
       Hello.
       ~~
 

--- a/Tests/FrontEndTests/Files/FileNameTests.swift
+++ b/Tests/FrontEndTests/Files/FileNameTests.swift
@@ -6,13 +6,13 @@ final class FileNameTests: XCTestCase {
 
   func testDescription() {
     XCTAssertEqual(FileName.local(.init(filePath: "/foo/bar")).description, "/foo/bar")
-    XCTAssertEqual(FileName.virtual(1234).description, "virtual://ya")
+    XCTAssertEqual(FileName.virtual(URL(string: "virtual:///1234")!).description, "virtual:///1234")
   }
 
   func testArchive() throws {
     let f1 = FileName.local(.init(filePath: "/foo/bar"))
     try XCTAssertEqual(f1, f1.storedAndLoaded())
-    let f2 = FileName.virtual(1234)
+    let f2 = FileName.virtual(URL(string: "virtual:///1234")!)
     try XCTAssertEqual(f2, f2.storedAndLoaded())
   }
 
@@ -23,8 +23,8 @@ final class FileNameTests: XCTestCase {
     XCTAssertFalse(f2.lexicographicallyPrecedes(f1))
     XCTAssertFalse(f1.lexicographicallyPrecedes(f1))
 
-    let f3 = FileName.virtual(1234)
-    let f4 = FileName.virtual(1235)
+    let f3 = FileName.virtual(URL(string: "virtual:///1234")!)
+    let f4 = FileName.virtual(URL(string: "virtual:///1235")!)
     XCTAssert(f3.lexicographicallyPrecedes(f4))
     XCTAssertFalse(f4.lexicographicallyPrecedes(f3))
     XCTAssertFalse(f3.lexicographicallyPrecedes(f3))

--- a/Tests/FrontEndTests/Files/SourceFileTests.swift
+++ b/Tests/FrontEndTests/Files/SourceFileTests.swift
@@ -75,6 +75,33 @@ final class SourceFileTests: XCTestCase {
     XCTAssertEqual(p2.description, "virtual://350c8wstjkie0:2:6")
   }
 
+  func testLineCount() {
+    XCTAssertEqual(SourceFile.helloWorld.lineCount, 2)
+  }
+
+  func testIndexAtStartOfFile() throws {
+    let f = SourceFile.helloWorld
+    XCTAssertEqual(f.index(line: 1, column: 1), f.text.startIndex)
+  }
+
+  func testIndexWithinFirstLine() throws {
+    let f = SourceFile.helloWorld
+    let comma = try XCTUnwrap(f.text.firstIndex(of: ","))
+    XCTAssertEqual(f.index(line: 1, column: 6), comma)
+  }
+
+  func testIndexAtStartOfSecondLine() throws {
+    let f = SourceFile.helloWorld
+    let line2Start = f.text.index(after: try XCTUnwrap(f.text.firstIndex(where: \.isNewline)))
+    XCTAssertEqual(f.index(line: 2, column: 1), line2Start)
+  }
+
+  func testIndexAtLastCharacter() throws {
+    let f = SourceFile.helloWorld
+    let bang = try XCTUnwrap(f.text.firstIndex(of: "!"))
+    XCTAssertEqual(f.index(line: 2, column: 6), bang)
+  }
+
   func testArchive() throws {
     let f = SourceFile.helloWorld
     try XCTAssertEqual(f, f.storedAndLoaded())

--- a/Tests/FrontEndTests/Files/SourceFileTests.swift
+++ b/Tests/FrontEndTests/Files/SourceFileTests.swift
@@ -62,17 +62,24 @@ final class SourceFileTests: XCTestCase {
   func testLineDescription() {
     let f = SourceFile.helloWorld
     let l = f.line(containing: f.text.startIndex)
-    XCTAssertEqual(l.description, "virtual://350c8wstjkie0:1")
+    XCTAssertEqual(l.description, "virtual:///350c8wstjkie0:1")
   }
 
-  func testPositionDescription() throws {
+  func testVirtualPositionDescription() throws {
     let f = SourceFile.helloWorld
     let i1 = try XCTUnwrap(f.text.firstIndex(of: ","))
     let p1 = SourcePosition(i1, in: f)
-    XCTAssertEqual(p1.description, "virtual://350c8wstjkie0:1:6")
+    XCTAssertEqual(p1.description, "virtual:///350c8wstjkie0:1:6")
     let i2 = try XCTUnwrap(f.text.firstIndex(of: "!"))
     let p2 = SourcePosition(i2, in: f)
-    XCTAssertEqual(p2.description, "virtual://350c8wstjkie0:2:6")
+    XCTAssertEqual(p2.description, "virtual:///350c8wstjkie0:2:6")
+  }
+
+  func testFilePositionDescription() throws {
+    let f = SourceFile(name: .virtual(URL(string: "file:///home/hylo/a.hylo")!), contents: "")
+    let p = SourcePosition(f.startIndex, in: f)
+    XCTAssertEqual(f.name.description, "/home/hylo/a.hylo")
+    XCTAssertEqual(p.description, "/home/hylo/a.hylo:1:1")
   }
 
   func testLineCount() {
@@ -108,10 +115,40 @@ final class SourceFileTests: XCTestCase {
   }
 
   func testInMemoryContents() {
-    let f = SourceFile(localPath: URL(string: "file:///tmp/test.hylo")!, contents: "fun main()")
+    let f = SourceFile(name: .local(URL(string: "file:///tmp/test.hylo")!), contents: "fun main()")
     XCTAssertEqual(f.text, "fun main()")
     XCTAssertEqual(f.name, .local(URL(string: "file:///tmp/test.hylo")!))
   }
+
+  /// Tests that when a file is created with a relative URL, it is equivalent 
+  /// to creating it with an absolute URL.
+  func testRelativePath() {
+    let nonCanonical = URL(fileURLWithPath: "a/../README.md")
+    let relative = URL(fileURLWithPath: "README.md")
+    let absolute = relative.absoluteURL
+
+    let sn = SourceFile(name: .local(nonCanonical), contents: "hello")
+    let sr = SourceFile(name: .local(relative), contents: "hello")
+    let sa = SourceFile(name: .local(absolute), contents: "hello")
+
+    XCTAssertEqual(sr.baseName, "README")
+    XCTAssertEqual(sa.baseName, "README")
+    XCTAssertEqual(sn.baseName, "README")
+
+    XCTAssertEqual(sr, sa)
+    XCTAssertEqual(sn, sa)
+    XCTAssertEqual(sr.hashValue, sa.hashValue)
+    XCTAssertEqual(sn.hashValue, sa.hashValue)
+
+    XCTAssertEqual(sr.name.url, absolute)
+    XCTAssertEqual(sn.name.url, absolute)
+  }
+
+  func testVirtualBaseName() {
+    let s = SourceFile(name: .virtual(URL(string: "virtual:///tests/something.txt")!), contents: "")
+    XCTAssertEqual(s.baseName, "something")
+  }
+
 }
 
 extension SourceFile {

--- a/Tests/FrontEndTests/Files/SourceFileTests.swift
+++ b/Tests/FrontEndTests/Files/SourceFileTests.swift
@@ -107,6 +107,11 @@ final class SourceFileTests: XCTestCase {
     try XCTAssertEqual(f, f.storedAndLoaded())
   }
 
+  func testInMemoryContents() {
+    let f = SourceFile(localPath: URL(string: "file:///tmp/test.hylo")!, contents: "fun main()")
+    XCTAssertEqual(f.text, "fun main()")
+    XCTAssertEqual(f.name, .local(URL(string: "file:///tmp/test.hylo")!))
+  }
 }
 
 extension SourceFile {

--- a/Tests/FrontEndTests/Files/SourceSpanTests.swift
+++ b/Tests/FrontEndTests/Files/SourceSpanTests.swift
@@ -109,9 +109,9 @@ final class SourceSpanTests: XCTestCase {
 
   func testDescription() {
     let f: SourceFile = "Hello."
-    XCTAssertEqual(f.span.description, "virtual://1ssiyy33rbj6z:1.1-7")
+    XCTAssertEqual(f.span.description, "virtual:///1ssiyy33rbj6z:1.1-7")
     let g: SourceFile = "A\nB"
-    XCTAssertEqual(g.span.description, "virtual://3ahohnnbwwf82:1.1-2:2")
+    XCTAssertEqual(g.span.description, "virtual:///3ahohnnbwwf82:1.1-2:2")
   }
 
 }

--- a/Tests/FrontEndTests/ProgramTests.swift
+++ b/Tests/FrontEndTests/ProgramTests.swift
@@ -1,4 +1,5 @@
 import Archivist
+import Foundation
 import FrontEnd
 import XCTest
 
@@ -81,6 +82,115 @@ final class ProgramTests: XCTestCase {
     XCTAssert(loaded)
     (loaded, _) = try q.load(module: p[archives[1].identity].name, from: archives[1].data)
     XCTAssert(loaded)
+  }
+
+  func testGivensCanBeQueriedThroughTypeCheckedProgram() async throws {
+    var p = Program()
+    let m = p.demandModule(.init("Main"))
+    let (_, f) = p[m].addSource(
+      """
+      trait P {}
+
+      struct A { 
+        given w1: B is P {}
+      }
+
+      struct B {}
+
+      given w2: A is P {}
+      """)
+
+    await p.assignScopes(m)
+    p.assignTypes(m, loggingInferenceWhere: nil)
+
+    // Query givens visible from the file level.
+    let givens = p.givens(in: m, visibleFrom: .init(file: f))
+    
+    // The visible given should be the top-level `w2`.
+    guard givens.count == 1, case .user(let given) = givens[0] else {
+      return XCTFail("expected exactly one user-defined given, got \(givens)")
+    }
+
+    let w2 = try XCTUnwrap(
+      p.select(from: m, .and(.tag(ConformanceDeclaration.self), .name(.init(identifier: "w2")))).first)
+    XCTAssertEqual(given.erased, w2)
+  }
+
+  func testQueryingSourceFileWithName() throws {
+    var p = Program()
+
+    let m0 = p.demandModule("M0")
+    let s0: SourceFile = "trait A {}"
+    let (_, id0) = p[m0].addSource(s0)
+
+    let m1 = p.demandModule("M1")
+    let s1: SourceFile = "trait B {}"
+    let (_, id1) = p[m1].addSource(s1)
+
+    // Sources that are present should be found:
+    let f0 = try XCTUnwrap(p.sourceFile(named: s0.name))
+    XCTAssertEqual(f0, id0)
+    XCTAssertEqual(p[sourceFile: f0], s0)
+
+    let f1 = try XCTUnwrap(p.sourceFile(named: s1.name))
+    XCTAssertEqual(f1, id1)
+    XCTAssertEqual(p[sourceFile: f1], s1)
+
+    // Missing sources should result in nil:
+    let missing: FileName = .virtual(URL(string: "virtual:///nonexistent")!)
+    XCTAssertNil(p.sourceFile(named: missing))
+  }
+
+  func testQueryingSourceFileLevelDiagnostics() throws {
+    var p = Program()
+    let m = p.demandModule("Main")
+    let s0: SourceFile = "trait Foo {}"
+    let s1: SourceFile = "trait Bar {}"
+    let (_, id0) = p[m].addSource(s0)
+    let (_, id1) = p[m].addSource(s1)
+
+    // Well-formed sources have no diagnostics.
+    XCTAssert(p.diagnostics(in: id0).elements.isEmpty)
+    XCTAssert(p.diagnostics(in: id1).elements.isEmpty)
+
+    // Adding a diagnostic to one source file must not affect the other.
+    p[m].addDiagnostic(.init(.error, "boom", at: p[sourceFile: id0].span))
+
+    let ds0 = p.diagnostics(in: id0)
+    XCTAssertEqual(ds0.elements.count, 1)
+    XCTAssert(ds0.containsError)
+
+    let ds1 = p.diagnostics(in: id1)
+    XCTAssert(ds1.elements.isEmpty)
+    XCTAssertFalse(ds1.containsError)
+  }
+
+  func testQueryingTopLevelDeclarationsPerSourceFile() async throws {
+    var p = Program()
+    let m = p.demandModule("Main")
+    let (_, id) = p[m].addSource(
+      """
+      trait A {}
+      struct B {}
+      """)
+
+    _ = p[m].addSource(
+      """
+      enum C {}
+      """)
+
+    await p.assignScopes(m)
+
+    let ds = Array(p.topLevelDeclarations(in: id))
+    
+    // `ds` should contain exactly the declarations from the first source file, and not
+    // ones from the second.
+    XCTAssertEqual(ds.count, 2)
+
+    let tags = Set(ds.map { p.tag(of: $0) })
+    XCTAssert(tags.contains(.init(TraitDeclaration.self)))
+    XCTAssert(tags.contains(.init(StructDeclaration.self)))
+    XCTAssertFalse(tags.contains(.init(EnumDeclaration.self)))
   }
 
 }


### PR DESCRIPTION
This PR exposes the necessary internals from the FrontEnd for the language server.

- Expose the frontend and standard library as library products.
- Support source files with given in-memory contents.
- Expose source container properties for reading through accessors in `Program`.
- Expose querying givens of a type-checked program.
- Expose bundled standard library path (related PR: #75 )
