### PR TITLE
Platform utilities

### DIFF
--- a/Sources/Utilities/Host.swift
+++ b/Sources/Utilities/Host.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// The platform on which the compiler or interpreter is running.
+public enum Host: Sendable {
+
+  #if os(macOS)
+    /// The host operating system.
+    public static let operatingSystem: Platform.OperatingSystem = .macOS
+  #elseif os(Linux)
+    /// The host operating system.
+    public static let operatingSystem: Platform.OperatingSystem = .linux
+  #elseif os(Windows)
+    /// The host operating system.
+    public static let operatingSystem: Platform.OperatingSystem = .windows
+  #else
+    #error("Unsupported host operating system")
+  #endif
+
+  #if arch(x86_64)
+    /// The host architecture.
+    public static let architecture: Platform.Architecture = .x86_64
+  #elseif arch(arm64)
+    /// The host architecture.
+    public static let architecture: Platform.Architecture = .arm64
+  #else
+    #error("Unsupported host architecture")
+  #endif
+
+  /// A view of the environment variables.
+  public struct Environment: Sendable {
+
+    /// Returns the value of the environment variable named `key`, if any.
+    ///
+    /// On Windows, the comparison is case-insensitive and takes linear time.
+    public subscript(_ key: String) -> String? {
+      #if os(Windows)
+        ProcessInfo.processInfo.environment
+          .first(where: { $0.key.caseInsensitiveCompare(key) == .orderedSame })?.value
+      #else
+        ProcessInfo.processInfo.environment[key]
+      #endif
+    }
+
+    /// Returns the value of the environment variable named `key` or `d` if it's not set.
+    ///
+    /// On Windows, the comparison is case-insensitive and takes linear time.
+    public subscript(_ key: String, default d: String) -> String {
+      self[key] ?? d
+    }
+
+  }
+
+  /// The environment variables of the current process.
+  public static let environment = Environment()
+
+  /// The locations of the executable search path (aka the `PATH` environment variable).
+  public static func searchPathLocations() -> [String] {
+    Host.environment["PATH", default: ""]
+      .split(separator: Host.searchPathSeparator)
+      .map(String.init)
+  }
+
+  /// The separator between individual locations in executable search path.
+  public static let searchPathSeparator: Character = Host.operatingSystem == .windows ? ";" : ":"
+
+  /// The suffix of native executables.
+  public static let nativeExecutableSuffix = operatingSystem == .windows ? ".exe" : ""
+
+  /// Returns the location of the native executable invoked as `name` using the search path or
+  /// throws `ExecutableNotFound` if no executable could be found.
+  ///
+  /// `name` shall be supplied without the native executable suffix, e.g. without `.exe` on Windows.
+  /// Only native executables are resolved. Script files such as `.cmd`, `.bat`, and `.ps1` are not.
+  public static func findNativeExecutable(invokedAs name: String) throws -> URL {
+   for base in searchPathLocations() {
+     let p =  URL(fileURLWithPath: base).appendingPathComponent(name + nativeExecutableSuffix)
+     if FileManager.default.isExecutableFile(atPath: p.path) { return p }
+   }
+   throw ExecutableNotFound(name: name)
+  }
+
+  /// Error thrown when an executable is not found on the PATH.
+  public struct ExecutableNotFound: Error, CustomStringConvertible {
+    
+    /// Name of the executable without native executable suffix.
+    public let name: String
+
+    /// A description of the error.
+    public var description: String {
+      "Executable not found on PATH: \(name)"
+    }
+
+  }
+
+}

