### PR TITLE
Add while loop and relax IR invariants

### DIFF
--- a/Sources/BackEnd/SubscriptDecomposition.swift
+++ b/Sources/BackEnd/SubscriptDecomposition.swift
@@ -178,6 +178,7 @@ extension FunctionGenerationContext {
     to slot: SwiftyLLVM.AnyInstruction.UnsafeReference
   ) {
     let parameters = llvm.unsafe[].parameters
+    assert(parameters.count >= 3, "Invalid parameter count for function being built: \(parameters)")
     let project = module.llvm.insertAlloca(module.nestedProject, atEntryOf: llvm)
 
     var v = module.llvm.poisonValue(of: module.nestedProject).v

--- a/Sources/FrontEnd/IR/AbstractInterpreter/AbstractContext.swift
+++ b/Sources/FrontEnd/IR/AbstractInterpreter/AbstractContext.swift
@@ -171,10 +171,15 @@ internal struct AbstractContext<Domain: AbstractDomain>: Hashable, Sendable {
   /// to contain the new object and the register is assigned to that place.
   ///
   /// The new object is defined as a uniform value `v`.
+  /// `g` is the control-flow graph of `f`.
   internal mutating func declare<T: InstructionIdentity>(
-    _ i: T, from f: IRFunction, initially v: Domain
+    _ i: T, from f: IRFunction, controlFlow g: ControlFlowGraph, initially v: Domain
   ) {
-    assert(locals[.register(i.erased)] == nil, "register is already assigned")
+    guard locals[.register(i.erased)] == nil else {
+      assert(isInCycle(i, in: f, g), 
+        "Register \(i) is already defined, which is only acceptable in a loop.")
+      return // Don't redefine if it's already there.
+    }
 
     // Create a new object.
     let t = f.resolved(f.at(i.erased).type)!
@@ -182,7 +187,6 @@ internal struct AbstractContext<Domain: AbstractDomain>: Hashable, Sendable {
 
     // If the register defines an address, create a new place and assigns it the new object.
     if t.isPlace {
-      assert(memory[.register(i.erased)] == nil, "storage already exists")
       memory[.register(i.erased)] = .init(type: t.type, value: .uniform(v))
       locals[.register(i.erased)] = .place(.root(.register(i.erased)))
     }
@@ -259,4 +263,12 @@ extension AbstractContext.Locals: Showable {
     }
   }
 
+}
+
+/// Returns `true` iff `i` is defined in a block that is its own (transitive) predecessor.
+private func isInCycle(
+  _ i: some InstructionIdentity, in f: IRFunction, _ g: ControlFlowGraph
+) -> Bool {
+  let b = f.block(defining: i)
+  return g.predecessors(of: b).contains(b)
 }

--- a/Sources/FrontEnd/IR/AbstractInterpreter/AbstractMachine.swift
+++ b/Sources/FrontEnd/IR/AbstractInterpreter/AbstractMachine.swift
@@ -26,13 +26,15 @@ internal protocol AbstractTransferFunction {
   /// a subset of the predecessors of `b` to their corresponding post-context. This map is only
   /// defined for the basic blocks that have been visited at least once.
   ///
+  /// `controlFlow` is the control-flow graph of `f`.
+  ///
   /// The return value is a set containing the basic blocks that may have been modified during the
   /// application of this method. Those blocks are placed back to the work list of the interpreter
   /// during the computation of a fixed point.
   mutating func apply(
     _ b: IRBlock.ID, from f: inout IRFunction, in c: inout Context,
     precededBy predecessors: SortedDictionary<IRBlock.ID, Context>,
-    using typer: inout Typer
+    controlFlow: ControlFlowGraph, using typer: inout Typer
   ) -> [IRBlock.ID]
 
 }
@@ -213,7 +215,8 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
     using interpret: inout Transfer, _ typer: inout Typer
   ) -> (next: Transfer.Context, updated: [IRBlock.ID]) {
     var next = initialContext
-    let updated = interpret.apply(b, from: &f, in: &next, precededBy: predecessors, using: &typer)
+    let updated = interpret.apply(
+      b, from: &f, in: &next, precededBy: predecessors, controlFlow: cfg, using: &typer)
     return (next, updated)
   }
 

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -518,6 +518,8 @@ internal struct IREmitter {
       return lowerAsStatement(program.castUnchecked(s, to: If.self))
     case Return.self:
       return lower(program.castUnchecked(s, to: Return.self))
+    case While.self:
+      return lower(program.castUnchecked(s, to: While.self))
     case Yield.self:
       return lower(program.castUnchecked(s, to: Yield.self))
     default:
@@ -628,6 +630,32 @@ internal struct IREmitter {
 
     // The return instruction is emitted by the caller handling this control-flow effect.
     return .return(s)
+  }
+
+  /// Generates the IR of `s`.
+  private mutating func lower(_ s: While.ID) -> ControlFlow {
+    
+    let conditionsStart = insertionContext.function!.addBlock()
+    let afterLoop = insertionContext.function!.addBlock()
+
+    // Jump to the head of the loop.
+    lowering(s, { $0._br(conditionsStart) })
+    
+    insertionContext.point = .end(of: conditionsStart)
+
+    // Lower the conditions.
+    for c in program[s].conditions {
+      insertionContext.point = .end(of: 
+        lowerCondition(c, onFailure: afterLoop))
+    }
+    
+    // Lower the body.
+    if lower(program[s].body) == .next {
+      lowering(after: program[s].body, { $0._br(conditionsStart) })
+    }
+
+    insertionContext.point = .end(of: afterLoop)
+    return .next
   }
 
   /// Generates the IR of `s`.

--- a/Sources/FrontEnd/IR/Instructions/IRAlloca.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRAlloca.swift
@@ -9,6 +9,10 @@ import Archivist
 /// Unlike LLVM's alloca, this instruction cannot be used to allocate dynamically sized buffers. It
 /// is nonetheless possible to allocate storage for a fixed number of contiguous instances using a
 /// tuple (e.g., `Int[8]` in surface syntax).
+///
+/// Repeated allocas may happen in loops, in which case only the first allocation is effective.
+/// Upon repeated allocations, the existing value in the storage must have been deinitialized.
+/// Moving all allocas to the entry block of the function is done during LLVM lowering.
 @Archivable
 public struct IRAlloca: Instruction {
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -76,6 +76,9 @@ private struct Transfer: AbstractTransferFunction {
   /// The context being updated.
   private var context: Context = .init()
 
+  /// The control-flow graph of the function being interpreted.
+  private var controlFlow: ControlFlowGraph! = nil
+
   /// `true` iff an application of this function raised an error.
   fileprivate private(set) var didFoundError: Bool = false
 
@@ -93,9 +96,11 @@ private struct Transfer: AbstractTransferFunction {
   mutating func apply(
     _ b: IRBlock.ID, from f: inout IRFunction, in c: inout Context,
     precededBy predecessors: SortedDictionary<IRBlock.ID, Context>,
+    controlFlow: ControlFlowGraph,
     using typer: inout Typer
   ) -> [IRBlock.ID] {
     self.typer = consume typer
+    self.controlFlow = controlFlow
     swap(&context, &c)
 
     defer {
@@ -153,7 +158,7 @@ private struct Transfer: AbstractTransferFunction {
 
     // Built-in values are implicitly copied.
     if (k == .sink) && f.isBuiltinValue(access.source, using: program) {
-      context.declare(i.erased, from: f, initially: .unique)
+      context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
       return f.instruction(after: i.erased)
     }
 
@@ -211,7 +216,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRAlloca.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
     return f.instruction(after: i.erased)
   }
 
@@ -219,7 +224,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRCase.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
     return f.instruction(after: i.erased)
   }
 
@@ -236,7 +241,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRGlobalAccess.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
     return f.instruction(after: i.erased)
   }
 
@@ -244,7 +249,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRPlaceCast.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
     return f.instruction(after: i.erased)
   }
 
@@ -261,7 +266,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRPointerToPlace.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
     return f.instruction(after: i.erased)
   }
 
@@ -269,7 +274,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRProject.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
     return f.instruction(after: i.erased)
   }
 
@@ -286,7 +291,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRProperty.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
     return f.instruction(after: i.erased)
   }
 
@@ -304,7 +309,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRWitnessTable.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .unique)
     return f.instruction(after: i.erased)
   }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -54,6 +54,9 @@ private struct Transfer: AbstractTransferFunction {
   /// A typer for querying type relations and resolve names.
   private var typer: Typer! = nil
 
+  /// The control-flow graph of the function being interpreted.
+  private var controlFlow: ControlFlowGraph! = nil
+
   /// The context being updated.
   private var context: Context = .init()
 
@@ -74,9 +77,11 @@ private struct Transfer: AbstractTransferFunction {
   mutating func apply(
     _ b: IRBlock.ID, from f: inout IRFunction, in c: inout Context,
     precededBy predecessors: SortedDictionary<IRBlock.ID, Context>,
+    controlFlow: ControlFlowGraph,
     using typer: inout Typer
   ) -> [IRBlock.ID] {
     self.typer = consume typer
+    self.controlFlow = controlFlow
     swap(&context, &c)
 
     defer {
@@ -229,7 +234,7 @@ private struct Transfer: AbstractTransferFunction {
 
     // Built-in values are implicitly copied.
     if (k == .sink) && f.isBuiltinValue(access.source, using: program) {
-      context.declare(i, from: f, initially: .initialized)
+      context.declare(i, from: f, controlFlow: controlFlow, initially: .initialized)
       return f.instruction(after: i.erased)
     }
 
@@ -246,13 +251,13 @@ private struct Transfer: AbstractTransferFunction {
         checkInitialized(place: access.source, in: f, at: access.anchor.site)
         if k == .sink { consume(place: access.source, with: i.erased, in: f) }
       }
-      context.declare(i, from: f, initially: .initialized)
+      context.declare(i, from: f, controlFlow: controlFlow, initially: .initialized)
 
     case .set:
       if isLegal {
         ensureDeinitialized(place: access.source, before: i.erased, in: &f)
       }
-      context.declare(i, from: f, initially: .uninitialized)
+      context.declare(i, from: f, controlFlow: controlFlow, initially: .uninitialized)
 
     case .auto:
       fatalError("invalid IR")
@@ -294,7 +299,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRAlloca.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .uninitialized)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .uninitialized)
     return f.instruction(after: i.erased)
   }
 
@@ -307,7 +312,7 @@ private struct Transfer: AbstractTransferFunction {
       passArgument(p, v, insertingDeinitializationBefore: i.erased, in: &f)
     }
 
-    context.declare(i, from: f, initially: .initialized)
+    context.declare(i, from: f, controlFlow: controlFlow, initially: .initialized)
     return f.instruction(after: i.erased)
   }
 
@@ -359,7 +364,7 @@ private struct Transfer: AbstractTransferFunction {
       }
     }
 
