### PR TITLE
Reserve memory for the type store to amortize reallocation costs

### DIFF
--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -82,6 +82,7 @@ public struct Program: Sendable {
     _ m: Module.ID,
     loggingInferenceWhere isLoggingEnabled: ((AnySyntaxIdentity, Program) -> Bool)?
   ) {
+    types.reserveCapacity(max(types.underestimatedCount << 1, 10000))
     var typer = Typer(typing: m, of: consume self, loggingInferenceWhere: isLoggingEnabled)
     typer.apply()
     self = typer.release()
@@ -1540,6 +1541,7 @@ extension Program {
     // Reserve an identity for the new module.
     let m = modules.count
     var c = Module.SerializationContext(identities: [name: m], types: .init())
+    types.reserveCapacity(max(types.underestimatedCount << 1, 10000))
 
     // Configure the serialization context.
     swap(&c.types, &types)

--- a/Sources/FrontEnd/Types/TypeStore.swift
+++ b/Sources/FrontEnd/Types/TypeStore.swift
@@ -30,6 +30,16 @@ public struct TypeStore: Sendable {
     self.nextFreshIdentifier = 0
   }
 
+  /// Returns a number less than the number of types created with this store.
+  public var underestimatedCount: Int {
+    types.count
+  }
+
+  /// Reserves enough space to store `minimumCapacity` types without allocating new storage.
+  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+    self.types.reserveCapacity(minimumCapacity)
+  }
+
   /// Returns the identity of a fresh type variable.
   public mutating func fresh() -> TypeVariable.ID {
     defer { nextFreshIdentifier += 1 }

--- a/Sources/Utilities/MutableValueSemantics.swift
+++ b/Sources/Utilities/MutableValueSemantics.swift
@@ -12,7 +12,7 @@ public func modify<T, U>(_ value: inout T, _ action: (inout T) throws -> U) reth
 public func modify<T, U>(
   _ value: inout Any, as: T.Type, _ action: (inout T) throws -> U
 ) rethrows -> U {
-  var v = value as! T
+  var v = consume value as! T
   defer { value = v }
   return try action(&v)
 }


### PR DESCRIPTION
Profiling suggests that the compiler spends a lot of time reallocating the internal storage of the type store. This PR attempts to fix this problem.