### PR TITLE
Build hc distributable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # Note: all combinations of the following will be run independently
         os: [macos-15, ubuntu-24.04, windows-2025]
-        swift: ["6.2"]
+        swift: ["6.2.4"]
         config: [release, debug]
 
         include:
@@ -23,7 +23,6 @@ jobs:
 
           # Enable exporting code coverage in a single configuration.
           - os: "ubuntu-24.04"
-            swift: "6.2"
             config: debug
             export-coverage: true
 
@@ -35,10 +34,14 @@ jobs:
         with:
           swift-version: ${{ matrix.swift }}
 
-      - uses: compnerd/gha-setup-vsdevenv@main
-          # Note that there was an issue previously with the Windows SDK that seems to have been
-          # that would crash CI. More information at:
-          # https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
+      - name: Download Recent Visual Studio and Windows SDK
+        uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          winsdk: "10.0.26100.0"
+          # Note: The GitHub windows-2025 runner has only a very old version of the Windows SDK available by default.
+          #       Swift is said to require version 10.0.22621.0: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
+          #       That no longer works, so we had to upgrade to 10.0.26100.0.
+          #       See also: https://github.com/swiftlang/swift/issues/88237
 
       - name: Verify swift version
         run: swift --version && swift --version | grep -q ${{ matrix.swift }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           #       See also: https://github.com/swiftlang/swift/issues/88237
 
       - name: Build distributable
-        run: swift build -c release --verbose --product hc --static-swift-stdlib
+        run: swift build -c release --verbose --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY
         shell: pwsh
 
       - name: Locate distributable
@@ -78,7 +78,7 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $binPath = (swift build -c release --product hc --static-swift-stdlib --show-bin-path).Trim()
+          $binPath = (swift build -c release --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY --show-bin-path).Trim()
           $binaryName = if ($env:RUNNER_OS -eq 'Windows') { 'hc.exe' } else { 'hc' }
           $binaryPath = Join-Path $binPath $binaryName
           $assetBaseName = "hylo-$env:TAG-$env:TARGET"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,17 +36,17 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
+            target: linux-x64
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: linux-arm64
           - os: macos-15
-            target: aarch64-apple-darwin
+            target: macos-arm64
           - os: macos-15-intel
-            target: x86_64-apple-darwin
+            target: macos-x64
           - os: windows-2025
-            target: x86_64-pc-windows-msvc
+            target: windows-x64
           - os: windows-11-arm
-            target: aarch64-pc-windows-msvc
+            target: windows-arm64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Publish release
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-draft-release:
+    name: Prepare draft release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
+            exit 0
+          fi
+          gh release create "$TAG" --repo "$REPOSITORY" --draft --generate-notes --latest=false --title "$TAG"
+        shell: bash
+
+  build-distributable:
+    name: Build distributable for ${{ matrix.target }}
+    needs: prepare-draft-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: macos-15
+            target: aarch64-apple-darwin
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+          - os: windows-2025
+            target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Swift
+        uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: "6.2.4"
+
+      - name: Download Recent Visual Studio and Windows SDK
+        uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          winsdk: "10.0.26100.0"
+          # Note: The GitHub windows-2025 runner has only a very old version of the Windows SDK available by default.
+          #       Swift is said to require version 10.0.22621.0: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
+          #       That no longer works, so we had to upgrade to 10.0.26100.0.
+          #       See also: https://github.com/swiftlang/swift/issues/88237
+
+      - name: Build distributable
+        run: swift build -c release --verbose --product hc --static-swift-stdlib
+        shell: pwsh
+
+      - name: Locate distributable
+        id: locate-distributable
+        env:
+          TAG: ${{ github.ref_name }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $binPath = (swift build -c release --product hc --static-swift-stdlib --show-bin-path).Trim()
+          $binaryName = if ($env:RUNNER_OS -eq 'Windows') { 'hc.exe' } else { 'hc' }
+          $binaryPath = Join-Path $binPath $binaryName
+          $assetBaseName = "hylo-$env:TAG-$env:TARGET"
+          $archivePath = Join-Path $env:RUNNER_TEMP "$assetBaseName.tar.zst"
+          "bin_path=$binPath" >> $env:GITHUB_OUTPUT
+          "binary_path=$binaryPath" >> $env:GITHUB_OUTPUT
+          "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+
+      - name: Verify distributable
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & "${{ steps.locate-distributable.outputs.binary_path }}" --help | Out-Null
+        shell: pwsh
+
+      - name: Archive distributable
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $archivePath = "${{ steps.locate-distributable.outputs.archive_path }}"
+          $binPath = "${{ steps.locate-distributable.outputs.bin_path }}"
+          if (Test-Path $archivePath) {
+            Remove-Item -Force $archivePath
+          }
+          tar --zstd -cf $archivePath -C $binPath .
+        shell: pwsh
+
+      - name: Upload distributable to draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          gh release upload $env:TAG "${{ steps.locate-distributable.outputs.archive_path }}" --repo $env:REPOSITORY --clobber
+        shell: pwsh
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+## Release Workflow
+Release drafts are created whenever pushing to a tag in the repository. You can manually
+publish a release when editing the draft.
+
+The conventional tag name for releases is `vX.Y.Z`, with an optional suffix for pre-releases (like `v0.0.2-test-lsp`).
+The release workflow only triggers for a pattern matching `v*`.

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -155,7 +155,7 @@ public struct Driver {
 
   /// Loads the standard library with `load(_:withSourcesAt:)`.
   public mutating func loadStandardLibrary() async throws {
-    try await load(Module.standardLibraryName, withSourcesAt: standardLibrarySources)
+    try await load(Module.standardLibraryName, withSourcesAt: bundledStandardLibrarySources)
   }
 
   /// Searches for an archive of `module` in `librarySearchPaths`, returning it if found.

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -154,8 +154,17 @@ public struct Driver {
   }
 
   /// Loads the standard library with `load(_:withSourcesAt:)`.
+  /// 
+  /// Use the `USE_BUNDLED_STANDARD_LIBRARY` compiler flag to control whether the 
+  /// bundled or local standard library is used. Defaults to local.
   public mutating func loadStandardLibrary() async throws {
-    try await load(Module.standardLibraryName, withSourcesAt: bundledStandardLibrarySources)
+    let sourceRoot: URL
+    #if USE_BUNDLED_STANDARD_LIBRARY // Set compiler flag in distributable builds.
+    sourceRoot = bundledStandardLibrarySources
+    #else
+    sourceRoot = localStandardLibrarySources
+    #endif
+    try await load(Module.standardLibraryName, withSourcesAt: sourceRoot)
   }
 
   /// Searches for an archive of `module` in `librarySearchPaths`, returning it if found.

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -1,6 +1,13 @@
 import Foundation
 
-/// The root folder of the standard library's sources.
+/// The root folder of the standard library's sources. 
+/// 
+/// Use this for development time.
 public let standardLibrarySources = URL(fileURLWithPath: #filePath)
   .deletingLastPathComponent()
   .appendingPathComponent("Sources")
+
+/// The path to the bundled standard library's root folder.
+/// 
+/// Use this in production.
+public let bundledStandardLibrarySources = Bundle.module.url(forResource: "Sources", withExtension: nil)!

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -2,12 +2,12 @@ import Foundation
 
 /// The root folder of the standard library's sources. 
 /// 
-/// Use this for development time.
-public let standardLibrarySources = URL(fileURLWithPath: #filePath)
+/// Use this for development time. Driver's default, unless USE_BUNDLED_STANDARD_LIBRARY option is set.
+public let localStandardLibrarySources = URL(fileURLWithPath: #filePath)
   .deletingLastPathComponent()
   .appendingPathComponent("Sources")
 
 /// The path to the bundled standard library's root folder.
 /// 
-/// Use this in production.
+/// Use this in distributable builds. Set compiler flag USE_BUNDLED_STANDARD_LIBRARY to true for Driver to use this.
 public let bundledStandardLibrarySources = Bundle.module.url(forResource: "Sources", withExtension: nil)!

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// The root folder of the standard library's sources. 
 /// 
-/// Use this for development time. Driver's default, unless USE_BUNDLED_STANDARD_LIBRARY option is set.
+/// This folder should be preferred during development. It is the Driver's default unless the
+/// flag `USE_BUNDLED_STANDARD_LIBRARY` is set.
 public let localStandardLibrarySources = URL(fileURLWithPath: #filePath)
   .deletingLastPathComponent()
   .appendingPathComponent("Sources")

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -10,5 +10,6 @@ public let localStandardLibrarySources = URL(fileURLWithPath: #filePath)
 
 /// The path to the bundled standard library's root folder.
 /// 
-/// Use this in distributable builds. Set compiler flag USE_BUNDLED_STANDARD_LIBRARY to true for Driver to use this.
+/// This folder is meant to be used in distributable builds in order to bundle the standard library
+/// together with the executable. Set the flag `USE_BUNDLED_STANDARD_LIBRARY` to select it.
 public let bundledStandardLibrarySources = Bundle.module.url(forResource: "Sources", withExtension: nil)!

--- a/Tests/CompilerTests/CompilerTests.swift
+++ b/Tests/CompilerTests/CompilerTests.swift
@@ -80,7 +80,7 @@ final class CompilerTests: XCTestCase {
     var driver = Driver(moduleCachePath: CompilerTests.moduleCachePath.url)
 
     if input.manifest.requiresStandardLibrary {
-      try await driver.load(Module.standardLibraryName, withSourcesAt: standardLibrarySources)
+      try await driver.load(Module.standardLibraryName, withSourcesAt: localStandardLibrarySources)
     }
 
     let m = driver.program.demandModule(.init("Test"))

--- a/Tests/CompilerTests/StandardLibraryLoadingTests.swift
+++ b/Tests/CompilerTests/StandardLibraryLoadingTests.swift
@@ -1,0 +1,21 @@
+import FrontEnd
+import XCTest
+import Driver
+import StandardLibrary
+
+final class StandardLibraryLoadingTests: XCTestCase {
+  func testStandardLibraryLoading() async throws {
+    var driver = Driver()
+    try await driver.loadStandardLibrary()
+  }
+
+  func testStandardLibraryLoadingBundled() async throws {
+    var driver = Driver()
+    try await driver.load(Module.standardLibraryName, withSourcesAt: bundledStandardLibrarySources)
+  }
+
+  func testStandardLibraryLoadingLocal() async throws {
+    var driver = Driver()
+    try await driver.load(Module.standardLibraryName, withSourcesAt: standardLibrarySources)
+  }
+}

--- a/Tests/CompilerTests/StandardLibraryLoadingTests.swift
+++ b/Tests/CompilerTests/StandardLibraryLoadingTests.swift
@@ -16,6 +16,6 @@ final class StandardLibraryLoadingTests: XCTestCase {
 
   func testStandardLibraryLoadingLocal() async throws {
     var driver = Driver()
-    try await driver.load(Module.standardLibraryName, withSourcesAt: standardLibrarySources)
+    try await driver.load(Module.standardLibraryName, withSourcesAt: localStandardLibrarySources)
   }
 }

--- a/Tests/CompilerTests/StandardLibraryLoadingTests.swift
+++ b/Tests/CompilerTests/StandardLibraryLoadingTests.swift
@@ -4,6 +4,7 @@ import Driver
 import StandardLibrary
 
 final class StandardLibraryLoadingTests: XCTestCase {
+
   func testStandardLibraryLoading() async throws {
     var driver = Driver()
     try await driver.loadStandardLibrary()

--- a/Tests/CompilerTests/StandardLibraryLoadingTests.swift
+++ b/Tests/CompilerTests/StandardLibraryLoadingTests.swift
@@ -19,4 +19,5 @@ final class StandardLibraryLoadingTests: XCTestCase {
     var driver = Driver()
     try await driver.load(Module.standardLibraryName, withSourcesAt: localStandardLibrarySources)
   }
+
 }


### PR DESCRIPTION
This PR adds a build step that packages the release build of the `hc` product along with statically linked Swift standard library.

I changed the Hylo standard library loading to reference the bundled standard library by default. In the old compiler we had [an extra option to use the local source path of the standard library](https://github.com/hylo-lang/hylo/blob/main/StandardLibrary/StandardLibrary.swift#L9) during development when the 
`HYLO_USE_BUILTIN_STDLIB` environment variable is set to true. I think this might be unnecessary if, when developing the standard library itself, we could invoke the compiler with `--no-std` and pass in the standard library module's directory as an input. But if needed, I can add the old behavior.

(Also pinning the Windows SDK version, based on https://github.com/hylo-lang/hylo/pull/1861)