### PR TITLE
ci: add spell-check workflow with crate-ci/typos (#98)

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,21 @@
+name: Spell check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  run:
+    name: Spell Check using typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        show-progress: false
+
+    - name: Check spelling
+      uses: crate-ci/typos@v1.45.1

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+inout = "inout" # Mutable projection keyword
+olt = "olt" # Abbreviation for "ordered less than"


### PR DESCRIPTION
Closes #98 (first commit; typo fixes left for follow-up).

Ports the spell-check workflow and config from the old hylo repo:

- \`.github/workflows/spell-check.yml\` — runs \`crate-ci/typos@v1.45.1\` on push to main and on PRs to any branch (matches old hylo behavior, with \`actions/checkout@v4\` to align with this repo's other workflows).
- \`.typos.toml\` — extends \`default.extend-words\` with \`inout\` (mutable projection keyword) and \`olt\` (\"ordered less than\" abbreviation), the same identifier exceptions the old repo used.

I left out the \`extend-exclude\` entry the old repo had for \`Tests/ManglingTests/MangledStrings.swift\` — that file does not exist in hylo-new.

## Heads up: the action will fail on the first run

Running \`typos --format brief\` locally on \`main\` reports 148 issues:

- 139 unambiguous corrections (auto-fixable via \`typos --write-changes\`, ~76 files touched)
- 9 ambiguous corrections needing manual review (e.g. \`commen\` → \`commend\` / \`comment\` / \`common\`, \`Simplicitly\` → \`Simplicity\` / \`Implicitly\`)

The issue explicitly notes this:

> After we add this action, we should also fix all current typos in a separate commit.

So this PR is intentionally just the CI + config. Happy to follow up with a typo-fix PR if useful, or leave that to maintainers who can call the ambiguous shots.