### PR TITLE
Fix typos in standard library

### DIFF
--- a/StandardLibrary/Sources/Core/Comparable.hylo
+++ b/StandardLibrary/Sources/Core/Comparable.hylo
@@ -5,8 +5,8 @@
 /// relation that satisfies the following for all instances `a`, `b`, and `c`:
 ///
 /// - `a < a` is always `false` (irreflexivity)
-/// - if `a < b` then `b < a` is `false` (antisymmetry)
-/// - if `a < b` and `b < b` then `a < c` (transitivity)
+/// - if `a < b` then `b < a` is `false` (asymmetry)
+/// - if `a < b` and `b < c` then `a < c` (transitivity)
 /// - if `a == b` is `false` then either `a < b` or `b < a` (totality)
 ///
 /// Making `T` conform to `Comparable` automatically equips `T` with members `infix>`, `infix>=`,

--- a/StandardLibrary/Sources/Core/Comparable.hylo
+++ b/StandardLibrary/Sources/Core/Comparable.hylo
@@ -5,7 +5,7 @@
 /// relation that satisfies the following for all instances `a`, `b`, and `c`:
 ///
 /// - `a < a` is always `false` (irreflexivity)
-/// - if `a < b` then `b < a` is `false` (asymmetry)
+/// - if `a < b` then `b < a` is `false` (antisymmetry)
 /// - if `a < b` and `b < c` then `a < c` (transitivity)
 /// - if `a == b` is `false` then either `a < b` or `b < a` (totality)
 ///

--- a/StandardLibrary/Sources/Core/Movable.hylo
+++ b/StandardLibrary/Sources/Core/Movable.hylo
@@ -1,4 +1,4 @@
-/// A type whose instances can be reloacted to different storage.
+/// A type whose instances can be relocated to different storage.
 @_symbol("Movable")
 public trait Movable {
 

--- a/StandardLibrary/Sources/Core/Numbers/Int.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int.hylo
@@ -8,7 +8,7 @@ public struct Int is Deinitializable {
   /// Creates an instance with its raw value.
   internal memberwise init
 
-  /// Creates an instance equal to `false`.
+  /// Creates an instance with value `0`.
   public init() {
     &self.value = Builtin.zeroinitializer_word()
   }

--- a/StandardLibrary/Sources/Core/Numbers/Int32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int32.hylo
@@ -8,7 +8,7 @@ public struct Int32 is Deinitializable {
   /// Creates an instance with its raw value.
   internal memberwise init
 
-  /// Creates an instance equal to `false`.
+  /// Creates an instance with value `0`.
   public init() {
     &self.value = Builtin.zeroinitializer_i32()
   }

--- a/StandardLibrary/Sources/Core/Numbers/Int64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int64.hylo
@@ -8,7 +8,7 @@ public struct Int64 is Deinitializable {
   /// Creates an instance with its raw value.
   internal memberwise init
 
-  /// Creates an instance equal to `false`.
+  /// Creates an instance with value `0`.
   public init() {
     &self.value = Builtin.zeroinitializer_i64()
   }


### PR DESCRIPTION
Fixes some typos and some inaccuracies in the docs of Comparable.