### PR TITLE
ci: add dependabot config for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Resolves #97.

Mirror the existing dependabot config from the legacy [hylo-lang/hylo](https://github.com/hylo-lang/hylo/blob/main/.github/dependabot.yml) repo (linked in the issue) so the GitHub Actions versions pinned in `.github/workflows/` stay current.

```yaml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

Weekly cadence matches the legacy repo. The repo currently has three workflows (`build-and-test`, `release`, `spell-check`) that pin actions like `actions/checkout@v4` — dependabot will open PRs as those publish new versions.

Swift Package Manager dependencies live in `Package.swift` / `Package.resolved`, but dependabot's swift-package-manager support is still preview-only and the legacy repo did not enable it either. Keeping this config narrow to `github-actions` for parity; SPM updates can be added in a follow-up if the team wants them.