-    context.declare(i, from: f, initially: v)
+    context.declare(i, from: f, controlFlow: controlFlow, initially: v)
     return f.instruction(after: i.erased)
   }
 
@@ -399,7 +404,7 @@ private struct Transfer: AbstractTransferFunction {
   ) -> AnyInstructionIdentity? {
     let s = f.at(i)
     checkInitialized(place: s.source, in: f, at: s.anchor.site)
-    context.declare(i.erased, from: f, initially: .initialized)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .initialized)
     return f.instruction(after: i.erased)
   }
 
@@ -407,7 +412,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRGlobalAccess.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .initialized)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .initialized)
     return f.instruction(after: i.erased)
   }
 
@@ -417,7 +422,7 @@ private struct Transfer: AbstractTransferFunction {
   ) -> AnyInstructionIdentity? {
     let s = f.at(i)
     consume(place: s.source, with: i.erased, in: f)
-    context.declare(i, from: f, initially: .initialized)
+    context.declare(i, from: f, controlFlow: controlFlow, initially: .initialized)
     return f.instruction(after: i.erased)
   }
 
@@ -461,7 +466,7 @@ private struct Transfer: AbstractTransferFunction {
       s.access, s.source, insertingDeinitializationBefore: i.erased, in: &f)
 
     let v: Domain = (f.at(i).access == .set) ? .uninitialized : .initialized
