### PR TITLE
Add coding conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Follow [../CONVENTIONS.md](../CONVENTIONS.md) strictly when reviewing code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,6 @@ publish a release when editing the draft.
 
 The conventional tag name for releases is `vX.Y.Z`, with an optional suffix for pre-releases (like `v0.0.2-test-lsp`).
 The release workflow only triggers for a pattern matching `v*`.
+
+## Coding Conventions
+Consult [CONVENTIONS.md](CONVENTIONS.md) for coding conventions used in this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,17 @@ The release workflow only triggers for a pattern matching `v*`.
 
 ## Coding Conventions
 Consult [CONVENTIONS.md](CONVENTIONS.md) for coding conventions used in this project.
+
+## LLM usage
+If you use an LLM to generate code, please disclose this in your Pull Request description.
+
+While we embrace tools that improve efficiency, we must avoid committing code we do not understand. If your PR includes
+LLM-generated code that is complex or opaque to you:
+
+1. Stop
+2. Understand and document what it is doing
+3. Simplify it so that others can follow.
+
+If you are unable to do these things, bring your problem up on Slack and work through a resolution with the community.
+
+Ultimately, you are responsible for the code you commit. Ensure you review and test generated code thoroughly, and always alert reviewers to it.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -33,6 +33,8 @@ or usages to infer meaning.
 - Conformance implementations are exempt from documentation when nothing useful can be added beyond the protocol
   requirement itself.
 - Test cases don't need to be documented, but should have a descriptive function name.
+- For types, the summary should say what the type *is*. For functions and subscripts, it should say what they *do* (e.g. returns, yields ...).
+- Describe if there is a significance in the element order of an array.
 
 ## Contracts
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -79,3 +79,19 @@ Avoid typed `throws` unless you are confident that the immediate caller will be 
 - Use explicit named parameters in parentheses for multi-statement closures: `{ element in ... }`. Use `$0` shorthand only in short, single-expression closures.
 - Use `// MARK:` comments to organize sections in large files.
 - Use `self.` in initializers when assigning to stored properties.
+
+## File names
+
+All Swift source files end with the extension `.swift` and all Hylo source files end with the extension `.hylo`.
+
+In general, a file is named after the main entity that it defines. A file that extends an existing type with a protocol (Swift) or trait (Hylo) conformance is named with a combination of the type name and the protocol or trait name, joined with a plus (`+`) sign. For more complex situations, exercise your best judgment.
+
+For example:
+
+- A Swift file defining a type named MyType is named MyType.swift.
+- A Swift file defining how MyType conforms to Equatable is named MyType+Equatable.swift.
+- Retroactive conformances can be added in `MyType+Extensions.swift`.
+
+Avoid defining multiple types, protocols, or traits in the same file unless they are scoped by a main entity or meant to
+be used only in that file. Usually, conformances and custom error types are small and are defined in the same file as 
+the type to which they apply.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -77,5 +77,5 @@ Avoid typed `throws` unless you are confident that the immediate caller will be 
 - Add blank lines inside type, extension, and enum declarations - leave one empty line after the opening brace and before the closing brace.
 - Separate protocol conformances into their own extensions unless it's a marker protocol.
 - Use explicit named parameters in parentheses for multi-statement closures: `{ element in ... }`. Use `$0` shorthand only in short, single-expression closures.
-- Use `MARK:` comments to organize sections in large files.
+- Use `// MARK:` comments to organize sections in large files.
 - Use `self.` in initializers when assigning to stored properties.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -33,7 +33,7 @@ When to use each termination mechanism:
 - **`unimplemented("feature name")`** - a stub for functionality not yet written.
 - **`fatalError("message")`** - avoid this, either `unreachable()` or `unimplemented()` should be used instead. If you don't expect it to be unreachable nor unimplemented, prefer reporting an error with throw or returning `nil`.
 
