### PR TITLE
Improve diagnostic for failed module cache parsing

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -124,15 +124,24 @@ public struct Driver {
     }
 
     // Attempt to load the module from disk.
-    if cachingIsEnabled, let data = archive(of: module) {
-      let h = SourceFile.fingerprint(contentsOf: sources)
-      var a = ReadableArchive(data)
-      let (_, fingerprint) = try Module.header(&a)
-      if h == fingerprint {
-        a = ReadableArchive(data)
-        try program.load(module: module, from: &a)
-        return
+    do {
+      if cachingIsEnabled, let data = archive(of: module) {
+        let h = SourceFile.fingerprint(contentsOf: sources)
+        var a = ReadableArchive(data)
+        let (_, fingerprint) = try Module.header(&a)
+        if h == fingerprint {
+          a = ReadableArchive(data)
+          try program.load(module: module, from: &a)
+          return
+        }
       }
+    } catch ArchiveError.invalidInput {
+      let m = """
+        Failed to parse module archive of '\(module)' at '\(moduleCachePath, default: "nil")'.
+
+        Maybe the archive is compiled using a different version of the compiler. Try erasing the module cache.
+        """
+      fatalError(m)
     }
 
     // Compile the module from sources.


### PR DESCRIPTION
As breaking changes to the serialization of the module cache are being introduced, the caches may represent incorrect values or fail to get parsed (more likely). The latter problems are caught, but before this commit it was not obvious what's the root cause and how to fix it.

Note: the former kind of breaking changes cannot be diagnosed easily via this fix, and will need the more involved versioning system @kyouko-taiga mentioned, but it's not a priority due to most common cases being covered by parse errors.

I didn't add a death test for this case as it's not natively supported by XCTest.