-    context.declare(i, from: f, initially: v)
+    context.declare(i, from: f, controlFlow: controlFlow, initially: v)
     return f.instruction(after: i.erased)
   }
 
@@ -488,7 +493,7 @@ private struct Transfer: AbstractTransferFunction {
   ) -> AnyInstructionIdentity? {
     let s = f.at(i)
     let v: Domain = (s.access == .set) ? .uninitialized : .initialized
-    context.declare(i.erased, from: f, initially: v)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: v)
     return f.instruction(after: i.erased)
   }
 
@@ -505,7 +510,7 @@ private struct Transfer: AbstractTransferFunction {
     }
 
     let v: Domain = (f.at(i).access == .set) ? .uninitialized : .initialized
-    context.declare(i, from: f, initially: v)
+    context.declare(i, from: f, controlFlow: controlFlow, initially: v)
     return f.instruction(after: i.erased)
   }
 
@@ -534,7 +539,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRProperty.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .initialized)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .initialized)
     return f.instruction(after: i.erased)
   }
 
@@ -605,7 +610,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRTypeApply.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .initialized)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .initialized)
     return f.instruction(after: i.erased)
   }
   /// Interprets `i`, which is in `f`.
@@ -619,7 +624,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRWitnessTable.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .initialized)
+    context.declare(i.erased, from: f, controlFlow: controlFlow, initially: .initialized)
     return f.instruction(after: i.erased)
   }
 

