### PR TITLE
Fix the typing of memberwise initializers

### DIFF
--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -1307,8 +1307,10 @@ public struct Typer {
       for b in program.collect(BindingDeclaration.self, in: program[s].members) {
         _ = declaredType(of: b)
         program.forEachVariable(introducedBy: b) { (v, _) in
-          let t = program[b.module].type(assignedTo: b) ?? .error
-          inputs.append(Parameter(label: program[v].identifier.value, access: .sink, type: t))
+          let l = program[v].identifier.value
+          let t = program[b.module].type(assignedTo: v)
+            .flatMap({ (u) in program.types.select(u, \RemoteType.projectee) })
+          inputs.append(Parameter(label: l, access: .sink, type: t ?? .error))
         }
       }
     }

--- a/Tests/CompilerTests/positive/memberwise-init.hylo
+++ b/Tests/CompilerTests/positive/memberwise-init.hylo
@@ -6,4 +6,11 @@ struct A {
   public let m1: Void
 }
 
+struct B {
+  public memberwise init
+  public let (m0, _, m1): {Void, Void, Void}
+}
+
 fun a() -> A { A(m0: (), m1: ()) }
+
+fun b() -> B { B(m0: (), m1: ()) }


### PR DESCRIPTION
This patch fixes the typing of memberwise initializers for structs having a binding declaration that involves more than one variable.