### PR TITLE
Add basic Int32 type to the standard library

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1024,6 +1024,8 @@ internal struct IREmitter {
     switch target {
     case program.standardLibraryType(.int):
       return .integer(value, program.types.demand(MachineType.word))
+    case program.standardLibraryType(.int32):
+      return .integer(value, program.types.demand(MachineType.i(32)))
     case program.standardLibraryType(.int64):
       return .integer(value, program.types.demand(MachineType.i(64)))
     default:

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1357,6 +1357,9 @@ extension Program {
     /// `Hylo.Int`.
     case int = "Int"
 
+    /// `Hylo.Int32`.
+    case int32 = "Int32"
+
     /// `Hylo.Int64`.
     case int64 = "Int64"
 

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4592,9 +4592,9 @@ public struct Typer {
   private mutating func isStandardLibraryIntegerType(_ t: AnyTypeIdentity) -> Bool {
     guard program.containsStandardLibrary else { return false }
     switch program.types.dealiased(t) {
-    case standardLibraryType(.int):
-      return true
-    case standardLibraryType(.int64):
+    case standardLibraryType(.int),
+        standardLibraryType(.int32),
+        standardLibraryType(.int64):
       return true
     default:
       return false

--- a/StandardLibrary/Sources/Core/Numbers/Int32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int32.hylo
@@ -1,0 +1,18 @@
+/// A 32-bit signed integer value.
+@_symbol("Int32")
+public struct Int32 is Deinitializable {
+
+  /// The raw value of this instance.
+  internal var value: Builtin.i32
+
+  /// Creates an instance with its raw value.
+  internal memberwise init
+
+  /// Creates an instance equal to `false`.
+  public init() {
+    &self.value = Builtin.zeroinitializer_i32()
+  }
+
+}
+
+public given Int32 is ExpressibleByIntegerLiteral { /* built-in */ }

--- a/StandardLibrary/Sources/Core/Numbers/Int64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int64.hylo
@@ -1,6 +1,6 @@
 /// A 64-bit signed integer value.
 @_symbol("Int64")
-public struct Int64 {
+public struct Int64 is Deinitializable {
 
   /// The raw value of this instance.
   internal var value: Builtin.i64

--- a/Tests/CompilerTests/positive/integer-literals.hylo
+++ b/Tests/CompilerTests/positive/integer-literals.hylo
@@ -1,0 +1,7 @@
+//! stage:lowering
+
+fun integer_literal_conversions() {
+  let a1: Int32 = 1
+  let a2: Int64 = 1
+  let a3: Int = 1
+}


### PR DESCRIPTION
The LLVM lowering of `main()` requires the `Int32` type. The more comprehensive solution with an automatic generator can be seen in https://github.com/hylo-lang/hylo-new/pull/76 although it slows down the test suite by a factor of 5-8.