--- a/Sources/FrontEnd/Parser/Lexer.swift
+++ b/Sources/FrontEnd/Parser/Lexer.swift
@@ -180,6 +180,7 @@ public struct Lexer: IteratorProtocol, Sequence {
     case "type": tag = .type
     case "var": tag = .var
     case "where": tag = .where
+    case "while": tag = .while
     case "yield": tag = .yield
     default: tag = .name
     }

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -2261,6 +2261,8 @@ public struct Parser {
       return try .init(parseDiscardStatement(in: &file))
     case .return:
       return try .init(parseReturnStatement(in: &file))
+    case .while:
+      return try .init(parseWhileStatement(in: &file))
     case .yield:
       return try .init(parseYieldStatement(in: &file))
     case _ where head.isDeclarationHead:
@@ -2305,6 +2307,21 @@ public struct Parser {
     }
 
     return file.insert(Return(introducer: i, value: v, site: span(from: i)))
+  }
+
+  /// Parses a while statement.
+  ///
+  ///     while-statement ::=
+  ///       'while' condition block
+  ///
+  private mutating func parseWhileStatement(
+    in file: inout Module.SourceContainer
+  ) throws -> While.ID {
+    let i = try take(.while) ?? expected("'while'")
+    let c = try parseConditionList(in: &file)
+    let s = try parseConditionalBody(in: &file)
+
+    return file.insert(While(introducer: i, condition: c, body: s, site: span(from: i)))
   }
 
   /// Parses a yield statement.