-When a contract seems too strict to use correctly without accidentally breaking preconditions, you can either relax the preconditions (e.g. `demandModule(name:)` - gets or creates module if doesn't exist yet) or report an error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not found).
+When a contract seems too strict to use correctly without accidentally breaking preconditions, you can either relax the preconditions (e.g. `demandModule(name:)` - gets or creates the module if it doesn't exist yet) or report an error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not found).
 
 Avoid typed `throws` unless you are confident that the immediate caller will be interested in handling the error and it doesn't just use its description but is interested in the specific error type.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -142,7 +142,9 @@ doesn't just use its description but is interested in the specific error type.
   ) -> DefinitionResponse {
     // body
   }
-  ``` 
+  ```
+- Avoid listing multiple cases in a switch: `case c1, c2, c3:`.
+- Avoid conformances in extensions where the new protocol is a refinement of a previously conformed-to protocol. E.g. don't declare a conformance to `LiteralExpression` separately when the struct already conforms to `Expression`.
 
 ## File names
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -19,6 +19,7 @@ Documentation enables local reasoning - it's a shortcut for understanding so rea
 - Create the strictest contracts possible, so long as the client can reason about the preconditions locally.
 - Preconditions and postconditions are relationships between components - think in terms of what the caller must provide and what the callee guarantees in return.
 - Contract evolution: you may safely weaken preconditions and strengthen postconditions. The reverse breaks clients, so you must inspect all call sites before introducing the change.
+- When a contract seems too strict to use correctly without accidentally breaking preconditions, you can either relax the preconditions (e.g. `demandModule(name:)` - gets or creates the module if it doesn't exist yet) or report an error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not found).
 
 ## Errors
 
@@ -33,9 +34,9 @@ When to use each termination mechanism:
 - **`unimplemented("feature name")`** - a stub for functionality not yet written.
 - **`fatalError("message")`** - avoid this, either `unreachable()` or `unimplemented()` should be used instead. If you don't expect it to be unreachable nor unimplemented, prefer reporting an error with throw or returning `nil`.
 
-When a contract seems too strict to use correctly without accidentally breaking preconditions, you can either relax the preconditions (e.g. `demandModule(name:)` - gets or creates the module if it doesn't exist yet) or report an error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not found).
-
-Avoid typed `throws` unless you are confident that the immediate caller will be interested in handling the error and it doesn't just use its description but is interested in the specific error type.
+Reporting errors:
+- Avoid typed `throws` unless you are confident that the immediate caller will be interested in handling the error, and it doesn't just use its description but is interested in the specific error type. Otherwise, you would expose implementation details that propagate through your program's APIs virally.
+- Avoid silently swallowing invalid input that would lead to accepting undesirable inputs; report and propagate errors instead.
 
 ## Safety
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -68,7 +68,7 @@ Avoid typed `throws` unless you are confident that the immediate caller will be 
 
 - All new code should be covered by tests.
 - Tests should exercise the contract: verify postconditions under valid preconditions.
-- (Death tests are not supported in Swift XCTest, but it would be nice to write tests that exercise libraries that they uphold safety by crashing correctly on precondition violations.)
+- (Death tests are not supported in Swift XCTest, but it would be nice to write tests that exercise that libraries uphold safety by crashing correctly on precondition violations.)
 
 ## Formatting
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -134,6 +134,15 @@ doesn't just use its description but is interested in the specific error type.
   ```
 - We should wrap as little code as possible in try blocks.
 - Add parenthesis around the parameter names of closures (e.g. `{ (e) in ... }`)
+- When the parameters of a function/subscript declaration don't fit in a single line, use this formatting style:
+  ```swift
+  func resolve(
+    _ p: SourcePosition, in program: Program, reportingTo l: Logger,
+    in f: SourceFile.ID
+  ) -> DefinitionResponse {
+    // body
+  }
+  ``` 
 
 ## File names
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -163,3 +163,8 @@ For example:
 Avoid defining multiple types, protocols, or traits in the same file unless they are scoped by a main entity or meant to
 be used only in that file. Usually, conformances and custom error types are small and are defined in the same file as
 the type to which they apply.
+
+
+# Project-specific conventions
+
+- Use the term `kind` exclusively to refer to the kind of a type.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -94,7 +94,7 @@ doesn't just use its description but is interested in the specific error type.
 - Prefer value types. Reference types (`class`) are appropriate only for identity, shared mutable state, or non-copyable
   resources—document why.
 
-## Naming
+## Naming and API design
 
 - Name mutating methods with imperative verb phrases; name nonmutating variants with past participle or `ing` forms.
 - No abbreviations in APIs unless universally known (e.g. `URL`, `ID`).
@@ -105,6 +105,7 @@ doesn't just use its description but is interested in the specific error type.
   `i`/`j` for indices.
 - When naming a collection of objects, use a plural form (even in case of short names): `files`, `xs`, `ms`.
 - Prefer descriptive labels over `for` as a parameter label.
+- Add explicit access specifiers to declarations, hiding as much as possible, unless there is a good reason to expose something. Exposing previously private details should be discussed during reviews.
 
 ## Testing
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,67 +1,108 @@
 # Coding Guidelines
 
+Our conventions are based on the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
+This document only describes guidelines that are not covered there.
+
 ## Documentation
 
-Documentation enables local reasoning - it's a shortcut for understanding so readers can avoid looking up implementation or usages to infer meaning.
+Documentation enables local reasoning - it's a shortcut for understanding so readers can avoid looking up implementation
+or usages to infer meaning.
 
-- Document every declaration with at least a summary sentence, using `///` style comments.
-- Start with a summary sentence fragment describing what it *does* (functions) or what it *is* (types, properties). End with a period.
-- Omit needless words: don't repeat the receiver's type, don't write `the`, `given`, `of self`, `of the current object` when context makes these obvious.
-- Use `iff` instead of `if` where applicable.
-- Use `<...>, if any.` for optional values where the absence reason is obvious. Otherwise: `<...> if <condition>, nil otherwise.`
-- Document preconditions with `- Requires:`. If the precondition is obvious from the summary, it need not be repeated.
-- Multiple preconditions should be in a markdown list below `- Requires:`.
-- Document performance of every operation that doesn't run in constant time and space.
-- Conformance implementations are exempt from documentation when nothing useful can be added beyond the protocol requirement itself.
+- Every declaration outside a function body must have a documentation comment that describes its contract.
+  - Start with a summary sentence fragment.
+    - Describe what a function or method does and what it returns.
+    - Describe what a property or type is.
+    - Separate the fragment from any additional documentation with a blank line and end it with a period.
+
+  - Preconditions, postconditions and invariants obviously implied by the summary need not be explicitly documented.
+
+  - Declarations that fulfill protocol requirements are exempted when nothing useful can be added to the documentation
+    of the protocol requirement itself.
+
+- Document the performance of every operation that doesn't execute in constant time and space, unless it's obvious from
+  the summary.
+- Test cases need not be documented, but should have a descriptive function name.
+
+- Phrasing conventions:
+  - Omit needless words: don't repeat the receiver's type, don't write `the`, `given`, `of self`,
+    `of the current object` when context makes these obvious.
+  - Use `iff` instead of `if` where applicable.
+  - Use `<...>, if any.` for optional values where the absence reason is obvious. Otherwise:
+    `<...> if <condition>, nil otherwise.`
+  - Document preconditions with `- Requires:`. If multiple preconditions apply, use a markdown list below `- Requires:`.
+- Conformance implementations are exempt from documentation when nothing useful can be added beyond the protocol
+  requirement itself.
+- Test cases don't need to be documented, but should have a descriptive function name.
 
 ## Contracts
 
 - Create the strictest contracts possible, so long as the client can reason about the preconditions locally.
-- Preconditions and postconditions are relationships between components - think in terms of what the caller must provide and what the callee guarantees in return.
-- Contract evolution: you may safely weaken preconditions and strengthen postconditions. The reverse breaks clients, so you must inspect all call sites before introducing the change.
-- When a contract seems too strict to use correctly without accidentally breaking preconditions, you can either relax the preconditions (e.g. `demandModule(name:)` - gets or creates the module if it doesn't exist yet) or report an error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not found).
+- Preconditions and postconditions are relationships between components - think in terms of what the caller must provide
+  and what the callee guarantees in return.
+- Contract evolution: you may safely weaken preconditions and strengthen postconditions. The reverse breaks clients, so
+  you must inspect all call sites before introducing the change.
+- When a contract seems too strict to use correctly without accidentally breaking preconditions, you can either relax
+  the preconditions (e.g. `demandModule(name:)` - gets or creates the module if it doesn't exist yet) or report an
+  error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not found).
 
 ## Errors
 
 Distinguish bugs from runtime errors:
+
 - **Bug**: a programming mistake. Stop before more damage is done.
-- **Runtime error**: postconditions can't be met despite correct usage. Respond by `throw`ing or returning an optional/result.
+- **Runtime error**: postconditions can't be met despite correct usage. Respond by `throw`ing or returning an
+  optional/result.
 
 When to use each termination mechanism:
-- **`precondition(condition, "message")`** - the caller violated a documented requirement. Checked in all builds.
-- **`assert(condition, "message")`** - an internal invariant that should hold if the implementation is correct. Checked only in debug builds.
-- **`unreachable("message")`** - a code path that is logically impossible given the surrounding control flow or type system.
-- **`unimplemented("feature name")`** - a stub for functionality not yet written.
-- **`fatalError("message")`** - avoid this, either `unreachable()` or `unimplemented()` should be used instead. If you don't expect it to be unreachable nor unimplemented, prefer reporting an error with throw or returning `nil`.
 
-Reporting errors:
-- Avoid typed `throws` unless you are confident that the immediate caller will be interested in handling the error, and it doesn't just use its description but is interested in the specific error type. Otherwise, you would expose implementation details that propagate through your program's APIs virally.
-- Avoid silently swallowing invalid input that would lead to accepting undesirable inputs; report and propagate errors instead.
+- **`precondition(condition, "message")`** - the caller violated a documented requirement. Checked in all builds.
+- **`assert(condition, "message")`** - an internal invariant that should hold if the implementation is correct. Checked
+  only in debug builds.
+- **`unreachable("message")`** - a code path that is logically impossible given the surrounding control flow or type
+  system.
+- **`unimplemented("feature name")`** - a stub for functionality not yet written.
+- **`fatalError("message")`** - avoid this, either `unreachable()` or `unimplemented()` should be used instead. If you
+  don't expect it to be unreachable nor unimplemented, prefer reporting an error with throw or returning `nil`.
+
+When a contract seems too strict to use correctly without accidentally breaking preconditions, you can either relax the
+preconditions (e.g. `demandModule(name:)` - gets or creates the module if it doesn't exist yet) or report an
+error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not found).
+
+Avoid typed `throws` unless you are confident that the immediate caller will be interested in handling the error and it
+doesn't just use its description but is interested in the specific error type.
 
 ## Safety
 
-- When using an unsafe or unchecked construct (e.g. `@unchecked Sendable`), include a comment that justifies the need and explains why it's safe.
+- When using an unsafe or unchecked construct (e.g. `@unchecked Sendable`), include a comment that justifies the need
+  and explains why it's safe.
 
 ## Algorithms
 
 - Prefer named algorithms over inline loops. A loop is a mechanism; a named algorithm is a statement of intent.
-- When a suitable algorithm doesn't exist, create one as an extension on the appropriate type (`Sequence`, `Collection`, etc.) rather than inlining the loop at the call site.
-- Structure data so efficient algorithms become possible (e.g. storing something in an ordered collection for binary search, or storing in a hashmap for O(1) lookup).
+- When a suitable algorithm doesn't exist, create one as an extension on the appropriate type (`Sequence`, `Collection`,
+  etc.) rather than inlining the loop at the call site.
+- Structure data so efficient algorithms become possible (e.g. storing something in an ordered collection for binary
+  search, or storing in a hashmap for O(1) lookup).
 
 ## Types
 
-- Use strong types to encode invariants. If a value can only be valid in certain states, make invalid states unrepresentable.
+- Use strong types to encode invariants. If a value can only be valid in certain states, make invalid states
+  unrepresentable.
 - Every instance of a type should have exactly one clearly-defined value, expressed in terms of its operations.
-- Keep the efficient basis of a type small and well-documented. All other operations should be derivable from it.
-- Prefer value types. Reference types (`class`) are appropriate only for identity, shared mutable state, or non-copyable resources—document why.
+- Keep the efficient basis of a type small and well-documented. All other operations should be derivable from it as
+  `extension`s.
+- Prefer value types. Reference types (`class`) are appropriate only for identity, shared mutable state, or non-copyable
+  resources—document why.
 
 ## Naming
 
-- Follow the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/). Name mutating methods with imperative verb phrases; name nonmutating variants with past participle or `ing` forms.
+- Name mutating methods with imperative verb phrases; name nonmutating variants with past participle or `ing` forms.
 - No abbreviations in APIs unless universally known (e.g. `URL`, `ID`).
 - Don't include the type in a binding's name.
-- If the type is too weak, a qualified argument label can help (e.g. `f(outputDirectory: URL)`), but prefer making the type more strict to capture the invariants (e.g. `f(output: DirectoryURL)`).
-- Single-letter names are fine in small scopes: `l`/`r` for binary operators, `n` for a syntax node, `m` for a module, `i`/`j` for indices.
+- If the type is too weak, a qualified argument label can help (e.g. `f(outputDirectory: URL)`), but prefer making the
+  type more strict to capture the invariants (e.g. `f(output: DirectoryURL)`).
+- Single-letter names are fine in small scopes: `l`/`r` for binary operators, `n` for a syntax node, `m` for a module,
+  `i`/`j` for indices.
 - When naming a collection of objects, use a plural form (even in case of short names): `files`, `xs`, `ms`.
 - Prefer descriptive labels over `for` as a parameter label.
 
@@ -69,23 +110,29 @@ Reporting errors:
 
 - All new code should be covered by tests.
 - Tests should exercise the contract: verify postconditions under valid preconditions.
-- (Death tests are not supported in Swift XCTest, but it would be nice to write tests that exercise that libraries uphold safety by crashing correctly on precondition violations.)
+- (Death tests are not supported in Swift XCTest, but it would be nice to write tests that exercise that libraries
+  uphold safety by crashing correctly on precondition violations.)
 
 ## Formatting
 
 - Indent with 2 spaces.
 - Use a 100-column line limit.
-- Add blank lines inside type, extension, and enum declarations - leave one empty line after the opening brace and before the closing brace.
+- Add blank lines inside type, extension, and enum declarations - leave one empty line after the opening brace and
+  before the closing brace.
 - Separate protocol conformances into their own extensions unless it's a marker protocol.
-- Use explicit named parameters in parentheses for multi-statement closures: `{ element in ... }`. Use `$0` shorthand only in short, single-expression closures.
+- Use explicit named parameters in parentheses for multi-statement closures: `{ element in ... }`. Use `$0` shorthand
+  only in short, single-expression closures.
 - Use `// MARK:` comments to organize sections in large files.
 - Use `self.` in initializers when assigning to stored properties.
+- Use single-expression function / computed property bodies over explicit return statements where possible.
 
 ## File names
 
 All Swift source files end with the extension `.swift` and all Hylo source files end with the extension `.hylo`.
 
-In general, a file is named after the main entity that it defines. A file that extends an existing type with a protocol (Swift) or trait (Hylo) conformance is named with a combination of the type name and the protocol or trait name, joined with a plus (`+`) sign. For more complex situations, exercise your best judgment.
+In general, a file is named after the main entity that it defines. A file that extends an existing type with a
+protocol (Swift) or trait (Hylo) conformance is named with a combination of the type name and the protocol or trait
+name, joined with a plus (`+`) sign. For more complex situations, exercise your best judgment.
 
 For example:
 
@@ -94,5 +141,5 @@ For example:
 - Retroactive conformances can be added in `MyType+Extensions.swift`.
 
 Avoid defining multiple types, protocols, or traits in the same file unless they are scoped by a main entity or meant to
-be used only in that file. Usually, conformances and custom error types are small and are defined in the same file as 
+be used only in that file. Usually, conformances and custom error types are small and are defined in the same file as
 the type to which they apply.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -126,6 +126,14 @@ doesn't just use its description but is interested in the specific error type.
 - Use `// MARK:` comments to organize sections in large files.
 - Use `self.` in initializers when assigning to stored properties.
 - Use single-expression function / computed property bodies over explicit return statements where possible.
+- Avoid calling methods on the result of a function applied with trailing closure syntax:
+  ```swift
+  array.first { (e) in
+    ...
+  }.doSomething() // discouraged
+  ```
+- We should wrap as little code as possible in try blocks.
+- Add parenthesis around the parameter names of closures (e.g. `{ (e) in ... }`)
 
 ## File names
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,81 @@
+# Coding Guidelines
+
+## Documentation
+
+Documentation enables local reasoning - it's a shortcut for understanding so readers can avoid looking up implementation or usages to infer meaning.
+
+- Document every declaration with at least a summary sentence, using `///` style comments.
+- Start with a summary sentence fragment describing what it *does* (functions) or what it *is* (types, properties). End with a period.
+- Omit needless words: don't repeat the receiver's type, don't write `the`, `given`, `of self`, `of the current object` when context makes these obvious.
+- Use `iff` instead of `if` where applicable.
+- Use `<...>, if any.` for optional values where the absence reason is obvious. Otherwise: `<...> if <condition>, nil otherwise.`
+- Document preconditions with `- Requires:`. If the precondition is obvious from the summary, it need not be repeated.
+- Multiple preconditions should be in a markdown list below `- Requires:`.
+- Document performance of every operation that doesn't run in constant time and space.
+- Conformance implementations are exempt from documentation when nothing useful can be added beyond the protocol requirement itself.
+
+## Contracts
+
+- Create the strictest contracts possible, so long as the client can reason about the preconditions locally.
+- Preconditions and postconditions are relationships between components - think in terms of what the caller must provide and what the callee guarantees in return.
+- Contract evolution: you may safely weaken preconditions and strengthen postconditions. The reverse breaks clients, so you must inspect all call sites before introducing the change.
+
+## Errors
+
+Distinguish bugs from runtime errors:
+- **Bug**: a programming mistake. Stop before more damage is done.
+- **Runtime error**: postconditions can't be met despite correct usage. Respond by `throw`ing or returning an optional/result.
+
+When to use each termination mechanism:
+- **`precondition(condition, "message")`** - the caller violated a documented requirement. Checked in all builds.
+- **`assert(condition, "message")`** - an internal invariant that should hold if the implementation is correct. Checked only in debug builds.
+- **`unreachable("message")`** - a code path that is logically impossible given the surrounding control flow or type system.
+- **`unimplemented("feature name")`** - a stub for functionality not yet written.
+- **`fatalError("message")`** - avoid this, either `unreachable()` or `unimplemented()` should be used instead. If you don't expect it to be unreachable nor unimplemented, prefer reporting an error with throw or returning `nil`.
+
+When a contract seems too strict to use correctly without accidentally breaking preconditions, you can either relax the preconditions (e.g. `demandModule(name:)` - gets or creates module if doesn't exist yet) or report an error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not found).
+
+Avoid typed `throws` unless you are confident that the immediate caller will be interested in handling the error and it doesn't just use its description but is interested in the specific error type.
+
+## Safety
+
+- When using an unsafe or unchecked construct (e.g. `@unchecked Sendable`), include a comment that justifies the need and explains why it's safe.
+
+## Algorithms
+
+- Prefer named algorithms over inline loops. A loop is a mechanism; a named algorithm is a statement of intent.
+- When a suitable algorithm doesn't exist, create one as an extension on the appropriate type (`Sequence`, `Collection`, etc.) rather than inlining the loop at the call site.
+- Structure data so efficient algorithms become possible (e.g. storing something in an ordered collection for binary search, or storing in a hashmap for O(1) lookup).
+
+## Types
+
+- Use strong types to encode invariants. If a value can only be valid in certain states, make invalid states unrepresentable.
+- Every instance of a type should have exactly one clearly-defined value, expressed in terms of its operations.
+- Keep the efficient basis of a type small and well-documented. All other operations should be derivable from it.
+- Prefer value types. Reference types (`class`) are appropriate only for identity, shared mutable state, or non-copyable resources—document why.
+
+## Naming
+
+- Follow the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/). Name mutating methods with imperative verb phrases; name nonmutating variants with past participle or `ing` forms.
+- No abbreviations in APIs unless universally known (e.g. `URL`, `ID`).
+- Don't include the type in a binding's name.
+- If the type is too weak, a qualified argument label can help (e.g. `f(outputDirectory: URL)`), but prefer making the type more strict to capture the invariants (e.g. `f(output: DirectoryURL)`).
+- Single-letter names are fine in small scopes: `l`/`r` for binary operators, `n` for a syntax node, `m` for a module, `i`/`j` for indices.
+- When naming a collection of objects, use a plural form (even in case of short names): `files`, `xs`, `ms`.
+- Prefer descriptive labels over `for` as a parameter label.
+
+## Testing
+
+- All new code should be covered by tests.
+- Tests should exercise the contract: verify postconditions under valid preconditions.
+- (Death tests are not supported in Swift XCTest, but it would be nice to write tests that exercise libraries that they uphold safety by crashing correctly on precondition violations.)
+
+## Formatting
+
+- Indent with 2 spaces.
+- Use a 100-column line limit.
+- Add blank lines inside type, extension, and enum declarations - leave one empty line after the opening brace and before the closing brace.
+- Separate protocol conformances into their own extensions unless it's a marker protocol.
+- Use explicit named parameters in parentheses for multi-statement closures: `{ element in ... }`. Use `$0` shorthand only in short, single-expression closures.
+- Use `MARK:` comments to organize sections in large files.
+- Use `self.` in initializers when assigning to stored properties.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -24,7 +24,7 @@ or usages to infer meaning.
 - Test cases need not be documented, but should have a descriptive function name.
 
 - Phrasing conventions:
-  - Omit needless words: don't repeat the receiver's type, don't write `the`, `given`, `of self`,
+  - Omit needless words: don't repeat the receiver's type, don't write `the`, `given`, `representing`, `of self`,
     `of the current object` when context makes these obvious.
   - Use `iff` instead of `if` where applicable.
   - Use `` `true` iff ...`` rather than `Whether ...`

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -148,6 +148,14 @@ doesn't just use its description but is interested in the specific error type.
   ```
 - Avoid listing multiple cases in a switch: `case c1, c2, c3:`.
 - Avoid conformances in extensions where the new protocol is a refinement of a previously conformed-to protocol. E.g. don't declare a conformance to `LiteralExpression` separately when the struct already conforms to `Expression`.
+- General guideline for declaration order:
+  - nested types and aliases
+  - static properties
+  - member properties
+  - initializers
+  - computed properties
+  - methods
+  - static methods
 
 ## File names
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -77,6 +77,9 @@ error/return an optional (e.g. `myHashmap[key]` - returns nil if key is not foun
 Avoid typed `throws` unless you are confident that the immediate caller will be interested in handling the error and it
 doesn't just use its description but is interested in the specific error type.
 
+Prefer throwing over optional when absence is always an error: If every caller of an optional-returning function 
+immediately converts nil into the same error, the function should throw that error itself.
+
 ## Safety
 
 - When using an unsafe or unchecked construct (e.g. `@unchecked Sendable`), include a comment that justifies the need

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -31,6 +31,8 @@ or usages to infer meaning.
   - Use `<...>, if any.` for optional values where the absence reason is obvious. Otherwise:
     `<...> if <condition>, nil otherwise.`
   - Document preconditions with `- Requires:`. If multiple preconditions apply, use a markdown list below `- Requires:`.
+  - Avoid words like “describing,” “representing,” “record” (as a noun) etc, which are redundant with the fact that it is a type.
+  - Just talk about the thing, not its ID when practical.
 - Conformance implementations are exempt from documentation when nothing useful can be added beyond the protocol
   requirement itself.
 - Test cases don't need to be documented, but should have a descriptive function name.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -41,7 +41,8 @@ or usages to infer meaning.
 
 ## Contracts
 
-- Create the strictest contracts possible, so long as the client can reason about the preconditions locally.
+- Create the strictest contracts possible.
+- A precondition must be something that is practically possible and efficient for a client to ensure, and that ensuring it often ends up being by construction. If the API author can reasonably predict that a check will be needed every time, well, it's not just a problem of preconditions; they have likely designed the wrong API.
 - Preconditions and postconditions are relationships between components - think in terms of what the caller must provide
   and what the callee guarantees in return.
 - Contract evolution: you may safely weaken preconditions and strengthen postconditions. The reverse breaks clients, so

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -27,6 +27,7 @@ or usages to infer meaning.
   - Omit needless words: don't repeat the receiver's type, don't write `the`, `given`, `of self`,
     `of the current object` when context makes these obvious.
   - Use `iff` instead of `if` where applicable.
+  - Use `` `true` iff ...`` rather than `Whether ...`
   - Use `<...>, if any.` for optional values where the absence reason is obvious. Otherwise:
     `<...> if <condition>, nil otherwise.`
   - Document preconditions with `- Requires:`. If multiple preconditions apply, use a markdown list below `- Requires:`.


### PR DESCRIPTION
- Introduces CONVENTIONS.md with guidelines for documentation, contracts, errors, testing, and formatting.
- Updates CONTRIBUTING.md to reference the new conventions and a copy of the LLM use section from our website.
- Adds .github/copilot-instructions.md to direct Github Copilot reviews to follow the conventions.