### PR TITLE
Add dummy LLVM compilation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,8 +26,16 @@ jobs:
             config: debug
             export-coverage: true
 
+          - config: release
+            llvm-build-type: MinSizeRel
+
+          - config: debug
+            llvm-build-type: Debug
+
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set up Swift ${{ matrix.swift }} on ${{ matrix.os }}
         uses: SwiftyLab/setup-swift@latest
@@ -46,6 +54,16 @@ jobs:
       - name: Verify swift version
         run: swift --version && swift --version | grep -q ${{ matrix.swift }}
         shell: bash
+
+      - name: Set up LLVM
+        uses: hylo-lang/get-llvm@v0.3.0
+        id: get-llvm
+        with:
+          llvmVersion: "20.1.6"
+          llvmBuildRelease: "20260309-221030"
+          llvmBuildConfig: ${{ matrix.llvm-build-type }}
+          addToPkgConfigPath: true
+          addToPath: true
 
       # We disabled the separate build step, as it consumes extra CI time - building for testing apparently doesn't
       # reuse the build cache from here, doubling the CI time.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,16 @@ jobs:
         with:
           swift-version: "6.2.4"
 
+      - name: Set up LLVM
+        uses: hylo-lang/get-llvm@v0.3.0
+        id: get-llvm
+        with:
+          llvmVersion: "20.1.6"
+          llvmBuildRelease: "20260309-221030"
+          llvmBuildConfig: MinSizeRel
+          addToPkgConfigPath: true
+          addToPath: true
+
       - name: Download Recent Visual Studio and Windows SDK
         uses: compnerd/gha-setup-vsdevenv@main
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "Swifty-LLVM"]
+	path = Swifty-LLVM
+	url = https://github.com/hylo-lang/Swifty-LLVM
+	branch = ambrus/api-v2

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let commonSwiftSettings: [SwiftSetting] = [
 let package = Package(
   name: "Hylo",
   platforms: [
-    .macOS(.v13)
+    .macOS(.v15)
   ],
   products: [
     .executable(name: "hc", targets: ["hc"])
@@ -36,6 +36,7 @@ let package = Package(
     .package(
       url: "https://github.com/apple/swift-collections.git",
       from: "1.1.0"),
+    .package(path: "./Swifty-LLVM"),
   ],
   targets: [
     .executableTarget(
@@ -45,6 +46,7 @@ let package = Package(
         .target(name: "FrontEnd"),
         .target(name: "Utilities"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SwiftyLLVM", package: "Swifty-LLVM"),
       ],
       swiftSettings: commonSwiftSettings),
 
@@ -59,9 +61,11 @@ let package = Package(
       name: "Driver",
       dependencies: [
         .target(name: "FrontEnd"),
+        .target(name: "LLVMEmitter"),
         .target(name: "StandardLibrary"),
         .target(name: "Utilities"),
         .product(name: "Archivist", package: "archivist"),
+        .product(name: "SwiftyLLVM", package: "Swifty-LLVM"),
       ],
       swiftSettings: commonSwiftSettings),
 
@@ -76,6 +80,17 @@ let package = Package(
         .product(name: "BigInt", package: "BigInt"),
       ],
       swiftSettings: commonSwiftSettings),
+
+    .target(
+      name: "LLVMEmitter",
+      dependencies: [
+        .target(name: "FrontEnd"),
+        .product(name: "SwiftyLLVM", package: "Swifty-LLVM"),
+        .target(name: "Utilities"),
+      ],
+      path: "Sources/BackEnd/LLVM",
+      swiftSettings: commonSwiftSettings,
+    ),
 
     .target(
       name: "StableCollections",
@@ -103,6 +118,7 @@ let package = Package(
       dependencies: [
         .target(name: "Driver"),
         .target(name: "FrontEnd"),
+        .target(name: "StandardLibrary"),
         .target(name: "Utilities"),
       ],
       exclude: ["negative", "positive", "README.md"],
@@ -113,6 +129,14 @@ let package = Package(
       name: "FrontEndTests",
       dependencies: [
         .target(name: "FrontEnd")
+      ],
+      swiftSettings: commonSwiftSettings),
+
+    .testTarget(
+      name: "LLVMEmitterTests",
+      dependencies: [
+        .target(name: "LLVMEmitter"),
+        .target(name: "Driver")
       ],
       swiftSettings: commonSwiftSettings),
 

--- a/README.md
+++ b/README.md
@@ -26,3 +26,34 @@ If `m` denotes a trait requirement, then name resolution should bind it to the e
 ## Questions
 
 - Is it desirable to write extensions of context functions?
+
+## Building Instructions
+
+Clone the repository, initializing the submodules:
+```
+git clone https://github.com/hylo-lang/hylo-new
+cd hylo-new
+git submodule update --init
+```
+
+### Linux
+- Install `zstd`'s development package: `sudo apt-get install libzstd-dev`
+- Install the latest Swift compiler using [swiftly](https://github.com/swift-server/swiftly)
+- Download and install [Hylo's LLVM build](https://github.com/hylo-lang/llvm-build)
+- `swift test`
+
+### Windows
+- Install the latest Swift compiler from [swift.org](https://www.swift.org/install/windows/)
+- Download and install [Hylo's LLVM build](https://github.com/hylo-lang/llvm-build)
+- `swift test`
+
+### MacOS
+- Install the latest Swift compiler from [swift.org](https://www.swift.org/install/macos)
+- Download and install [Hylo's LLVM build](https://github.com/hylo-lang/llvm-build)
+- `swift test`
+- TODO see if any dependencies are missing
+
+
+## Hylo Compiler's Runtime Dependencies
+`hc` uses `clang` and `lld` for linking, resolving them from PATH. On macOS, you will need `xcrun` 
+on PATH so the compiler can find the SDK.

--- a/Sources/BackEnd/LLVM/CodeGenerationContext.swift
+++ b/Sources/BackEnd/LLVM/CodeGenerationContext.swift
@@ -1,0 +1,25 @@
+import FrontEnd
+import SwiftyLLVM
+import Utilities
+
+extension Program {
+
+  /// Compiles the IR of `m` for target `t`.
+  ///
+  /// - Requires: `m` has been lowered and all required passes have been run.
+  public func compileToLLVM(_ m: FrontEnd.Module.ID, target t: consuming TargetMachine) throws -> SwiftyLLVM.Module {
+    var llvm = try SwiftyLLVM.Module("MainModule", targetMachine: t)
+
+    // FIXME: Emitting trivial main function for now. Replace with actual code generation.
+
+    // fun main() -> Int32 { 0 }
+    let mainType = llvm.functionType(from: (), to: llvm.i32)
+    let main = llvm.declareFunction("main", mainType)
+
+    let entry = llvm.appendBlock(to: main)
+    llvm.insertReturn(llvm.i32.unsafe[].zero, at: llvm.endOf(entry))
+
+    return llvm
+  }
+
+}

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -1,8 +1,19 @@
 import Archivist
 import Foundation
 import FrontEnd
+import LLVMEmitter
 import StandardLibrary
+import SwiftyLLVM
 import Utilities
+
+/// Utilities and constants related to the host machine.
+private typealias Host = Utilities.Host
+
+/// A SwiftyLLVM module.
+private typealias LLVMModule = SwiftyLLVM.Module
+
+/// A FrontEnd module.
+public typealias Module = FrontEnd.Module // Shadowing the name ambiguity
 
 /// A helper to drive the compilation of Hylo source files.
 public struct Driver {
@@ -10,12 +21,50 @@ public struct Driver {
   /// The path containing cached module data.
   public let moduleCachePath: URL?
 
+  /// The target specification (triple + CPU + features).
+  public var target: TargetSpecification
+
+  /// The optimization level for code generation.
+  public var optimization: OptimizationLevel
+
+  /// The relocation model for code generation.
+  public var relocation: RelocationModel
+
+  /// The code model for code generation.
+  public var codeModel: CodeModel
+
+  /// The list of directories in which to search for libraries to link.
+  public var librarySearchPaths: [URL]
+
+  /// The names of the native libraries to link.
+  public var librariesToLink: [String]
+
+  /// `true` iff the standard library and its shim should be excluded from compilation and linking.
+  public var noStandardLibrary: Bool = false
+
   /// The program being compiled by the driver.
   public var program: Program
 
+  /// The corresponding LLVM module for each Hylo module.
+  ///
+  /// Populated by `lowerToLLVM(_:)`.
+  private var llvmModules: [Module.ID: LLVMModuleBox] = [:]
+
   /// Creates an instance with the given properties.
-  public init(moduleCachePath: URL? = nil) {
+  public init(
+    moduleCachePath: URL? = nil, targetSpecification: TargetSpecification,
+    optimization: OptimizationLevel = .none,
+    relocation: RelocationModel = .default,
+    codeModel: CodeModel = .default,
+    librarySearchPaths: [URL] = [], librariesToLink: [String] = []
+  ) {
     self.moduleCachePath = moduleCachePath
+    self.target = targetSpecification
+    self.optimization = optimization
+    self.relocation = relocation
+    self.codeModel = codeModel
+    self.librarySearchPaths = librarySearchPaths
+    self.librariesToLink = librariesToLink
     self.program = .init()
   }
 
@@ -28,26 +77,26 @@ public struct Driver {
   @discardableResult
   public mutating func parse(
     _ sources: [SourceFile], into module: Module.ID
-  ) async -> (elapsed: Duration, containsError: Bool) {
+  ) async -> PhaseResult {
     let clock = ContinuousClock()
     let elapsed = clock.measure {
       modify(&program[module]) { (m) in
         for s in sources { m.addSource(s) }
       }
     }
-    return (elapsed, program[module].containsError)
+    return .init(elapsed: elapsed, containsError: program[module].containsError)
   }
 
   /// Assigns the trees in `module` to their scopes.
   @discardableResult
   public mutating func assignScopes(
     of module: Module.ID
-  ) async -> (elapsed: Duration, containsError: Bool) {
+  ) async -> PhaseResult {
     let clock = ContinuousClock()
     let elapsed = await clock.measure {
       await program.assignScopes(module)
     }
-    return (elapsed, program[module].containsError)
+    return .init(elapsed: elapsed, containsError: program[module].containsError)
   }
 
   /// Assigns the trees in `module` to their types.
@@ -55,57 +104,119 @@ public struct Driver {
   public mutating func assignTypes(
     of module: Module.ID,
     loggingInferenceWhere isLoggingEnabled: ((AnySyntaxIdentity, Program) -> Bool)? = nil
-  ) async -> (elapsed: Duration, containsError: Bool) {
+  ) async -> PhaseResult {
     let clock = ContinuousClock()
     let elapsed = clock.measure {
       program.assignTypes(module, loggingInferenceWhere: isLoggingEnabled)
     }
-    return (elapsed, program[module].containsError)
+    return .init(elapsed: elapsed, containsError: program[module].containsError)
   }
 
   /// Lowers the contents of `module` to IR.
   @discardableResult
   public mutating func lower(
     _ module: Module.ID
-  ) async -> (elapsed: Duration, containsError: Bool) {
+  ) async -> PhaseResult {
     let clock = ContinuousClock()
     let elapsed = clock.measure {
       program.lower(module)
     }
-    return (elapsed, program[module].containsError)
+    return .init(elapsed: elapsed, containsError: program[module].containsError)
   }
 
   /// Applies mandatory transformation passes on the IR of `module`.
   @discardableResult
   public mutating func applyTransformationPasses(
     _ module: Module.ID
-  ) async -> (elapsed: Duration, containsError: Bool) {
+  ) async -> PhaseResult {
     let elapsed = ContinuousClock().measure {
       program.applyTransformationPasses(module)
     }
-    return (elapsed, program[module].containsError)
+    return .init(elapsed: elapsed, containsError: program[module].containsError)
   }
 
-  /// Generates backend code for `module`.
-  public mutating func generateCode(
-    _ module: Module.ID
-  ) async -> (elapsed: Duration, containsError: Bool) {
-    let clock = ContinuousClock()
-    let elapsed = clock.measure {
-      // TODO
+  /// Lowers the program to LLVM IR and stores the result in `self.llvmModules`.
+  ///
+  /// - Requires:
+  ///   - `module` has been lowered and all required transformation passes have been run.
+  ///   - `module` has not been lowered to LLVM IR yet.
+  public mutating func lowerToLLVM(_ module: Module.ID) throws -> PhaseResult {
+    precondition(llvmModules[module] == nil,
+      "LLVM code is already generated for module \(moduleName(module))")
+
+    let elapsed = try ContinuousClock().measure {
+      var m = try program.compileToLLVM(
+        module,
+        target: TargetMachine(
+          target: target, optimization: optimization, relocation: relocation, codeModel: codeModel))
+
+      #if DEBUG
+        try m.verify()
+      #endif
+
+      m.runDefaultModulePasses()
+
+      #if DEBUG
+        try m.verify()
+      #endif
+
+      llvmModules[module] = LLVMModuleBox(consume m)
     }
-    return (elapsed, program[module].containsError)
+    return .init(elapsed: elapsed, containsError: program[module].containsError)
   }
 
-  /// Generates executable from `module`.
+  /// Generates executable from `module`, linking the standard library unless `noStandardLibrary` is true.
+  ///
+  /// - Requires: `module` has been lowered to LLVM.
+  /// - Throws: if the parent folder of `output` doesn't exist.
   public mutating func generateExecutable(
-    _ module: Module.ID
-  ) async -> (elapsed: Duration, containsError: Bool) {
-    let clock = ContinuousClock()
-    let elapsed = clock.measure {
-      // TODO
+    from module: Module.ID,
+    writingTo output: URL
+  ) throws -> PhaseResult {
+    let elapsed = try ContinuousClock().measure {
+      let modulesToLink = [module]
+      // FIXME: link the dependencies of `module`.
+
+      if !noStandardLibrary {
+        // FIXME: Enable this after we can lower the standard library
+        // modulesToLink.append(program.modules[.standardLibrary]!.identity)
+      }
+
+      try FileManager.default.withUniqueTemporaryDirectory { objectDirectory in
+        let objects = try writeObjectFiles(for: modulesToLink, into: objectDirectory)
+        try linkExecutable(from: objects, writingTo: output)
+      }
     }
-    return (elapsed, program[module].containsError)
+    return .init(elapsed: elapsed, containsError: program[module].containsError)
+  }
+
+  /// Returns the LLVM IR generated for `module`, if any.
+  public func llvmIR(of module: Module.ID) -> String? {
+    llvmModules[module]?.module.llCode()
+  }
+
+  /// Returns the assembly of module `m`.
+  ///
+  /// - Requires: module `m` has been lowered to LLVM.
+  public func assembly(of m: Module.ID) throws -> String {
+    try llvmModules[m]!.module.compile(.assembly).utf8Decoded
+      .unwrapOrThrow(Error(message: "Failed to decode assembly as an UTF8 string."))
+  }
+
+  /// Writes object files for `modules` into `destinationDirectory` and returns their paths.
+  ///
+  /// - Requires: each element of `modules` has been lowered to LLVM.
+  /// - Throws: if `destinationDirectory` doesn't exist.
+  @discardableResult
+  public func writeObjectFiles(
+    for modules: [Module.ID], into destinationDirectory: URL
+  ) throws -> [URL] {
+    let objectFiles = try modules.map { (module) in
+      let object = destinationDirectory.appendingPathComponent(moduleName(module) + ".o", isDirectory: false)
+      try llvmModules[module]!.module.write(.objectFile, to: object.path)
+      return object
+    }
+    return objectFiles
   }
 
   /// Loads `module`, whose sources are in `root`, into `program`.
@@ -141,7 +252,7 @@ public struct Driver {
 
         Maybe the archive is compiled using a different version of the compiler. Try erasing the module cache.
         """
-      fatalError(m)
+      throw Error(message: m)
     }
 
     // Compile the module from sources.
@@ -192,6 +303,77 @@ public struct Driver {
     if program[m].containsError {
       throw CompilationError(diagnostics: .init(program[m].diagnostics))
     }
+  }
+
+  /// Links the provided object files into an executable at `output`, using lld.
+  ///
+  /// - Throws: if the parent folder of `output` doesn't exist.
+  private func linkExecutable(from objectFiles: [URL], writingTo output: URL) throws {
+    var arguments = ["-fuse-ld=lld", "-o", output.path]
+    arguments += librarySearchPaths.map({ "-L\($0.path)" })
+    arguments += librariesToLink.map({ "-l\($0)" })
+    arguments += objectFiles.map(\.path)
+
+    #if os(macOS)
+    let sdk = try Process.executionOutput(
+      try Host.findNativeExecutable(invokedAs: "xcrun"), arguments: ["--sdk", "macosx", "--show-sdk-path"])
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    arguments += ["-isysroot", sdk, "-lSystem"]
+    #endif
+
+    _ = try Process.executionOutput(try Host.findNativeExecutable(invokedAs: "clang"), arguments: arguments)
+  }
+
+  /// The name of `module`.
+  private func moduleName(_ module: Module.ID) -> String {
+    program.modules.elements[module].key
+  }
+
+  /// A reference-semantic wrapper for the non-copiable `LLVMModule` type.
+  ///
+  /// Allows `LLVMModule` to be stored in a collection.
+  private final class LLVMModuleBox {
+
+    /// The wrapped module.
+    var module: LLVMModule
+
+    /// Wraps `module` by consuming it.
+    init(_ module: consuming LLVMModule) {
+      self.module = module
+    }
+
+  }
+
+  /// An error thrown by the driver.
+  public struct Error: Swift.Error, CustomStringConvertible {
+
+    /// The error message.
+    public let message: String
+
+    /// The error message.
+    public var description: String {
+      message
+    }
+
+  }
+
+  /// The result of a compilation phase.
+  ///
+  /// Used for logging and early termination.
+  public struct PhaseResult {
+
+    /// The elapsed time during the subtask's execution.
+    public let elapsed: Duration
+
+    /// `true` iff after the subtask's execution, the program contains errors.
+    public let containsError: Bool
+
+    /// Creates a new instance from its parts.
+    public init(elapsed: Duration, containsError: Bool) {
+      self.elapsed = elapsed
+      self.containsError = containsError
+    }
+
   }
 
 }

--- a/Sources/Utilities/FileManager+Extensions.swift
+++ b/Sources/Utilities/FileManager+Extensions.swift
@@ -14,4 +14,27 @@ extension FileManager {
     .init(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
   }
 
+  /// Creates a uniquely named temporary directory.
+  ///
+  /// The caller is responsible for removing the directory, if needed.
+  public func createUniqueTemporaryDirectory() throws -> URL {
+    let directory = temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+  }
+
+  /// Creates an empty temporary directory for the duration of `action`.
+  public func withUniqueTemporaryDirectory<T>(_ action: (_ directory: URL) throws -> T) throws -> T {
+    let d = try createUniqueTemporaryDirectory()
+    defer { try? removeItem(at: d) }
+    return try action(d)
+  }
+
+  /// Creates an empty temporary directory for the duration of `action`.
+  public func withUniqueTemporaryDirectory<T>(_ action: (_ directory: URL) async throws -> T) async throws -> T {
+    let d = try createUniqueTemporaryDirectory()
+    defer { try? removeItem(at: d) }
+    return try await action(d)
+  }
+
 }

--- a/Sources/hc-tests/CommandLine.swift
+++ b/Sources/hc-tests/CommandLine.swift
@@ -79,7 +79,9 @@ import Foundation
       at: root,
       includingPropertiesForKeys: [.isRegularFileKey],
       options: [.skipsHiddenFiles, .skipsPackageDescendants])!
-    for case let u as URL in items where u.pathExtension == "observed" {
+
+    let generatedExtensions = ["observed", "exe", "executable"]
+    for case let u as URL in items where generatedExtensions.contains(u.pathExtension) {
       try FileManager.default.removeItem(at: u)
     }
   }

--- a/Sources/hc/CodeModel+ExpressibleByArgument.swift
+++ b/Sources/hc/CodeModel+ExpressibleByArgument.swift
@@ -1,0 +1,20 @@
+import SwiftyLLVM
+import ArgumentParser
+
+extension CodeModel: @retroactive ExpressibleByArgument {
+
+  /// Parses a string argument into an enum case, excluding JIT support.
+  public init?(argument: String) {
+    guard argument != "jit",
+          let c = Self.allCases.first(where: { String(describing: $0) == argument }) else {
+      return nil
+    }
+    self = c
+  }
+
+  /// All possible values for this flag, excluding JIT support.
+  public static var allValueStrings: [String] {
+    allCases.filter { $0 != .jit }.map { String(describing: $0) }
+  }
+
+}

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -2,7 +2,11 @@ import ArgumentParser
 import Driver
 import Foundation
 import FrontEnd
+import SwiftyLLVM
 import Utilities
+
+/// Disambiguate FrontEnd.Module from SwiftyLLVM.Module.
+private typealias Module = FrontEnd.Module
 
 /// The top-level command of `hc`.
 @main struct CommandLine: AsyncParsableCommand {
@@ -28,6 +32,48 @@ import Utilities
     transform: URL.init(fileURLWithPath:))
   private var moduleCachePath: URL?
 
+  /// The target triple, or nil for the host machine's triple.
+  @Option(
+    name: [.customLong("target")],
+    help: ArgumentHelp(
+      "Target triple (default: host).",
+      valueName: "triple"))
+  private var targetTriple: String?
+
+  /// The target CPU name: "native" for host, "generic" for baseline, or an explicit name.
+  @Option(
+    name: [.customLong("cpu")],
+    help: ArgumentHelp(
+      "Target CPU: native, generic, or an explicit name (default: native for host, generic for cross).",
+      valueName: "cpu"))
+  private var targetCPU: String?
+
+  /// The target CPU feature string: "native" for host, or an explicit "+feat,-feat" string.
+  @Option(
+    name: [.customLong("cpu-features")],
+    help: ArgumentHelp(
+      "CPU features: native, or an explicit feature string (default: native for host, none for cross).",
+      valueName: "features"))
+  private var targetCPUFeatures: String?
+
+  /// The code generation optimization level (0-3).
+  @Option(
+    name: [.customShort("O"), .customLong("optimization-level")],
+    help: "Optimization level: 0, 1, 2, 3 (default: 0).")
+  private var optimizationLevel: OptimizationLevel = .none
+
+  /// The relocation model for code generation.
+  @Option(
+    name: [.customLong("relocation-model")],
+    help: "Relocation model (default: pic on Linux).")
+  private var relocationModel: RelocationModel?
+
+  /// The code model for code generation.
+  @Option(
+    name: [.customLong("code-model")],
+    help: "Code model (default: target decides).")
+  private var codeModel: CodeModel?
+
   /// `true` iff the driver should not read/write modules from/to the cache.
   @Flag(help: "Disable caching.")
   private var noCaching: Bool = false
@@ -44,7 +90,7 @@ import Utilities
     help: ArgumentHelp(
       "Produce the specified output: \(OutputType.allValueStrings.joined(separator: ", ")).",
       valueName: "output-type"))
-  private var outputType: OutputType = .ir
+  private var outputType: OutputType = .binary
 
   /// The line at which type inference should be traced.
   @Option(
@@ -80,80 +126,167 @@ import Utilities
   /// Executes the command.
   public mutating func run() async throws {
     try configureSearchPaths()
-    var driver = Driver(moduleCachePath: noCaching ? nil : moduleCachePath!)
 
-    // Load the standard library.
-    if !noStandardLibrary {
-      note("load Hylo's standard library")
-      do {
+    var driver = Driver(
+      moduleCachePath: noCaching ? nil : moduleCachePath!,
+      targetSpecification: try resolveTarget(),
+      optimization: optimizationLevel,
+      relocation: relocationModel ?? defaultRelocationModel(),
+      codeModel: codeModel ?? .default,
+      librarySearchPaths: librarySearchPaths)
+
+    do {
+      // Load the standard library.
+      if !noStandardLibrary {
+        note("load the Hylo standard library")
         try await driver.loadStandardLibrary()
-      } catch let e as CompilationError {
-        render(e.diagnostics.elements)
-        CommandLine.exit(withError: ExitCode.failure)
       }
+
+      // Create a module for the product being compiled.
+      let product = productName(inputs)
+      note("start compiling \(product)")
+      let module = driver.program.demandModule(product)
+      if !noStandardLibrary {
+        driver.program[module].addDependency(Module.standardLibraryName)
+      }
+
+      // Compile from sources.
+      let sources = try sourceFiles(recursivelyContainedIn: inputs)
+      await perform("parsing", for: module, { await driver.parse(sources, into: module) })
+      await perform("scoping", for: module, { await driver.assignScopes(of: module) })
+      if outputType == .ast {
+        try emitAst(module, in: driver.program, name: product)
+        return
+      }
+
+      await perform("typing", for: module, {
+        await driver.assignTypes(of: module, loggingInferenceWhere: inferenceLoggerFilter())
+      })
+      if outputType == .typedAST {
+        try emitAst(module, in: driver.program, name: product)
+        return
+      }
+
+      await perform("lowering", for: module, { await driver.lower(module) })
+      if outputType == .rawIR {
+        try emitIR(module, in: driver.program, name: product)
+        return
+      }
+
+      await perform("normalization", for: module, { await driver.applyTransformationPasses(module) })
+      if outputType == .ir {
+        try emitIR(module, in: driver.program, name: product)
+        return
+      }
+
+      // Write the module to the cache for future runs.
+      let a = try driver.program.archive(module: module)
+      note("module archive size: \(a.count)")
+
+      try await perform("code generation", for: module, { try driver.lowerToLLVM(module) })
+      if outputType == .llvm {
+        try emitLLVM(module, from: driver, name: product)
+        return
+      }
+      if outputType == .asm {
+        try write(driver.assembly(of: module), to: asmFile(product))
+        return
+      }
+      if outputType == .object {
+        // FIXME: output the dependencies of `module`, including the standard library.
+        let directory = try objectFilesDirectory()
+        try driver.writeObjectFiles(for: [module], into: directory)
+        note("written \(directory.path)")
+        return
+      }
+
+      assert(outputType == .binary)
+      try await perform("generating executable", for: module,
+        { try driver.generateExecutable(from: module, writingTo: binaryFile(product)) })
+    } catch let e as CompilationError {
+      render(e.diagnostics.elements)
+      CommandLine.exit(withError: ExitCode.failure)
     }
 
-    // Create a module for the product being compiled.
-    let product = productName(inputs)
-    note("start compiling \(product)")
-    let module = driver.program.demandModule(product)
-    if !noStandardLibrary {
-      driver.program[module].addDependency(Module.standardLibraryName)
-    }
-
-    // Compile from sources.
-    let sources = try sourceFiles(recursivelyContainedIn: inputs)
-    await perform("parsing", { await driver.parse(sources, into: module) })
-    await perform("scoping", { await driver.assignScopes(of: module) })
-    if outputType == .ast {
-      try emitAst(module, in: driver.program, name: product)
-      return
-    }
-
-    await perform("typing") {
-      await driver.assignTypes(of: module, loggingInferenceWhere: inferenceLoggerFilter())
-    }
-    if outputType == .typedAST {
-      try emitAst(module, in: driver.program, name: product)
-      return
-    }
-
-    await perform("lowering", { await driver.lower(module) })
-    if outputType == .rawIR {
-      try emitIR(module, in: driver.program, name: product)
-      return
-    }
-
-    await perform("normalization", { await driver.applyTransformationPasses(module) })
-    if outputType == .ir {
-      try emitIR(module, in: driver.program, name: product)
-      return
-    }
-
-    await perform("code generation", { await driver.generateCode(module) })
-    if outputType == .llvm {
-      try emitLLVM(module, in: driver.program, name: product)
-      return
-    }
-    if outputType == .asm {
-      try emitAsm(module, in: driver.program, name: product)
-      return
-    }
-
-    // Write the module to the cache for future runs.
-    let a = try driver.program.archive(module: module)
-    note("module archive size: \(a.count)")
-
-    assert(outputType == .binary)
-    await perform("generating executable", { await driver.generateExecutable(module) })
-
-    func perform(
-      _ phase: String, _ action: () async -> (elapsed: Duration, containsError: Bool)
-    ) async {
-      let a = await action()
+    /// Performs `action`, logs its duration, and exits with diagnostics if it resulted in an error.
+    func perform(_ phase: String, for module: FrontEnd.Module.ID,
+      _ action: () async throws -> Driver.PhaseResult) async rethrows {
+      let a = try await action()
       note("\(phase) completed in \(a.elapsed.human)")
       exitOnError(driver.program[module])
     }
+  }
+
+  // MARK: - Target Machine Resolution
+
+  /// Resolves the `--cpu` CLI option to a concrete CPU name string.
+  ///
+  /// - Throws: `ValidationError` iff `crossCompiling` and `targetCPU` is `"native"`.
+  /// - Returns:
+  ///   - "" (generic cpu) when nothing or "generic" is specified for `--cpu`;
+  ///   - native CPU of the host when "native" is specified;
+  ///   - the raw `--cpu` argument value otherwise.
+  private func resolveCPU(crossCompiling: Bool) throws -> String {
+    switch targetCPU {
+    case nil, "generic":
+      "" // Use generic CPU (inferred from triple)
+    case "native":
+      if crossCompiling {
+        throw ValidationError(
+          "Cannot use 'native' CPU when cross-compiling. "
+          + "Use '--cpu=generic' or specify an explicit CPU name.")
+      } else {
+        TargetSpecification.hostCPUName
+      }
+    case let explicit?:
+      explicit
+    }
+  }
+
+  /// Resolves the `--cpu-features` CLI option to a concrete feature string.
+  ///
+  /// - Returns:
+  ///   - "" (generic target) when nothing or "generic" is specified for `--cpu-features`;
+  ///   - native CPU features of the host when "native" is specified;
+  ///   - the raw `--cpu-features` argument value otherwise.
+  private func resolveCPUFeatures(crossCompiling: Bool) throws -> String {
+    switch targetCPUFeatures {
+    case nil, "generic":
+      "" // Use only generic cpu features.
+    case "native":
+      if crossCompiling {
+        throw ValidationError(
+          "Cannot use 'native' features when cross-compiling. "
+          + "Use an explicit feature string or omit --cpu-features.")
+      } else {
+        TargetSpecification.hostCPUFeatures
+      }
+    case let explicit?:
+      explicit
+    }
+  }
+
+  /// Resolves the `--target`, `--cpu`, and `--cpu-features` CLI options into a `TargetSpecification`.
+  private func resolveTarget() throws -> TargetSpecification {
+    let host = try Target.host()
+    let triple = try targetTriple.map(Target.init) ?? host
+    let crossCompiling = triple.backend != host.backend
+
+    return try TargetSpecification(
+      target: triple,
+      cpu: resolveCPU(crossCompiling: crossCompiling),
+      features: resolveCPUFeatures(crossCompiling: crossCompiling))
+  }
+
+  /// The default relocation model when not specified on the command line.
+  ///
+  /// Note: This may be obsolete after https://github.com/hylo-lang/hylo-new/issues/96 is resolved.
+  private func defaultRelocationModel() -> RelocationModel {
+    #if os(Linux)
+      return .pic
+    #else
+      return .default
+    #endif
   }
 
   /// Emits the AST of `module` in `program` with name `name`, using the tree printer.
@@ -175,17 +308,15 @@ import Utilities
   }
 
   /// Emits the LLVM IR of `module` in `program` with name `name`.
+  ///
+  /// - Requires: `module` has been already lowered to LLVM.
   private func emitLLVM(
-    _ module: Module.ID, in program: Program, name: Module.Name
+    _ module: Module.ID, from driver: Driver, name: Module.Name
   ) throws {
-    // TODO
-  }
-
-  /// Emits the assembly of `module` in `program` with name `name`.
-  private func emitAsm(
-    _ module: Module.ID, in program: Program, name: Module.Name
-  ) throws {
-    // TODO
+    guard let output = driver.llvmIR(of: module) else {
+      unreachable("missing LLVM output")
+    }
+    try write(output, to: llvmFile(name))
   }
 
   /// Writes `content` to `url`, or to the standard output if `url` is "-".
@@ -258,13 +389,6 @@ import Utilities
     }
   }
 
-  /// Writes `message` to the standard error and exit.
-  private func fatal(_ message: String) {
-    var stderr = StandardError()
-    print(message, to: &stderr)
-    CommandLine.exit(withError: ExitCode.failure)
-  }
-
   /// Returns the configuration corresponding to the given `flags`.
   private func treePrinterConfiguration(
     for flags: [TreePrinterFlag]
@@ -282,6 +406,35 @@ import Utilities
       }
     }
     return "Main"
+  }
+
+  /// The type of the output files to generate.
+  private enum OutputType: String, ExpressibleByArgument, CaseIterable {
+
+    /// Abstract syntax tree before typing.
+    case ast = "ast"
+
+    /// Abstract syntax tree after typing.
+    case typedAST = "typed-ast"
+
+    /// Hylo IR before mandatory transformations.
+    case rawIR = "raw-ir"
+
+    /// Hylo IR.
+    case ir = "ir"
+
+    /// LLVM IR.
+    case llvm = "llvm"
+
+    /// Assembly.
+    case asm = "asm"
+
+    /// Object file.
+    case object = "object"
+
+    /// Executable binary.
+    case binary = "binary"
+
   }
 
   /// Given the desired name of the compiler's product, returns the file to write when "raw-ast" is
@@ -308,10 +461,18 @@ import Utilities
     outputURL ?? URL(fileURLWithPath: productName.description + ".s")
   }
 
+  /// Returns the directory to write when "object" is selected as the output type.
+  private func objectFilesDirectory() throws -> URL {
+    guard outputURL?.relativePath != "-" else {
+      throw ValidationError("object files cannot be written to the standard output")
+    }
+    return outputURL ?? URL(fileURLWithPath: "./")
+  }
+
   /// Given the desired name of the compiler's product, returns the file to write when "binary" is
   /// selected as the output type.
   private func binaryFile(_ productName: Module.Name) -> URL {
-    outputURL ?? URL(fileURLWithPath: productName.description)
+    outputURL ?? URL(fileURLWithPath: productName.description + Host.nativeExecutableSuffix)
   }
 
   private func inferenceLoggerFilter() -> ((AnySyntaxIdentity, Program) -> Bool)? {
@@ -328,31 +489,6 @@ import Utilities
         }
       }
     }
-  }
-
-  /// The type of the output files to generate.
-  private enum OutputType: String, ExpressibleByArgument, CaseIterable {
-
-    /// Abstract syntax tree before typing.
-    case ast = "ast"
-
-    /// Abstract syntax tree after typing.
-    case typedAST = "typed-ast"
-
-    /// Hylo IR before mandatory transformations.
-    case rawIR = "raw-ir"
-
-    /// Hylo IR.
-    case ir = "ir"
-
-    /// LLVM IR.
-    case llvm = "llvm"
-
-    /// Assembly.
-    case asm = "asm"
-
-    /// Executable binary.
-    case binary = "binary"
   }
 
   /// Tree printing flags.

--- a/Sources/hc/OptimizationLevel+ExpressibleByArgument.swift
+++ b/Sources/hc/OptimizationLevel+ExpressibleByArgument.swift
@@ -1,0 +1,20 @@
+import SwiftyLLVM
+import ArgumentParser
+
+extension OptimizationLevel: @retroactive ExpressibleByArgument {
+
+  /// Creates an instance from a command-line argument string.
+  public init?(argument: String) {
+    switch argument {
+    case "0": self = .none
+    case "1": self = .less
+    case "2": self = .default
+    case "3": self = .aggressive
+    default: return nil
+    }
+  }
+
+  /// All possible optimization levels (-O0, -O1, -O2, -O3).
+  public static var allValueStrings: [String] { ["0", "1", "2", "3"] }
+
+}

--- a/Sources/hc/RelocationModel+ExpressibleByArgument.swift
+++ b/Sources/hc/RelocationModel+ExpressibleByArgument.swift
@@ -1,0 +1,19 @@
+import SwiftyLLVM
+import ArgumentParser
+
+extension RelocationModel: @retroactive ExpressibleByArgument {
+
+  /// All enum cases as strings are possible values for this flag.
+  public static var allValueStrings: [String] {
+    allCases.map { String(describing: $0) }
+  }
+
+  /// Parses a string argument into an enum case.
+  public init?(argument: String) {
+    guard let c = Self.allCases.first(where: { String(describing: $0) == argument }) else {
+      return nil
+    }
+    self = c
+  }
+
+}

--- a/Tests/CompilerTests/CompilerTests.swift
+++ b/Tests/CompilerTests/CompilerTests.swift
@@ -4,6 +4,7 @@ import FrontEnd
 import StandardLibrary
 import Utilities
 import XCTest
+typealias Host = Utilities.Host
 
 /// The driver for generated compiler tests.
 ///
@@ -58,6 +59,15 @@ final class CompilerTests: XCTestCase {
       }
     }
 
+    /// Returns where to save the generated executable upon failure.
+    func executableDestination() -> URL {
+      if isPackage {
+        root.appending(component: ".executable\(Host.nativeExecutableSuffix)")
+      } else {
+        root.deletingPathExtension().appendingPathExtension("executable\(Host.nativeExecutableSuffix)")
+      }
+    }
+
     /// Saves `contents` into a file at its test-case level observation destination
     /// as specified by `testCaseLevelObservationDestination(tag:)`.
     ///
@@ -101,6 +111,11 @@ final class CompilerTests: XCTestCase {
     /// The compiled IR artifact of the tested module, if any.
     var llvmIR: String?
 
+    /// The URL of the generated executable residing in a temporary directory, if any.
+    ///
+    /// Copied to the test case destination upon test case failure.
+    var executable: URL?
+
     /// Saves the artifacts into test-case-level observation files of `test`.
     func save(into test: TestDescription) throws {
       if let rawIR {
@@ -112,8 +127,16 @@ final class CompilerTests: XCTestCase {
       if let llvmIR {
         try test.saveTestCaseLevelObservation(llvmIR, tag: "ll")
       }
+      if let executable {
+        try FileManager.default.copyItem(at: executable, to: test.executableDestination())
+      }
     }
 
+  }
+
+  /// Whether the test case has recorded any failures or uncaught exceptions.
+  var testFailed: Bool {
+    if let testRun, testRun.totalFailureCount > 0 { true } else { false }
   }
 
   /// The test case currently being run.
@@ -124,37 +147,62 @@ final class CompilerTests: XCTestCase {
 
   /// Saves any available compilation artifacts on test failure
   /// or if `alwaysSaveArtifacts` is true to facilitate diagnosis.
-  ///
-  /// Run by XCTest after each test case.
-  override func tearDownWithError() throws {
-    if let testRun, testRun.failureCount > 0 || alwaysSaveArtifacts, let testCase {
+  func saveArtifactsIfNeeded() throws {
+    if testFailed || alwaysSaveArtifacts, let testCase {
       try artifacts.save(into: testCase)
     }
   }
 
+  /// Run by XCTest after each test case.
+  override func tearDownWithError() throws {
+    try saveArtifactsIfNeeded()
+  }
+
+  /// The result of a successful compilation.
+  private struct CompilationResult {
+
+    /// The driver used to compile the test program.
+    var driver: Driver
+
+    /// The main module being compiled.
+    let module: FrontEnd.Module.ID
+
+    /// The expected diagnostics for each source file.
+    let expectedDiagnostics: [FileName: String]
+
+  }
+
   /// Compiles `input` expecting no compilation error.
   func positive(_ input: TestDescription) async throws {
-    let (program, _) = try await compile(input)
-    assertSansError(program)
+    do {
+      let r = try await compile(input)
+      try assertSansError(r.driver.program)
+    } catch let error as TestFailure {
+      XCTFail(error.localizedDescription + "\nSource: \(input.root.path)\n")
+    }
   }
 
   /// Compiles `input` expecting at least one compilation error.
   func negative(_ input: TestDescription) async throws {
-    let (program, expectations) = try await compile(input)
-    XCTAssert(program.containsError, "program compiled but an error was expected")
-    assertExpectations(expectations, program.diagnostics)
+    do {
+      let r = try await compile(input)
+      XCTAssert(r.driver.program.containsError, "program compiled but an error was expected.\nSource: \(input.root.path)\n")
+      assertExpectations(r.expectedDiagnostics, r.driver.program.diagnostics)
+    } catch let error as TestFailure {
+      XCTFail(error.localizedDescription + "\nSource: \(input.root.path)\n")
+    }
   }
 
-  /// Compiles `input` into `p` and returns expected diagnostics for each compiled source file.
+  /// Compiles `input` into `outputDirectory` and returns expected diagnostics for each compiled source file.
   ///
   /// Sets up the `testCase` context and populates `artifacts` as soon as compilation stages succeed.
-  private func compile(_ input: TestDescription) async throws -> (Program, [FileName: String]) {
+  private func compile(_ input: TestDescription) async throws -> CompilationResult {
     self.testCase = input
 
-    var driver = Driver(moduleCachePath: CompilerTests.moduleCachePath.url)
+    var driver = try Driver(moduleCachePath: CompilerTests.moduleCachePath.url, targetSpecification: .native())
 
     if input.manifest.requiresStandardLibrary {
-      try await driver.load(Module.standardLibraryName, withSourcesAt: localStandardLibrarySources)
+      try await driver.loadStandardLibrary()
     }
 
     let m = driver.program.demandModule(.init("Test"))
@@ -172,8 +220,11 @@ final class CompilerTests: XCTestCase {
       expectedDiagnostics[source.name] = expected
     }
 
-    func done() -> (Program, [FileName: String]) {
-      (driver.program, expectedDiagnostics)
+    func done() -> CompilationResult {
+      .init(
+        driver: driver,
+        module: m,
+        expectedDiagnostics: expectedDiagnostics)
     }
 
     // Exit if there are parsing errors or if the stage is set to `parsing`.
@@ -196,12 +247,47 @@ final class CompilerTests: XCTestCase {
 
     if input.manifest.stage == .lowering { return done() }
 
-    // Code generation.
-    assert(input.manifest.stage == .codegen)
+    // LLVM Lowering.
+    if (try driver.lowerToLLVM(m)).containsError { return done() }
+    artifacts.llvmIR = driver.llvmIR(of: m)!
+    if input.manifest.stage == .llvmLowering { return done() }
+
+    // When the stdlib can be compiled, lower it to LLVM so generateExecutable can link it.
+    if input.manifest.requiresStandardLibrary {
+      // let stdlibID = driver.program.demandModule(Module.standardLibraryName)
+      // if await driver.lower(stdlibID).containsError { return done() }
+      // if await driver.applyTransformationPasses(stdlibID).containsError { return done() }
+      // if (try driver.lowerToLLVM(stdlibID)).containsError { return done() }
+    }
+
+    if input.manifest.stage == .executableLinking {
+      let outputDirectory = try FileManager.default.createUniqueTemporaryDirectory()
+
+      let executable = outputDirectory.appendingPathComponent(driver.program[m].name)
+      _ = try driver.generateExecutable(from: m, writingTo: executable)
+      artifacts.executable = executable
+    }
+
     return done()
   }
 
-  private func compile(_ m: Module.ID, driver: inout Driver) {
+  /// An error thrown to signal test failure with given reason.
+  private enum TestFailure: Error {
+
+    case missingExecutableOutput
+    case compilationError(String)
+    case invalidTestDescription(String)
+
+    var localizedDescription: String {
+      switch self {
+      case .missingExecutableOutput:
+        return "missing executable output"
+      case .compilationError(let message):
+        return "Compilation failure:\n\(message)"
+      case .invalidTestDescription(let d):
+        return "Invalid test description (\(d))"
+      }
+    }
 
   }
 
@@ -242,7 +328,7 @@ final class CompilerTests: XCTestCase {
   }
 
   /// Asserts that `program` does not contain any error.
-  private func assertSansError(_ program: Program) {
+  private func assertSansError(_ program: Program) throws {
     if !program.containsError { return }
 
     let root = URL(filePath: #filePath).deletingLastPathComponent()
@@ -261,7 +347,7 @@ final class CompilerTests: XCTestCase {
       }
       report.write(o)
     }
-    XCTFail(report)
+    throw TestFailure.compilationError(report)
   }
 
   /// Returns a message explaining `delta`, which is the result of comparing `expectation` to some

--- a/Tests/CompilerTests/DriverTests.swift
+++ b/Tests/CompilerTests/DriverTests.swift
@@ -1,0 +1,74 @@
+import Driver
+import SwiftyLLVM
+import XCTest
+
+final class DriverTests: XCTestCase {
+
+  func testHostDriverCreation() throws {
+    let driver = try Driver(targetSpecification: .host())
+
+    // Should be generic
+    XCTAssertEqual("", driver.target.cpu)
+    XCTAssertEqual("", driver.target.features)
+  }
+
+  func testNativeDriverCreation() throws {
+    let driver = try Driver(targetSpecification: .native())
+    XCTAssertFalse(driver.target.cpu.isEmpty)
+  }
+
+  func testCreateDriverWithOptions() throws {
+    let driver = try Driver(
+      targetSpecification: .host(),
+      optimization: .aggressive,
+      relocation: .pic,
+      codeModel: .small)
+    XCTAssertEqual(driver.optimization, .aggressive)
+    XCTAssertEqual(driver.relocation, .pic)
+    XCTAssertEqual(driver.codeModel, .small)
+  }
+
+  func testModuleCacheDisabled() throws {
+    let d = try Driver(moduleCachePath: nil, targetSpecification: .native())
+    XCTAssertNil(d.archive(of: "test"))
+  }
+
+  func testModuleCacheNotFound() throws {
+    let d = try Driver(
+      moduleCachePath: FileManager.default.temporaryDirectory, 
+      targetSpecification: .native())
+    XCTAssertNil(d.archive(of: "test"))
+  }
+
+  func testInvalidArchive() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (cacheRoot) in 
+      try await FileManager.default.withUniqueTemporaryDirectory { (sourceRoot) in
+        var d = try Driver(
+          moduleCachePath: cacheRoot, 
+          targetSpecification: .native())
+        
+        let cachePath = cacheRoot.appendingPathComponent("Main.hylomodule")
+        // Write an invalid archive
+        try "invalid".write(to: cachePath, atomically: true, encoding: .utf8)
+
+        XCTAssertNotNil(d.archive(of: "Main"))
+
+
+        // Now try to load it - this should fail
+        do {
+          try await d.load("Main", withSourcesAt: sourceRoot)
+          XCTFail("Expected load to fail")
+        } catch let error as Driver.Error {
+          XCTAssertEqual(error.message, """
+            Failed to parse module archive of 'Main' at '\(cacheRoot)'.
+
+            Maybe the archive is compiled using a different version of the compiler. Try erasing the module cache.
+            """)
+
+          XCTAssertEqual("\(error)", error.message)
+        }
+      }
+    }
+  }
+
+}

--- a/Tests/CompilerTests/Manifest.swift
+++ b/Tests/CompilerTests/Manifest.swift
@@ -4,7 +4,7 @@ import Utilities
 /// A test manifest.
 struct Manifest {
 
-  /// A stage of the compilation pipelne.
+  /// A stage of the compilation pipeline.
   enum Stage: String {
 
     /// After the abstract syntax tree has been parsed.
@@ -16,8 +16,11 @@ struct Manifest {
     /// After IR lowering.
     case lowering
 
-    /// After the program has been compiled to binary.
-    case codegen
+    /// After LLVM lowering.
+    case llvmLowering
+
+    /// After the program has been linked into an executable.
+    case executableLinking
 
   }
 
@@ -25,7 +28,7 @@ struct Manifest {
   private(set) var requiresStandardLibrary: Bool = true
 
   /// The stage up to which the input should be compiled.
-  private(set) var stage: Stage = .codegen
+  private(set) var stage: Stage = .llvmLowering
 
   /// Creates an instance with a default configuration.
   init() {}

--- a/Tests/CompilerTests/StandardLibraryLoadingTests.swift
+++ b/Tests/CompilerTests/StandardLibraryLoadingTests.swift
@@ -6,17 +6,17 @@ import StandardLibrary
 final class StandardLibraryLoadingTests: XCTestCase {
 
   func testStandardLibraryLoading() async throws {
-    var driver = Driver()
+    var driver = try Driver(targetSpecification: .native())
     try await driver.loadStandardLibrary()
   }
 
   func testStandardLibraryLoadingBundled() async throws {
-    var driver = Driver()
+    var driver = try Driver(targetSpecification: .native())
     try await driver.load(Module.standardLibraryName, withSourcesAt: bundledStandardLibrarySources)
   }
 
   func testStandardLibraryLoadingLocal() async throws {
-    var driver = Driver()
+    var driver = try Driver(targetSpecification: .native())
     try await driver.load(Module.standardLibraryName, withSourcesAt: localStandardLibrarySources)
   }
 

--- a/Tests/LLVMEmitterTests/SimpleFunctionEmitterTest.swift
+++ b/Tests/LLVMEmitterTests/SimpleFunctionEmitterTest.swift
@@ -1,0 +1,52 @@
+import Driver
+import FrontEnd
+import LLVMEmitter
+import XCTest
+
+final class SimpleFunctionEmitterTest: XCTestCase {
+
+  // TODO: Re-enable when transpileToLLVM is implemented.
+  func testTrivial() async throws {
+    var driver = try Driver(targetSpecification: .native())
+
+    let m = driver.program.demandModule("M0")
+
+    if await driver.assignScopes(of: m).containsError { return XCTFail("Failed to assign scopes") }
+    if await driver.assignTypes(of: m).containsError { return XCTFail("Failed to assign types") }
+
+    // IR Lowering.
+    let l = await driver.lower(m)
+    if l.containsError { return XCTFail("Failed to lower IR") }
+
+    // IR Transformation passes.
+    let t = await driver.applyTransformationPasses(m)
+    if t.containsError { return XCTFail("Failed to apply transformation passes") }
+
+    // LLVM Lowering.
+    if (try driver.lowerToLLVM(m)).containsError { return XCTFail("Failed to lower to LLVM") }
+    XCTAssertEqual(
+      driver.llvmIR(of: m),
+      """
+      ; ModuleID = 'MainModule'
+      source_filename = "MainModule"
+
+      define i32 @main() {
+        ret i32 0
+      }
+
+      """)
+
+    XCTAssertTrue(try driver.assembly(of: m).contains("main:"))
+    
+    let outputDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+      UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: false)
+
+    let executable = outputDirectory.appendingPathComponent(driver.program[m].name)
+    _ = try driver.generateExecutable(from: m, writingTo: executable)
+
+    let output = try Process.executionOutput(executable)
+    XCTAssertEqual(output.trimming(while: \.isWhitespace), "")
+  }
+
+}

--- a/Tests/UtilitiesTests/FileManagerExtensionsTests.swift
+++ b/Tests/UtilitiesTests/FileManagerExtensionsTests.swift
@@ -1,0 +1,33 @@
+import Utilities
+import XCTest
+import Foundation
+
+final class FileManagerExtensionsTests: XCTestCase {
+
+  func testWithUniqueTemporaryDirectory() throws {
+    var path: URL? = nil
+    try FileManager.default.withUniqueTemporaryDirectory { p in
+      path = p
+      var isDirectory: ObjCBool = false
+      XCTAssertTrue(FileManager.default.fileExists(atPath: p.path, isDirectory: &isDirectory))
+      XCTAssertTrue(isDirectory.boolValue)
+    }
+    let p = try XCTUnwrap(path)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: p.path))
+  }
+
+  func testWithUniqueTemporaryDirectoryAsync() async throws {
+    var path: URL? = nil
+    try await FileManager.default.withUniqueTemporaryDirectory { p in
+      path = p
+      var isDirectory: ObjCBool = false
+      XCTAssertTrue(FileManager.default.fileExists(atPath: p.path, isDirectory: &isDirectory))
+      XCTAssertTrue(isDirectory.boolValue)
+
+      try await Task.sleep(for: .microseconds(0))
+    }
+    let p = try XCTUnwrap(path)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: p.path))
+  }
+
+}


### PR DESCRIPTION
- Adds SwiftyLLVM v2 as a submodule and sets up LLVM on CI
- Adds options to Driver to configure LLVM options
  - code model
  - relocation model
  - optimization level
  - target triple, cpu, features
- Improves error handling in the Driver for module cache reading failures, added tests.

Closes #29 