### PR TITLE
Add floating point literals and machine types

### DIFF
--- a/Sources/FrontEnd/IR/BigInt+Extensions.swift
+++ b/Sources/FrontEnd/IR/BigInt+Extensions.swift
@@ -39,11 +39,3 @@ extension BigUInt {
 
 }
 
-extension StringProtocol {
-
-  /// Returns `self` with each occurrence of `c` removed.
-  fileprivate func sans(_ c: Character) -> String {
-    .init(filter({ (a) in a != c }))
-  }
-
-}

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -558,6 +558,8 @@ internal struct IREmitter {
       lower(store: program.castUnchecked(e, to: InoutExpression.self), to: target)
     case IntegerLiteral.self:
       lower(store: program.castUnchecked(e, to: IntegerLiteral.self), to: target)
+    case FloatingPointLiteral.self:
+      lower(store: program.castUnchecked(e, to: FloatingPointLiteral.self), to: target)
     case NameExpression.self:
       lower(store: program.castUnchecked(e, to: NameExpression.self), to: target)
     case SyntheticExpression.self:
@@ -683,6 +685,11 @@ internal struct IREmitter {
 
   /// Implements `lower(store:to:)` for integer literals.
   private mutating func lower(store e: IntegerLiteral.ID, to target: IRValue) {
+    unreachable()
+  }
+  
+  /// Implements `lower(store:to:)` for integer literals.
+  private mutating func lower(store e: FloatingPointLiteral.ID, to target: IRValue) {
     unreachable()
   }
 
@@ -1116,9 +1123,12 @@ internal struct IREmitter {
     case .expressibleByIntegerLiteralInit:
       let s = program.cast(source.value, to: IntegerLiteral.self)!
       return loweredBuiltinIntegerLiteralConversion(from: s, to: target)
+    case .expressibleByFloatingPointLiteralInit:
+      let s = program.cast(source.value, to: FloatingPointLiteral.self)!
+      return loweredBuiltinFloatingPointLiteralConversion(from: s, to: target)
 
     default:
-      program.unexpected(e)
+      unreachable("unexpected call to '\(program.show(e))' applied to '\(f)'")
     }
   }
 
@@ -1141,7 +1151,28 @@ internal struct IREmitter {
     case program.standardLibraryType(.int64):
       return .integer(value, program.types.demand(MachineType.i(64)))
     default:
-      program.unexpected(source)
+      program.unexpected(target)
+    }
+  }
+
+  /// Returns the value denoted by `source` interpreted as the floating point
+  /// type `target`, defined in the standard library.
+  ///
+  /// Standard library floating point types are thin wrappers around a machine type. For instance, `Float32` wraps
+  /// a single `Builtin.float32` property. This method returns the value of that property converted from
+  /// a floating point number literal.
+  private mutating func loweredBuiltinFloatingPointLiteralConversion(
+    from source: FloatingPointLiteral.ID, to target: AnyTypeIdentity
+  ) -> IRValue {
+    let value = program[source].value.sans("_")
+
+    switch target {
+    case program.standardLibraryType(.float32):
+      return .floatingPoint(literal: value, program.types.demand(.float32))
+    case program.standardLibraryType(.float64):
+      return .floatingPoint(literal: value, program.types.demand(.float64))
+    default:
+      program.unexpected(target)
     }
   }
 

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -376,6 +376,8 @@ public struct IRFunction: Sendable {
       return resolved(at(i).type)
     case .integer(_, let t):
       return (t.erased, false)
+    case .floatingPoint(_, let t):
+      return (t.erased, false)
     case .function(_, let t):
       return (t, true)
     case .type(_, let t):

--- a/Sources/FrontEnd/IR/IRValue.swift
+++ b/Sources/FrontEnd/IR/IRValue.swift
@@ -12,6 +12,12 @@ public enum IRValue: Hashable, Sendable {
   /// A constant integer.
   indirect case integer(BigInt, MachineType.ID)
 
+  /// A constant floating point number.
+  ///
+  /// `literal` contains the string representation of the floating point number
+  /// in the format `[+-]? [0-9]+ "." [0-9]* ([eE] [+-]? [0-9]+)?`.
+  indirect case floatingPoint(literal: String, MachineType.ID)
+
   /// A reference to a lowered function.
   indirect case function(IRFunction.Name, AnyTypeIdentity)
 
@@ -70,6 +76,8 @@ extension IRValue: Showable {
     case .register(let i):
       return "%r\(i.address.rawValue)"
     case .integer(let n, let t):
+      return "\(printer.show(t)) \(n)"
+    case .floatingPoint(let n, let t):
       return "\(printer.show(t)) \(n)"
     case .function(let n, _):
       return printer.show(n)

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -1485,6 +1485,8 @@ public struct Parser {
       return .init(file.insert(BooleanLiteral(site: take()!.site)))
     case .integerLiteral:
       return .init(file.insert(IntegerLiteral(site: take()!.site)))
+    case .floatingPointLiteral:
+      return .init(file.insert(FloatingPointLiteral(site: take()!.site)))
     case .stringLiteral:
       return .init(file.insert(StringLiteral(site: take()!.site)))
     case .underscore:

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -635,6 +635,8 @@ public struct Program: Sendable {
     switch m {
     case standardLibraryDeclaration(.expressibleByIntegerLiteralInit):
       return .expressibleByIntegerLiteralInit
+    case standardLibraryDeclaration(.expressibleByFloatingPointLiteralInit):
+      return .expressibleByFloatingPointLiteralInit
     default:
       return nil
     }
@@ -1424,6 +1426,12 @@ extension Program {
     /// `Hylo.Int64`.
     case int64 = "Int64"
 
+    /// `Hylo.Float32`.
+    case float32 = "Float32"
+
+    /// `Hylo.Float64`.
+    case float64 = "Float64"
+
     /// `Hylo.Deinitializable`.
     case deinitializable = "Deinitializable"
 
@@ -1444,6 +1452,12 @@ extension Program {
 
     /// `Hylo.ExpressibleByIntegerLiteral.init(integer_literal:)`.
     case expressibleByIntegerLiteralInit = "ExpressibleByIntegerLiteral.init(integer_literal:)"
+
+    /// `Hylo.ExpressibleByFloatingPointLiteral`.
+    case expressibleByFloatingPointLiteral = "ExpressibleByFloatingPointLiteral"
+
+    /// `Hylo.ExpressibleByFloatingPointLiteral.init(floating_point_literal:)`.
+    case expressibleByFloatingPointLiteralInit = "ExpressibleByFloatingPointLiteral.init(floating_point_literal:)"
 
   }
 

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -1105,7 +1105,7 @@ extension BuiltinFunction {
       self = .markUninitialized
 
     //    case "advanced":
-    //      guard let ((_, _), t) = (exactly("by") ++ exactly("bytes") ++ machineType)(&tokens)
+    //      guard let ((_, _), t) = (exactly("by") + exactly("bytes") + machineType)(&tokens)
     //      else { return nil }
     //      self = .advancedByBytes(byteOffset: t)
 
@@ -1124,19 +1124,19 @@ extension BuiltinFunction {
     //      self = .shl(p, t)
     //
     //    case "udiv":
-    //      guard let (p, t) = (maybe("exact") ++ machineType)(&tokens) else { return nil }
+    //      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
     //      self = .udiv(exact: p != nil, t)
     //
     //    case "sdiv":
-    //      guard let (p, t) = (maybe("exact") ++ machineType)(&tokens) else { return nil }
+    //      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
     //      self = .sdiv(exact: p != nil, t)
     //
     //    case "lshr":
-    //      guard let (p, t) = (maybe("exact") ++ machineType)(&tokens) else { return nil }
+    //      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
     //      self = .lshr(exact: p != nil, t)
     //
     //    case "ashr":
-    //      guard let (p, t) = (maybe("exact") ++ machineType)(&tokens) else { return nil }
+    //      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
     //      self = .ashr(exact: p != nil, t)
     //
     //    case "urem":
@@ -1179,23 +1179,23 @@ extension BuiltinFunction {
       self = .icmp(p, s.demand(t))
 
     //    case "trunc":
-    //      guard let (s, d) = (machineType ++ machineType)(&tokens) else { return nil }
+    //      guard let (s, d) = (machineType + machineType)(&tokens) else { return nil }
     //      self = .trunc(s, d)
     //
     //    case "zext":
-    //      guard let (s, d) = (machineType ++ machineType)(&tokens) else { return nil }
+    //      guard let (s, d) = (machineType + machineType)(&tokens) else { return nil }
     //      self = .zext(s, d)
     //
     //    case "sext":
-    //      guard let (s, d) = (machineType ++ machineType)(&tokens) else { return nil }
+    //      guard let (s, d) = (machineType + machineType)(&tokens) else { return nil }
     //      self = .sext(s, d)
     //
     //    case "uitofp":
-    //      guard let (s, d) = (machineType ++ machineType)(&tokens) else { return nil }
+    //      guard let (s, d) = (machineType + machineType)(&tokens) else { return nil }
     //      self = .uitofp(s, d)
     //
     //    case "sitofp":
-    //      guard let (s, d) = (machineType ++ machineType)(&tokens) else { return nil }
+    //      guard let (s, d) = (machineType + machineType)(&tokens) else { return nil }
     //      self = .sitofp(s, d)
     //
     //    case "inttoptr":

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -109,27 +109,37 @@ public enum BuiltinFunction: Hashable, Sendable {
   //  case inttoptr(MachineType.ID)
   //
   //  case ptrtoint(MachineType.ID)
-  //
-  //  case fadd(MathFlags, MachineType.ID)
-  //
-  //  case fsub(MathFlags, MachineType.ID)
-  //
-  //  case fmul(MathFlags, MachineType.ID)
-  //
-  //  case fdiv(MathFlags, MachineType.ID)
-  //
-  //  case frem(MathFlags, MachineType.ID)
-  //
-  //  case fcmp(MathFlags, FloatingPointPredicate, MachineType.ID)
-  //
-  //  case fptrunc(MachineType.ID, MachineType.ID)
-  //
-  //  case fpext(MachineType.ID, MachineType.ID)
-  //
-  //  case fptoui(MachineType.ID, MachineType.ID)
-  //
-  //  case fptosi(MachineType.ID, MachineType.ID)
-  //
+
+  /// In LLVM: `fadd`.
+  case fadd(MathFlags, MachineType.ID)
+
+  /// In LLVM: `fsub`.
+  case fsub(MathFlags, MachineType.ID)
+
+  /// In LLVM: `fmul`.
+  case fmul(MathFlags, MachineType.ID)
+
+  /// In LLVM: `fdiv`.
+  case fdiv(MathFlags, MachineType.ID)
+
+  /// In LLVM: `frem`.
+  case frem(MathFlags, MachineType.ID)
+
+  /// In LLVM: `fcmp`.
+  case fcmp(MathFlags, FloatingPointPredicate, MachineType.ID)
+
+  /// In LLVM: `fptrunc .. to`.
+  case fptrunc(MachineType.ID, MachineType.ID)
+
+  /// In LLVM: `fpext .. to`.
+  case fpext(MachineType.ID, MachineType.ID)
+
+  /// In LLVM: `fptoui`.
+  case fptoui(MachineType.ID, MachineType.ID)
+
+  /// In LLVM: `fptosi`.
+  case fptosi(MachineType.ID, MachineType.ID)
+
   //  case ctpop(MachineType.ID)
   //
   //  case ctlz(MachineType.ID)
@@ -462,26 +472,26 @@ extension BuiltinFunction {
     //      return .init(^t, to: .builtin(.ptr))
     //    case .ptrtoint(let t):
     //      return .init(.builtin(.ptr), to: ^t)
-    //    case .fadd(_, let t):
-    //      return .init(^t, ^t, to: ^t)
-    //    case .fsub(_, let t):
-    //      return .init(^t, ^t, to: ^t)
-    //    case .fmul(_, let t):
-    //      return .init(^t, ^t, to: ^t)
-    //    case .fdiv(_, let t):
-    //      return .init(^t, ^t, to: ^t)
-    //    case .frem(_, let t):
-    //      return .init(^t, ^t, to: ^t)
-    //    case .fcmp(_, _, let t):
-    //      return .init(^t, ^t, to: .builtin(.i(1)))
-    //    case .fptrunc(let s, let d):
-    //      return .init(^s, to: ^d)
-    //    case .fpext(let s, let d):
-    //      return .init(^s, to: ^d)
-    //    case .fptoui(let s, let d):
-    //      return .init(^s, to: ^d)
-    //    case .fptosi(let s, let d):
-    //      return .init(^s, to: ^d)
+    case .fadd(_, let t):
+      return s.demand(Arrow(t, t, to: t))
+    case .fsub(_, let t):
+      return s.demand(Arrow(t, t, to: t))
+    case .fmul(_, let t):
+      return s.demand(Arrow(t, t, to: t))
+    case .fdiv(_, let t):
+      return s.demand(Arrow(t, t, to: t))
+    case .frem(_, let t):
+      return s.demand(Arrow(t, t, to: t))
+    case .fcmp(_, _, let t):
+      return s.demand(Arrow(t, t, to: i1))
+    case .fptrunc(let f, let d):
+      return s.demand(Arrow(f, to: d))
+    case .fpext(let f, let d):
+      return s.demand(Arrow(f, to: d))
+    case .fptoui(let f, let d):
+      return s.demand(Arrow(f, to: d))
+    case .fptosi(let f, let d):
+      return s.demand(Arrow(f, to: d))
     //    case .ctpop(let t):
     //      return .init(^t, to: ^t)
     //    case .ctlz(let t):
@@ -800,26 +810,26 @@ extension BuiltinFunction: Showable {
     //      return "inttoptr_\(t)"
     //    case .ptrtoint(let t):
     //      return "ptrtoint_\(t)"
-    //    case .fadd(let f, let t):
-    //      return f.isEmpty ? "fadd_\(t)" : "fadd_\(f)_\(t)"
-    //    case .fsub(let f, let t):
-    //      return f.isEmpty ? "fsub_\(t)" : "fsub_\(f)_\(t)"
-    //    case .fmul(let f, let t):
-    //      return f.isEmpty ? "fmul_\(t)" : "fmul_\(f)_\(t)"
-    //    case .fdiv(let f, let t):
-    //      return f.isEmpty ? "fdiv_\(t)" : "fdiv_\(f)_\(t)"
-    //    case .frem(let f, let t):
-    //      return f.isEmpty ? "frem_\(t)" : "frem_\(f)_\(t)"
-    //    case .fcmp(let f, let p, let t):
-    //      return f.isEmpty ? "fcmp_\(p)_\(t)" : "fcmp_\(f)_\(p)_\(t)"
-    //    case .fptrunc(let l, let r):
-    //      return "fptrunc_\(l)_\(r)"
-    //    case .fpext(let l, let r):
-    //      return "fpext_\(l)_\(r)"
-    //    case .fptoui(let l, let r):
-    //      return "fptoui_\(l)_\(r)"
-    //    case .fptosi(let l, let r):
-    //      return "fptosi_\(l)_\(r)"
+    case .fadd(let f, let t):
+      return f.isEmpty ? "fadd_\(t)" : "fadd_\(f)_\(t)"
+    case .fsub(let f, let t):
+      return f.isEmpty ? "fsub_\(t)" : "fsub_\(f)_\(t)"
+    case .fmul(let f, let t):
+      return f.isEmpty ? "fmul_\(t)" : "fmul_\(f)_\(t)"
+    case .fdiv(let f, let t):
+      return f.isEmpty ? "fdiv_\(t)" : "fdiv_\(f)_\(t)"
+    case .frem(let f, let t):
+      return f.isEmpty ? "frem_\(t)" : "frem_\(f)_\(t)"
+    case .fcmp(let f, let p, let t):
+      return f.isEmpty ? "fcmp_\(p)_\(t)" : "fcmp_\(f)_\(p)_\(t)"
+    case .fptrunc(let l, let r):
+      return "fptrunc_\(l)_\(r)"
+    case .fpext(let l, let r):
+      return "fpext_\(l)_\(r)"
+    case .fptoui(let l, let r):
+      return "fptoui_\(l)_\(r)"
+    case .fptosi(let l, let r):
+      return "fptosi_\(l)_\(r)"
     //    case .ctpop(let t):
     //      return "ctpop_\(t)"
     //    case .ctlz(let t):
@@ -1196,45 +1206,46 @@ extension BuiltinFunction {
     //      guard let t = machineType(&tokens) else { return nil }
     //      self = .ptrtoint(t)
     //
-    //    case "fadd":
-    //      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
-    //      self = .fadd(p, t)
-    //
-    //    case "fsub":
-    //      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
-    //      self = .fsub(p, t)
-    //
-    //    case "fmul":
-    //      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
-    //      self = .fmul(p, t)
-    //
-    //    case "fdiv":
-    //      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
-    //      self = .fdiv(p, t)
-    //
-    //    case "frem":
-    //      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
-    //      self = .frem(p, t)
-    //
-    //    case "fcmp":
-    //      guard let (p, t) = floatingPointComparisonTail(&tokens) else { return nil }
-    //      self = .fcmp(p.0, p.1, t)
-    //
-    //    case "fptrunc":
-    //      guard let (s, d) = (builtinType ++ builtinType)(&tokens) else { return nil }
-    //      self = .fptrunc(s, d)
-    //
-    //    case "fpext":
-    //      guard let (s, d) = (builtinType ++ builtinType)(&tokens) else { return nil }
-    //      self = .fpext(s, d)
-    //
-    //    case "fptoui":
-    //      guard let (s, d) = (machineType ++ machineType)(&tokens) else { return nil }
-    //      self = .fptoui(s, d)
-    //
-    //    case "fptosi":
-    //      guard let (s, d) = (machineType ++ machineType)(&tokens) else { return nil }
-    //      self = .fptosi(s, d)
+    case "fadd":
+      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
+      self = .fadd(p, s.demand(t))
+
+    case "fsub":
+      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
+      self = .fsub(p, s.demand(t))
+
+    case "fmul":
+      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
+      self = .fmul(p, s.demand(t))
+
+    case "fdiv":
+      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
+      self = .fdiv(p, s.demand(t))
+
+    case "frem":
+      guard let (p, t) = floatingPointArithmeticTail(&tokens) else { return nil }
+      self = .frem(p, s.demand(t))
+
+    case "fcmp":
+      guard let (p, t) = floatingPointComparisonTail(&tokens) else { return nil }
+      self = .fcmp(p.0, p.1, s.demand(t))
+
+    case "fptrunc":
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .fptrunc(s.demand(f), s.demand(d))
+
+    case "fpext":
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .fpext(s.demand(f), s.demand(d))
+
+    case "fptoui":
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .fptoui(s.demand(f), s.demand(d))
+
+    case "fptosi":
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .fptosi(s.demand(f), s.demand(d))
+
     //
     //    case "ctpop":
     //      guard let t = machineType(&tokens) else { return nil }

--- a/Sources/FrontEnd/Syntax/Expressions/FloatingPointLiteral.swift
+++ b/Sources/FrontEnd/Syntax/Expressions/FloatingPointLiteral.swift
@@ -1,8 +1,8 @@
 import Archivist
 
-/// The expression of an integer literal.
+/// The expression of a floating point number literal.
 @Archivable
-public struct IntegerLiteral: LiteralExpression {
+public struct FloatingPointLiteral: LiteralExpression {
 
   /// The site from which `self` was parsed.
   public let site: SourceSpan
@@ -15,11 +15,11 @@ public struct IntegerLiteral: LiteralExpression {
   /// The value of the literal.
   public var value: Substring { site.text }
 
-  public static let literalType: LiteralType = .integer
+  public static let literalType: LiteralType = .float
 
 }
 
-extension IntegerLiteral: Showable {
+extension FloatingPointLiteral: Showable {
 
   /// Returns a textual representation of `self` using `printer`.
   public func show(using printer: inout TreePrinter) -> String {

--- a/Sources/FrontEnd/Syntax/Expressions/LiteralExpression.swift
+++ b/Sources/FrontEnd/Syntax/Expressions/LiteralExpression.swift
@@ -1,0 +1,7 @@
+/// A literal expression.
+public protocol LiteralExpression: Expression {
+  
+  /// The literal type associated with `Self`.
+  static var literalType: LiteralType { get }
+
+}

--- a/Sources/FrontEnd/Syntax/SyntaxTag.swift
+++ b/Sources/FrontEnd/Syntax/SyntaxTag.swift
@@ -55,6 +55,7 @@ public struct SyntaxTag: Sendable {
     ImplicitQualification.self,
     InoutExpression.self,
     IntegerLiteral.self,
+    FloatingPointLiteral.self,
     KindExpression.self,
     Lambda.self,
     NameExpression.self,

--- a/Sources/FrontEnd/Syntax/SyntaxVisitor.swift
+++ b/Sources/FrontEnd/Syntax/SyntaxVisitor.swift
@@ -88,6 +88,8 @@ extension Program {
       traverse(castUnchecked(n, to: Conversion.self), calling: &v)
     case EqualityWitnessExpression.self:
       traverse(castUnchecked(n, to: EqualityWitnessExpression.self), calling: &v)
+    case FloatingPointLiteral.self:
+      break
     case If.self:
       traverse(castUnchecked(n, to: If.self), calling: &v)
     case ImplicitQualification.self:

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -872,6 +872,8 @@ public struct Typer {
     switch concept {
     case program.standardLibraryDeclaration(.expressibleByIntegerLiteral):
       return isStandardLibraryIntegerType(conformer)
+    case program.standardLibraryDeclaration(.expressibleByFloatingPointLiteral):
+      return isStandardLibraryFloatingPointType(conformer)
     default:
       return false
     }
@@ -1941,7 +1943,11 @@ public struct Typer {
     case InoutExpression.self:
       return inferredType(of: castUnchecked(e, to: InoutExpression.self), in: &context)
     case IntegerLiteral.self:
-      return inferredType(of: castUnchecked(e, to: IntegerLiteral.self), in: &context)
+      return inferredType(of: castUnchecked(e, to: IntegerLiteral.self), in: &context, 
+        conversionLabel: "integer_literal", defaultInferredType: .int)
+    case FloatingPointLiteral.self:
+      return inferredType(of: castUnchecked(e, to: FloatingPointLiteral.self), in: &context,
+        conversionLabel: "floating_point_literal", defaultInferredType: .float64)
     case Lambda.self:
       return inferredType(of: castUnchecked(e, to: Lambda.self), in: &context)
     case NameExpression.self:
@@ -2228,23 +2234,24 @@ public struct Typer {
     return context.obligations.assume(e, hasType: t, at: program[e].site)
   }
 
-  /// Returns the inferred type of `e`.
-  private mutating func inferredType(
-    of e: IntegerLiteral.ID, in context: inout InferenceContext
+  /// Returns the inferred type of a primitive literal `e`, ensuring `e` is elaborated to a call 
+  /// to the inferred type's `.new(<conversionLabel>: e)` initializer.
+  private mutating func inferredType<Literal: LiteralExpression>(
+    of e: Literal.ID, in context: inout InferenceContext, conversionLabel: String,
+    defaultInferredType: Program.StandardLibraryEntity
   ) -> AnyTypeIdentity {
     // Did we already elaborate this expression?
     if let t = program[e.module].type(assignedTo: e) {
       return context.obligations.assume(e, hasType: t, at: program[e].site)
     }
 
-    // Otherwise, elaborate to `.new(integer_literal: e)`.
+    // Otherwise, elaborate to `.new(<Literal.conversionLabel>: e)`.
     else {
       let s = SourceSpan.empty(at: program[e].site.start)
       let p = program.parent(containing: e)
 
       let literal = program[e.module].insert(program[e], in: p)
-      let integer = demand(LiteralType.integer).erased
-      program[e.module].setType(integer, for: literal)
+      program[e.module].setType(demand(Literal.literalType).erased, for: literal)
 
       let q = program[e.module].insert(
         ImplicitQualification(site: s), in: p)
@@ -2256,11 +2263,11 @@ public struct Typer {
         .init(e),
         with: Call(
           callee: .init(m),
-          arguments: [.init(label: Parsed("integer_literal", at: s), value: .init(literal))],
+          arguments: [.init(label: Parsed(conversionLabel, at: s), value: .init(literal))],
           style: .parenthesized,
           site: program[e].site))
 
-      let qualification = context.expectedType ?? standardLibraryType(.int)
+      let qualification = context.expectedType ?? standardLibraryType(defaultInferredType)
       return context.withSubcontext(expectedType: qualification) { (ctx) in
         inferredType(of: c, in: &ctx)
       }
@@ -4595,6 +4602,21 @@ public struct Typer {
     case standardLibraryType(.int),
         standardLibraryType(.int32),
         standardLibraryType(.int64):
+      return true
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` iff `t` is a standard library floating point type (e.g., `Hylo.Float32`).
+  ///
+  /// The module containing the standard library must have been loaded in the `self.program`, or
+  /// `self.module` is the standard library.
+  private mutating func isStandardLibraryFloatingPointType(_ t: AnyTypeIdentity) -> Bool {
+    guard program.containsStandardLibrary else { return false }
+    switch program.types.dealiased(t) {
+    case standardLibraryType(.float32),
+        standardLibraryType(.float64):
       return true
     default:
       return false

--- a/Sources/FrontEnd/Types/LiteralType.swift
+++ b/Sources/FrontEnd/Types/LiteralType.swift
@@ -24,7 +24,7 @@ extension LiteralType: CustomStringConvertible {
     case .integer:
       return "IntegerLiteral"
     case .float:
-      return "FloatingPointerLiteral"
+      return "FloatingPointLiteral"
     }
   }
 
@@ -36,7 +36,7 @@ extension LiteralType: LosslessStringConvertible {
     switch description {
     case "IntegerLiteral":
       self = .integer
-    case "FloatingPointerLiteral":
+    case "FloatingPointLiteral":
       self = .float
     default:
       return nil

--- a/Sources/Utilities/StringProtocol+Extensions.swift
+++ b/Sources/Utilities/StringProtocol+Extensions.swift
@@ -24,6 +24,11 @@ extension StringProtocol {
     return r
   }
 
+  /// Returns `self` with each occurrence of `c` removed.
+  public func sans(_ c: Character) -> String {
+    .init(filter({ (a) in a != c }))
+  }
+
 }
 
 extension StringProtocol where SubSequence == Substring {

--- a/StandardLibrary/Sources/Core/Numbers/ExpressibleByFloatingPointLiteral.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/ExpressibleByFloatingPointLiteral.hylo
@@ -1,0 +1,8 @@
+/// A type whose instances can be expressed by a floating point literal.
+@_symbol("ExpressibleByFloatingPointLiteral")
+public trait ExpressibleByFloatingPointLiteral {
+
+  @_symbol("ExpressibleByFloatingPointLiteral.init(floating_point_literal:)")
+  init(floating_point_literal literal: Builtin.FloatingPointLiteral)
+
+}

--- a/StandardLibrary/Sources/Core/Numbers/Float32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Float32.hylo
@@ -1,0 +1,75 @@
+@_symbol("Float32")
+struct Float32 is Deinitializable {
+  
+  /// The raw value of this instance.
+  internal var value: Builtin.float32
+
+  /// Creates an instance with its raw value.
+  internal memberwise init
+  
+  /// Creates an instance with value 0.
+  public init() {
+    &self.value = Builtin.zeroinitializer_float32()
+  }
+
+}
+
+public given Float32 is ExpressibleByFloatingPointLiteral { /* built-in */ }
+
+public given Float32 is Movable {}
+
+public given Float32 is Equatable {
+
+  public fun infix== (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_ueq_float32(self.value, other.value))
+  }
+
+  public fun infix!= (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_une_float32(self.value, other.value))
+  }
+
+}
+
+public given Float32 is Comparable {
+
+  public fun infix< (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_ult_float32(self.value, other.value))
+  }
+
+  public fun infix<= (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_ule_float32(self.value, other.value))
+  }
+
+  public fun infix> (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_ugt_float32(self.value, other.value))
+  }
+
+  public fun infix>= (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_uge_float32(self.value, other.value))
+  }
+
+}
+
+public given Float32 is AdditiveArithmetic {
+
+  public fun infix+ (other: Self) -> Self {
+    Self(value: Builtin.fadd_float32(self.value, other.value))
+  }
+
+  public fun infix- (other: Self) -> Self {
+    Self(value: Builtin.fsub_float32(self.value, other.value))
+  }
+
+  public static fun zero() -> Self {
+    .new()
+  }
+
+}
+
+public given Float32 is Numeric {
+
+  public fun infix* (other: Self) -> Self {
+    .new(value: Builtin.fmul_float32(self.value, other.value))
+  }
+
+}

--- a/StandardLibrary/Sources/Core/Numbers/Float64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Float64.hylo
@@ -1,0 +1,75 @@
+@_symbol("Float64")
+public struct Float64 is Deinitializable {
+  
+  /// The raw value of this instance.
+  internal var value: Builtin.float64
+
+  /// Creates an instance with its raw value.
+  internal memberwise init
+  
+  /// Creates an instance with value 0.
+  public init() {
+    &self.value = Builtin.zeroinitializer_float64()
+  }
+
+}
+
+public given Float64 is ExpressibleByFloatingPointLiteral { /* built-in */ }
+
+public given Float64 is Movable {}
+
+public given Float64 is Equatable {
+
+  public fun infix== (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_ueq_float64(self.value, other.value))
+  }
+
+  public fun infix!= (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_une_float64(self.value, other.value))
+  }
+
+}
+
+public given Float64 is Comparable {
+
+  public fun infix< (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_ult_float64(self.value, other.value))
+  }
+
+  public fun infix<= (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_ule_float64(self.value, other.value))
+  }
+
+  public fun infix> (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_ugt_float64(self.value, other.value))
+  }
+
+  public fun infix>= (other: Self) -> Bool {
+    .new(value: Builtin.fcmp_uge_float64(self.value, other.value))
+  }
+
+}
+
+public given Float64 is AdditiveArithmetic {
+
+  public fun infix+ (other: Self) -> Self {
+    Self(value: Builtin.fadd_float64(self.value, other.value))
+  }
+
+  public fun infix- (other: Self) -> Self {
+    Self(value: Builtin.fsub_float64(self.value, other.value))
+  }
+
+  public static fun zero() -> Self {
+    .new()
+  }
+
+}
+
+public given Float64 is Numeric {
+
+  public fun infix* (other: Self) -> Self {
+    .new(value: Builtin.fmul_float64(self.value, other.value))
+  }
+
+}

--- a/Tests/CompilerTests/positive/float-literal-lowering.hylo
+++ b/Tests/CompilerTests/positive/float-literal-lowering.hylo
@@ -1,0 +1,6 @@
+//! stage:lowering
+
+fun float_literal_conversions() {
+  let a1: Float32 = 0.5
+  let a2: Float64 = -0.5
+}

--- a/Tests/CompilerTests/positive/float-literal.hylo
+++ b/Tests/CompilerTests/positive/float-literal.hylo
@@ -1,0 +1,11 @@
+//! stage:typing
+
+fun check<T>(x: T) {}
+
+public fun main() {
+  let x0 = 3.14
+  check<Float64>(x0)
+
+  let x1 = 3.14 as Float32
+  check<Float32>(x1)
+}

--- a/Tests/UtilitiesTests/SubstringTests.swift
+++ b/Tests/UtilitiesTests/SubstringTests.swift
@@ -21,4 +21,10 @@ final class SubstringTests: XCTestCase {
     XCTAssertEqual(t, "bc")
   }
 
+  func testSans() {
+    let s = "vadalma"
+    let t = s.sans("a")
+    XCTAssertEqual(t, "vdlm")
+  }
+
 }


### PR DESCRIPTION
This PR adds Float32, Float64 and the necessary conversions, similarly to how it's done for integer literals. A current limitation is that we can't use an integer literal for floating point types, we must explicitly add the `.0` suffix.

LLVM code generation is already implemented and tested in the #53 branch.

The floating point literal values are stored in a string after lexing and parsing (within the FloatLiteral expression), then during IR lowering, we strip all `_` symbols so the literal becomes parsable by standard float parsers. In the LLVM lowering branch, I used this string value and parsed by the corresponding LLVM floating point type's constant creation function that parses the value straight to the destination type. This may be slightly fragile, as we depend on LLVM float parsing to match our expectations, but we can save ourselves from an extra BigDecimal library. We can also mitigate unexpected parsing divergences by writing some integration tests exercising the edge cases of float syntax.

Some of the floating point builtin cases are not yet covered by tests because they are not yet used in the standard library, and I don't think it's worth testing the fact that lowering them succeeds without a crash. LMK if you disagree, I can add these tests (just calling `Builtin.f*` and ignoring the result).

Closes #114 and #53 .

For the lucky reviewer: https://open.spotify.com/track/0r8SR1mxjyN42Kz8NfQJl9?si=fe2fcc8f3ee048aa