--- a/Sources/FrontEnd/Parser/Token.swift
+++ b/Sources/FrontEnd/Parser/Token.swift
@@ -42,6 +42,7 @@ public struct Token: Hashable, Sendable {
     case type
     case `var`
     case `where`
+    case `while`
     case yield
 
     // Scalar literals

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -3,7 +3,7 @@ import OrderedCollections
 import Utilities
 
 /// A Hylo program.
-/// 
+///
 /// - Invariant: The FileName of source files in `self` are unique.
 public struct Program: Sendable {
 
@@ -1592,7 +1592,8 @@ public struct Program: Sendable {
       return spanForDiagnostic(about: castUnchecked(n, to: Return.self))
     case Yield.self:
       return spanForDiagnostic(about: castUnchecked(n, to: Yield.self))
-
+    case While.self:
+      return self[castUnchecked(n, to: While.self)].introducer.site
     default:
       return self[n].site
     }

--- a/Sources/FrontEnd/Syntax/Statements/While.swift
+++ b/Sources/FrontEnd/Syntax/Statements/While.swift
@@ -1,0 +1,38 @@
+import Archivist
+
+/// A while statement.
+@Archivable
+public struct While: Statement {
+
+  /// The introducer of this statement.
+  public let introducer: Token
+
+  /// The condition of the loop.
+  ///
+  /// - Requires `condition.count > 0`.
+  public let conditions: [ConditionIdentity]
+
+  /// The site from which `self` was parsed.
+  public let site: SourceSpan
+
+  /// The body of the loop: `{ ... }`.
+  public let body: Block.ID
+
+  /// Creates an instance with the given properties.
+  public init(introducer: Token, condition: [ConditionIdentity], body: Block.ID, site: SourceSpan) {
+    self.introducer = introducer
+    self.conditions = condition
+    self.body = body
+    self.site = site
+  }
+
+}
+
+extension While: Showable {
+
+  /// Returns a textual representation of `self` using `printer`.
+  public func show(using printer: inout TreePrinter) -> String {
+    "while \(printer.show(conditions)) \(printer.show(body))"
+  }
+
+}

--- a/Sources/FrontEnd/Syntax/SyntaxTag.swift
+++ b/Sources/FrontEnd/Syntax/SyntaxTag.swift
@@ -81,6 +81,7 @@ public struct SyntaxTag: Sendable {
     Block.self,
     Discard.self,
     Return.self,
+    While.self,
     Yield.self,
   ]
 

--- a/Sources/FrontEnd/Syntax/SyntaxVisitor.swift
+++ b/Sources/FrontEnd/Syntax/SyntaxVisitor.swift
@@ -142,6 +142,8 @@ extension Program {
       traverse(castUnchecked(n, to: Discard.self), calling: &v)
     case Return.self:
       traverse(castUnchecked(n, to: Return.self), calling: &v)
+    case While.self:
+      traverse(castUnchecked(n, to: While.self), calling: &v)
     case Yield.self:
       traverse(castUnchecked(n, to: Yield.self), calling: &v)
 
@@ -398,6 +400,12 @@ extension Program {
   /// Visits the children of `n` in pre-order, calling back `v` when a node is entered or left.
   public func traverse<T: SyntaxVisitor>(_ n: Return.ID, calling v: inout T) {
     visit(self[n].value, calling: &v)
+  }
+
+  /// Visits the children of `n` in pre-order, calling back `v` when a node is entered or left.
+  public func traverse<T: SyntaxVisitor>(_ n: While.ID, calling v: inout T) {
+    visit(self[n].conditions, calling: &v)
+    visit(self[n].body, calling: &v)
   }
 
   /// Visits the children of `n` in pre-order, calling back `v` when a node is entered or left.

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -1095,6 +1095,17 @@ public struct Typer {
     assert(t == .void)
   }
 
+  /// Type checks `e`, which occurs as a statement.
+  private mutating func check(_ e: While.ID) {
+    if program[e.module].type(assignedTo: e) != nil { return }
+
+    var c = InferenceContext(expectedType: .void)
+    let t = inferredType(of: e, in: &c)
+
+    discharge(c.obligations, relatedTo: e)
+    assert(t == .void)
+  }
+
   /// Type checks `s`.
   private mutating func check(_ s: StatementIdentity) {
     switch program.tag(of: s) {
@@ -1106,6 +1117,8 @@ public struct Typer {
       checkAsStatement(program.castUnchecked(s, to: If.self))
     case Return.self:
       check(program.castUnchecked(s, to: Return.self))
+    case While.self:
+      check(program.castUnchecked(s, to: While.self))
     case Yield.self:
       check(program.castUnchecked(s, to: Yield.self))
     case _ where program.isExpression(s):
@@ -2262,6 +2275,19 @@ public struct Typer {
       report(.error, "branches of if-expression cannot contain statements", about: e)
       return context.obligations.assume(e, hasType: .error, at: site)
     }
+  }
+
+  /// Type checks `e` and returns its inferred type (Void).
+  private mutating func inferredType(
+    of e: While.ID, in context: inout InferenceContext
+  ) -> AnyTypeIdentity {
+    for n in program[e].conditions { check(n) }
+
+    // Is the expression occurring as a statement?
+    context.withSubcontext { (ctx) in
+      _ = inferredType(of: program[e].body, occurringAsStatement: true, in: &ctx)
+    }
+    return context.obligations.assume(e, hasType: .void, at: program[e].site)
   }
 
   /// Returns the inferred type of `e`.

--- a/StandardLibrary/Sources/Core/Numbers/Int32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int32.hylo
@@ -1,4 +1,4 @@
-/// A 32-bit signed integer value.
+/// A signed 32-bit integer.
 @_symbol("Int32")
 public struct Int32 is Deinitializable {
 
@@ -13,6 +13,13 @@ public struct Int32 is Deinitializable {
     &self.value = Builtin.zeroinitializer_i32()
   }
 
+  /// Returns the absolute value of `self`.
+  ///
+  /// - Requires: `self` must not be `Int32`'s minimum value.
+  public fun abs() -> Self {
+    if self < Self.zero() { Self.zero() - self } else { Self(value: self.value) }
+  }
+
 }
 
 public given Int32 is ExpressibleByIntegerLiteral { /* built-in */ }
@@ -20,3 +27,99 @@ public given Int32 is ExpressibleByIntegerLiteral { /* built-in */ }
 public given Int32 is Movable {}
 
 public given Int32 is Copyable {}
+
+public given Int32 is Equatable {
+
+  /// Returns `true` iff `self` is equal to `other`.
+  public fun infix== (other: Self) -> Bool {
+    .new(value: Builtin.icmp_eq_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is not equal to `other`.
+  public fun infix!= (other: Self) -> Bool {
+    .new(value: Builtin.icmp_ne_i32(self.value, other.value))
+  }
+
+}
+
+public given Int32 is Comparable {
+
+  /// Returns `true` iff `self` is less than `other`.
+  public fun infix< (other: Self) -> Bool {
+    .new(value: Builtin.icmp_slt_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is less than or equal to `other`.
+  public fun infix<= (other: Self) -> Bool {
+    .new(value: Builtin.icmp_sle_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is greater than `other`.
+  public fun infix> (other: Self) -> Bool {
+    .new(value: Builtin.icmp_sgt_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is greater than or equal to `other`.
+  public fun infix>= (_ other: Self) -> Bool {
+    .new(value: Builtin.icmp_sge_i32(self.value, other.value))
+  }
+
+}
+
+public given Int32 is AdditiveArithmetic {
+
+  /// Returns `self` added to `other`.
+  fun infix+ (other: Self) -> Self {
+    let (result, overflow) = Builtin.sadd_with_overflow_i32(self.value, other.value)
+    if Bool(value: overflow) {
+      fatal_error()
+    } else {
+      return .new(value: result)
+    }
+  }
+
+  /// Increments `self` by `other`.
+  public fun infix+= (other: Self) inout {
+    &self = self + other
+  }
+
+  /// Returns `other` subtracted from `self`.
+  fun infix- (other: Self) -> Self {
+    let (result, overflow) = Builtin.ssub_with_overflow_i32(self.value, other.value)
+    if Bool(value: overflow) {
+      fatal_error()
+    } else {
+      return .new(value: result)
+    }
+  }
+
+  /// Decrements `self` by `other`.
+  public fun infix-= (other: Self) inout {
+    &self = self - other
+  }
+
+  /// Returns `0`.
+  static fun zero() -> Self {
+    .new()
+  }
+
+}
+
+public given Int32 is Numeric {
+
+  /// Returns `self` multiplied by `other`.
+  fun infix* (other: Self) -> Self {
+    let (result, overflow) = Builtin.smul_with_overflow_i32(self.value, other.value)
+    if Bool(value: overflow) {
+      fatal_error()
+    } else {
+      return .new(value: result)
+    }
+  }
+
+  /// Multiplies `self` by `other`.
+  public fun infix*= (other: Self) inout {
+    &self = self * other
+  }
+
+}

--- a/Tests/CompilerTests/positive/loop-no-alloca.hylo
+++ b/Tests/CompilerTests/positive/loop-no-alloca.hylo
@@ -1,0 +1,12 @@
+//! exit-status:42
+
+fun main() -> Int32 {
+  var r: Int32 = 42
+  var c: Int32 = 0
+  while r > .zero() {
+    &r -= 1 as Int32
+    &c += 1 as Int32
+  }
+
+  return c
+}

--- a/Tests/CompilerTests/positive/loop-with-alloca.hylo
+++ b/Tests/CompilerTests/positive/loop-with-alloca.hylo
@@ -1,0 +1,13 @@
+//! exit-status:3
+
+fun main() -> Int32 {
+  var r: Int32 = 30
+  var counter: Int32 = 0
+  while r > .zero() {
+    let a = (5 as Int32) * (2 as Int32) // stack allocation in the loop
+    &r -= a // r -= 10
+    &counter += 1 as Int32
+  }
+
+  return counter
+}

--- a/Tests/CompilerTests/positive/loop-with-nested-alloca.hylo
+++ b/Tests/CompilerTests/positive/loop-with-nested-alloca.hylo
@@ -1,0 +1,20 @@
+//! exit-status:55
+
+fun loop_with_nested_allocation() {
+  var i: Int32 = 10
+  var sum: Int32 = 0
+
+  while i > .zero() {
+    var j = i + .zero()
+
+    while j > .zero() {
+      let d = (1 as Int32) + .zero()
+      &j -= d
+      &sum += 1 as Int32
+    }
+
+    &i -= 1 as Int32
+  }
+
+  return
+}


### PR DESCRIPTION
This PR adds:
- parsing, type checking and lowering of while statement #117 
- relaxing the invariants of IRAlloca declarartion in the abstract interpreter

The static allocas are already hoisted during LLVM lowering, but not the dynamic ones (e.g. for stack-allocating generic return value).

Please review carefully especially the IREmitter and abstract context changes. I had to change many usages of AbstractContext's `declare` to wire a `ControlFlowGraph` to `declare`. I saw a similar pattern already for passing in `Typer!`, but it still feels a bit too intrusive, so let me know if you have a better idea.

I added a check that repeated allocations for the same instructions must only happen if the instruction is in a loop (using the control flow graph). I couldn't yet add the check that would ensure that upon reentering the same allocation, the value at that place should have been already deinitialized. IIUC this check needs to reside in lifetime normalization, but `declare` is used there in a number of places, so I was not sure where to add this check. I'm also not confident at upholding the invariants of lifetime normalization/abstract interpretation yet, so I think I shouldn't attempt a potential refactoring / changing of invariants myself. But LMK if there would be a straightforward path, I can try then. We could also merge the PR without this extra guardrail, and add it later.