### PR TITLE
Minor fixes resulted from working on IR instruction documentation.

### DIFF
--- a/Sources/FrontEnd/IR/IRAlignment.swift
+++ b/Sources/FrontEnd/IR/IRAlignment.swift
@@ -4,9 +4,6 @@ public enum IRAlignment: Hashable, Sendable {
   /// The preferred alignment of a type on the target.
   case align(of: AnyTypeIdentity)
 
-  /// A fixed alignment.
-  case fixed(Int)
-
 }
 
 extension IRAlignment: Showable {
@@ -16,8 +13,6 @@ extension IRAlignment: Showable {
     switch self {
     case .align(let t):
       return "#align(of: \(printer.show(t)))"
-    case .fixed(let n):
-      return String(describing: n)
     }
   }
 

--- a/Sources/FrontEnd/IR/Instructions/IRLoad.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRLoad.swift
@@ -1,8 +1,10 @@
 /// Loads a value from memory to register.
 ///
-/// The operation requires exclusive access to the source, which must be initialized before
-/// the operation and is left uninitialized after. The size of the value being loaded must be known
-/// at compile-time.
+/// If the source is not a machine type, the operation requires exclusive access to the source,
+/// which must be initialized before the operation and is left uninitialized after. For machine
+/// types, we always copy the values, so no consume semantics.
+/// 
+/// The size of the value being loaded must be known at compile-time.
 public struct IRLoad: Instruction {
 
   /// The operands of the instruction.

--- a/Sources/FrontEnd/IR/Instructions/IRStore.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRStore.swift
@@ -1,9 +1,14 @@
 /// Writes a value to memory.
 ///
-/// The target refers to storage capable of holding the value being stored. The operation requires
-/// exclusive access to the target, which must be uninitialized before the operation and is left
-/// initialized after. If the value to write is held in a register, it is consumed and the register
-/// can no longer be used after the operation.
+/// The target refers to storage capable of holding the value being stored.
+/// 
+/// If the source is not a machine type, the operation requires exclusive access to the target,
+/// which must be uninitialized before the operation. If the value to write is held in a register,
+/// it is consumed and the register can no longer be used after the operation.
+/// 
+/// For machine types, we always copy the values, so no consume semantics.
+/// 
+/// Regardless of the type being stored, the target is in an initialized state after the operation.
 public struct IRStore: Instruction {
 
   /// The operands of the instruction.

--- a/Sources/FrontEnd/IR/Instructions/IRSubfield.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRSubfield.swift
@@ -42,7 +42,7 @@ extension IRSubfield: Showable {
 
   /// Returns a textual representation of `self` using `printer`.
   public func show(using printer: inout TreePrinter) -> String {
-    "subfield \(printer.show(base)) at \(list: path)"
+    "subfield \(printer.show(base)) at \(list: path) as \(printer.show(typeOfSubfield))"
   }
 
 }


### PR DESCRIPTION
- remove `fixed` alignment, until we have a use-case for it
- better document the semantics of IRLoad and IRStore
- also write the type of subfield in the generated IR text