### PR TITLE
Simplify CI trigger for build and test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,12 +6,6 @@ on:
       - "LICENSE"
       - ".gitignore"
       - ".editorconfig"
-  pull_request:
-    paths-ignore:
-      - "**.md"
-      - "LICENSE"
-      - ".gitignore"
-      - ".editorconfig"
 
 jobs:
   test:

--- a/Sources/FrontEnd/CodeCovTest.swift
+++ b/Sources/FrontEnd/CodeCovTest.swift
@@ -1,0 +1,3 @@
+private func test1() -> Int {
+  return 1
+}


### PR DESCRIPTION
- Removed the `pull_request` trigger because `push` already subsumes it.
- Added a dummy code change to try codecov