--- a/Sources/Utilities/Platform.swift
+++ b/Sources/Utilities/Platform.swift
@@ -1,0 +1,32 @@
+/// The platform on which the compiler or interpreter is running/targeting.
+public enum Platform: Sendable {
+
+  /// An operating system on which the Hylo compiler toolchain can run as a host.
+  public enum OperatingSystem: String, Codable, CustomStringConvertible, Sendable {
+
+    case macOS = "macOS"
+
+    case linux = "Linux"
+
+    case windows = "Windows"
+
+    /// A description of `self`.
+    public var description: String {
+      rawValue
+    }
+
+  }
+
+  /// An architecture on which the Hylo compiler toolchain can run as a host.
+  public enum Architecture: String, Codable, CustomStringConvertible, Sendable {
+
+    case x86_64, arm64
+
+    /// String representation.
+    public var description: String {
+      return rawValue
+    }
+
+  }
+
+}

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+extension Process {
+
+  /// The error thrown when a process exits with a non-zero status.
+  public struct NonzeroExit: Error {
+
+    /// The exit code of the process.
+    public let exitCode: Int32
+
+    /// The data written to the standard output of the process.
+    public let standardOutput: String
+
+    /// The data written to the standard error of the process.
+    public let standardError: String
+
+    /// The path to the executable ran by the process.
+    public let executable: URL
+
+    /// The arguments passed to the process.
+    public let arguments: [String]
+
+  }
+
+  /// Runs `executable` with `arguments` and returns the data written to the standard output.
+  ///
+  /// Throws a `NonzeroExit` upon terminating with non-zero exit code.
+  public static func executionOutput(
+    _ executable: URL, arguments: [String] = []
+  ) throws -> String {
+    let process = Process()
+    let standardOutput = Pipe()
+    let standardError = Pipe()
+    process.executableURL = executable
+    process.arguments = arguments
+    process.standardOutput = standardOutput
+    process.standardError = standardError
+    try process.run()
+    process.waitUntilExit()
+
+    let output = String(decoding: standardOutput.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let error = String(decoding: standardError.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+
+    if process.terminationStatus != 0 {
+      throw NonzeroExit(
+        exitCode: process.terminationStatus,
+        standardOutput: output,
+        standardError: error,
+        executable: executable,
+        arguments: arguments)
+    }
+
+    return output
+  }
+
+  /// Runs `executable` with `arguments` and returns its execution report.
+  public static func execute(
+    _ executable: URL, arguments: [String] = []
+  ) throws -> ExecutionReport {
+    let process = Process()
+    let standardOutput = Pipe()
+    let standardError = Pipe()
+    process.arguments = arguments
+    process.executableURL = executable
+    process.standardOutput = standardOutput
+    process.standardError = standardError
+    try process.run()
+    process.waitUntilExit()
+
+    let output = String(decoding: standardOutput.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let error = String(decoding: standardError.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+
+    return .init(
+      standardOutput: output,
+      standardError: error,
+      exitCode: process.terminationStatus)
+  }
+
+
+  /// The result of executing a process.
+  public struct ExecutionReport {
+
+    /// The data written to the standard output of the process.
+    public let standardOutput: String
+
+    /// The data written to the standard error of the process.
+    public let standardError: String
+
+    /// The exit code of the process.
+    public let exitCode: Int32
+
+    /// Creates an instance from its parts.
+    public init(standardOutput: String, standardError: String, exitCode: Int32) {
+      self.standardOutput = standardOutput
+      self.standardError = standardError
+      self.exitCode = exitCode
+    }
+
+  }
+}

--- a/Tests/UtilitiesTests/HostTests.swift
+++ b/Tests/UtilitiesTests/HostTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Utilities
+import XCTest
+
+typealias Host = Utilities.Host
+
+
+final class HostTests: XCTestCase {
+
+  func testFindNativeExecutableThrowsForUnknownCommand() throws {
+    XCTAssertThrowsError(
+      try Host.findNativeExecutable(invokedAs: "randomNotFoundExecutable"), "",
+      { (error) in
+        if let e = error as? Host.ExecutableNotFound {
+          XCTAssertEqual(e.name, "randomNotFoundExecutable")
+          XCTAssertEqual(e.description, "Executable not found on PATH: randomNotFoundExecutable")
+        } else {
+          XCTFail("Expected Host.ExecutableNotFound, got \(error)")
+        }
+      })
+  }
+
+  #if os(Windows)
+    func testFindNativeExecutableFindsAndExecutesWhereExe() throws {
+      let whereExe = try Host.findNativeExecutable(invokedAs: "where")
+      XCTAssertEqual(whereExe.lastPathComponent.lowercased(), "where.exe")
+
+      let output = try Process.executionOutput(whereExe, arguments: ["cmd"])
+      XCTAssertTrue(output.lowercased().contains("cmd.exe"))
+    }
+  #else
+    func testFindNativeExecutableFindsAndExecutesBash() throws {
+      let bash = try Host.findNativeExecutable(invokedAs: "bash")
+      XCTAssertEqual(bash.lastPathComponent, "bash")
+
+      let output = try Process.executionOutput(bash, arguments: ["-lc", "printf '%s' bash-ok"])
+      XCTAssertEqual(output, "bash-ok")
+    }
+  #endif
+
+  func testExecutionOutputThrowsOnNonzeroExit() throws {
+    #if os(Windows)
+      let executable = try Host.findNativeExecutable(invokedAs: "cmd")
+      let arguments = ["/c", "exit", "42"]
+    #else
+      let executable = try Host.findNativeExecutable(invokedAs: "bash")
+      let arguments = ["-lc", "exit 42"]
+    #endif
+
+    XCTAssertThrowsError(
+      try Process.executionOutput(executable, arguments: arguments), "",
+      { (error) in
+        if let e = error as? Process.NonzeroExit {
+          XCTAssertEqual(e.exitCode, 42)
+          XCTAssertEqual(e.executable, executable)
+          XCTAssertEqual(e.arguments, arguments)
+        } else {
+          XCTFail("Expected Process.NonzeroExit, got \(error)")
+        }
+      })
+  }
+
+  func testExecuteReturnsReportOnNonzeroExit() throws {
+    #if os(Windows)
+      let executable = try Host.findNativeExecutable(invokedAs: "cmd")
+      let arguments = ["/c", "exit", "42"]
+    #else
+      let executable = try Host.findNativeExecutable(invokedAs: "bash")
+      let arguments = ["-lc", "exit 42"]
+    #endif
+
+    let r = try Process.execute(executable, arguments: arguments)
+    XCTAssertEqual(r.exitCode, 42)
+    XCTAssertEqual(r.standardOutput, "")
+    XCTAssertEqual(r.standardError, "")
+  }
+
+}

--- a/Tests/UtilitiesTests/PlatformTests.swift
+++ b/Tests/UtilitiesTests/PlatformTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Utilities
+import XCTest
+
+final class PlatformTests: XCTestCase {
+
+  func testArchitectureDescription() {
+    XCTAssertEqual(Platform.Architecture.arm64.description, "arm64")
+    XCTAssertEqual(Platform.Architecture.x86_64.description, "x86_64")
+  }
+
+  func testOperatingSystemDescription() {
+    XCTAssertEqual(Platform.OperatingSystem.macOS.description, "macOS")
+    XCTAssertEqual(Platform.OperatingSystem.linux.description, "Linux")
+    XCTAssertEqual(Platform.OperatingSystem.windows.description, "Windows")
+  }
+
+}


### PR DESCRIPTION
Platform utilities for representing the architectures and operating systems at runtime. These additions will be useful for the driver to invoke the linker and the output executable.

The original version can be found at https://github.com/hylo-lang/hylo/blob/main/Sources/Utils/Host.swift and https://github.com/hylo-lang/hylo/blob/main/Sources/Utils/Platform.swift

The newly added utilities for resolving an executable on the PATH only supports resolving and running and resolving native executables, not arbitrary shell files that cmd or powershell could execute. For now, this is sufficient, as the only tool we depend on at runtime is the Clang driver. Adding support for ps1/cmd/bat files would require running them in a shell (they cannot be executed natively), so I wanted to avoid that extra complexity. With this constraint in mind, it's also sufficient to use the PATH based lookup on Windows instead of calling the `where.exe` subprocess.