### PR TITLE
Don't emit temporary upon assignment when lhs and rhs roots don't overlap

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -461,15 +461,12 @@ internal struct IREmitter {
       return .next
     }
 
-    // If the LHS does not occur in the RHS, we can build the RHS in place.
-    if let n = program.cast(target, to: NameExpression.self) {
-      if case .direct(let d) = program.declaration(referredToBy: n) {
-        if !program.occurs(referenceTo: d, in: program[s].rhs) {
-          let target = lowered(lvalue: target)
-          lower(store: program[s].rhs, to: target)
-          return .next
-        }
-      }
+    // If the LHS is a name chain rooted at a direct declaration that does not occur in the RHS,
+    // we can build the RHS in place rather than storing it to a temporary and moving it.
+    if let d = lvalueRoot(target), !program.occurs(referenceTo: d, in: program[s].rhs) {
+      let l = lowered(lvalue: target)
+      lower(store: program[s].rhs, to: l)
+      return .next
     }
 
     // Otherwise, the right-hand side stored to a temporary and then moved to the LHS.
@@ -480,6 +477,23 @@ internal struct IREmitter {
     lowering(program[s].rhs, { $0._emitMove([.inout, .set], r, to: l) })
 
     return .next
+  }
+
+  /// Returns the declaration at the root of the name chain denoted by `e`, if any.
+  ///
+  /// An lvalue formed by a chain of `NameExpression`s (e.g., `self.foo.bar`) is rooted at the
+  /// direct reference at the head of that chain (e.g., `self`). Returns `nil` if `e` is not such
+  /// a chain or if its head is not a direct reference to a declaration.
+  private func lvalueRoot(_ e: ExpressionIdentity) -> DeclarationIdentity? {
+    var head = e
+    while let n = program.cast(head, to: NameExpression.self) {
+      guard let q = program[n].qualification else {
+        return if case .direct(let d) =
+          program.declaration(referredToBy: n) { d } else { nil }
+      }
+      head = q
+    }
+    return nil
   }
 
   /// Generates the IR of `s`.

--- a/Tests/CompilerTests/positive/in-place-construct-member.hylo
+++ b/Tests/CompilerTests/positive/in-place-construct-member.hylo
@@ -1,0 +1,40 @@
+//! stage:lowering
+
+/// Regression test for https://github.com/hylo-lang/hylo-new/issues/126.
+///
+/// Assigning a value to a stored property of `self` should build the value in place rather than
+/// storing it into a temporary and moving it. In particular, the type of the assigned value need
+/// not conform to `Movable`, as demonstrated here by omitting a `Movable` witness for `Wrapper`.
+
+struct Wrapper is Deinitializable {
+  var x: Int
+  var y: Int
+  var z: Int
+
+  public init(x: Int, y: Int, z: Int) {
+    &self.x = x + 0
+    &self.y = y + 0
+    &self.z = z + 0
+  }
+
+  public fun manualCopy() -> Wrapper {
+    return Wrapper(
+      self.x + 0,
+      self.y + 0,
+      self.z + 0)
+  }
+}
+
+struct Box is Deinitializable {
+  public var payload: Wrapper
+
+  /// The RHS is an in-place constructor call that does not mention `self`.
+  public init() {
+    &self.payload = Wrapper(0, 0, 0)
+  }
+
+  /// The RHS is a non-constructor call whose arguments do not mention `self`.
+  public init(_ payload: Wrapper) {
+    &self.payload = payload.manualCopy()
+  }
+}


### PR DESCRIPTION
This is a partial solution to #126. It still doesn't account for the case when we know the memory layout of the left hand side, and we would be able to prove that the LHS and RHS don't overlap. 

E.g. `&self.x = self.y.copy()` doesn't work yet because the compiler has a too conservative understanding, and sees that `self`, the root of LHS is used by RHS.

Test case:

````
//! stage:lowering

struct Wrapper is Deinitializable {
  var x: Int
  var y: Int
  var z: Int

  public init(x: Int, y: Int, z: Int) {
    &self.x = x + 0
    &self.y = y + 0
    &self.z = z + 0
  }

  public fun manualCopy() -> Wrapper {
    return Wrapper(
      self.x + 0,
      self.y + 0,
      self.z + 0)
  }
}

struct Box is Deinitializable {
  public var w1: Wrapper
  public var w2: Wrapper

  /// The RHS is a non-constructor call whose arguments do not mention `self`.
  public init(_ payload: Wrapper) {
    &self.w1 = payload.manualCopy()
    &self.w2 = self.w1.manualCopy()
  }
}
```