### PR TITLE
Add code coverage exporting and uploading

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,17 @@
+ignore:
+  - '!(Sources|StandardLibrary)/'
+
+comment:
+  require_changes: true
+
+coverage:
+  status:
+
+    project:
+      default:
+        threshold: 0%
+
+    patch:
+      default:
+        target: auto
+        threshold: 0%

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,16 @@ jobs:
         swift: ["6.2"]
         config: [release, debug]
 
+        include:
+          # Disable exporting code coverage by default.
+          - export-coverage: false
+
+          # Enable exporting code coverage in a single configuration.
+          - os: "ubuntu-24.04"
+            swift: "6.2"
+            config: debug
+            export-coverage: true
+
     steps:
       - uses: actions/checkout@v4
 
@@ -45,6 +55,16 @@ jobs:
       # reuse the build cache from here, doubling the CI time.
 
       - name: Build and test for ${{ matrix.swift }} on ${{ matrix.os }} in ${{ matrix.config }} mode
-        run: swift test -c ${{ matrix.config }} --verbose
+        run: swift test -c ${{ matrix.config }} --verbose ${{ matrix.export-coverage && '--enable-code-coverage' || '' }}
+
+      - name: Export code coverage
+        if: ${{ matrix.export-coverage }}
+        run: llvm-cov export $(swift build --show-bin-path)/HyloPackageTests.xctest  --format="lcov" --instr-profile $(swift build --show-bin-path)/codecov/default.profdata > info.lcov
+
+      - name: Upload coverage report to Codecov
+        if: ${{ matrix.export-coverage }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR automates the exporting and uploading of code coverage data to Codecov. 

The coverage exporting could be simplified compared to the old compiler repo thanks to this article: https://fabianfett.dev/codecoverage-from-spm-build