### PR TITLE
Fix the typing of implicit qualification

### DIFF
--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -130,6 +130,8 @@ private struct Transfer: AbstractTransferFunction {
         pc = interpret(f.castUnchecked(i, to: IRSubfield.self), from: &f)
       case IRTypeApply.self:
         pc = interpret(f.castUnchecked(i, to: IRTypeApply.self), from: &f)
+      case IRUnreachable.self:
+        pc = interpret(f.castUnchecked(i, to: IRUnreachable.self), from: &f)
       case IRWitnessTable.self:
         pc = interpret(f.castUnchecked(i, to: IRWitnessTable.self), from: &f)
       case IRYield.self:
@@ -494,6 +496,12 @@ private struct Transfer: AbstractTransferFunction {
     _ i: IRTypeApply.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
     context.declare(i.erased, from: f, initially: .initialized)
+    return f.instruction(after: i.erased)
+  }
+  /// Interprets `i`, which is in `f`.
+  private mutating func interpret(
+    _ i: IRUnreachable.ID, from f: inout IRFunction
+  ) -> AnyInstructionIdentity? {
     return f.instruction(after: i.erased)
   }
 

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -2078,7 +2078,8 @@ public struct Typer {
     if let q = program.implicitQualification(of: callee) {
       let t =
         context.expectedType ?? context.obligations.assume(e, hasType: fresh().erased, at: site)
-      _ = context.withSubcontext(expectedType: t) { (ctx) in inferredType(of: q, in: &ctx) }
+      let u = program.types.demand(Metatype(inhabitant: t)).erased
+      _ = context.withSubcontext(expectedType: u) { (ctx) in inferredType(of: q, in: &ctx) }
     }
 
     let r = SyntaxRole(program[e].style, labels: program[e].labels)
@@ -2419,13 +2420,13 @@ public struct Typer {
       role = .unspecified
     }
 
-    let s = resolveQualification(of: e, in: &context)
-    let t = demand(Metatype(inhabitant: s)).erased
+    let q = program[e].qualification
+    let s = context.withSubcontext { (ctx) in inferredType(of: q, in: &ctx) }
     let u = fresh().erased
 
     context.obligations.assume(
       MemberConstraint(
-        member: program[e].target, role: role, qualification: t, type: u, site: site))
+        member: program[e].target, role: role, qualification: s, type: u, site: site))
     context.obligations.assume(program[e].target, hasType: u, at: site)
 
     let v = fresh().erased
@@ -2585,7 +2586,7 @@ public struct Typer {
   private mutating func inferredType(
     of e: TupleMember.ID, in context: inout InferenceContext
   ) -> AnyTypeIdentity {
-    let parent = context.withSubcontext() { (ctx) in
+    let parent = context.withSubcontext { (ctx) in
       inferredType(of: program[e].parent, in: &ctx)
     }
 
@@ -3935,17 +3936,6 @@ public struct Typer {
     case .right(let d):
       report(d)
       return .error
-    }
-  }
-
-  /// Resolves and returns the qualification of `e`, which occurs in `context`.
-  private mutating func resolveQualification(
-    of e: New.ID, in context: inout InferenceContext
-  ) -> AnyTypeIdentity {
-    if let q = program.cast(program[e].qualification, to: ImplicitQualification.self) {
-      return inferredType(of: q, in: &context)
-    } else {
-      return evaluatePartialTypeAscription(program[e].qualification, in: &context).result
     }
   }
 

--- a/Tests/CompilerTests/positive/implicit-qualification.hylo
+++ b/Tests/CompilerTests/positive/implicit-qualification.hylo
@@ -1,4 +1,4 @@
-//! stage:typing no-std
+//! stage:lowering
 
 struct A<T> {
   public var x: T
@@ -6,8 +6,10 @@ struct A<T> {
   public static fun make(x: sink T) -> A<T> { .new(x: x) }
 }
 
+given A<Void> is Deinitializable {}
+
 extension <T> A<T> {
-  public fun id() sink -> Self { self }
+  public fun id() -> Self { fatal_error() }
 }
 
 public fun use<T>(x: A<T>) {}

--- a/Tests/CompilerTests/positive/implicit-qualification.hylo
+++ b/Tests/CompilerTests/positive/implicit-qualification.hylo
@@ -4,6 +4,9 @@ struct A<T> {
   public var x: T
   public memberwise init
   public static fun make(x: sink T) -> A<T> { .new(x: x) }
+}
+
+extension <T> A<T> {
   public fun id() sink -> Self { self }
 }
 


### PR DESCRIPTION
This patch gives implicit qualification the metatype of the expected type rather than the expected directly, which is necessary for lowering and fixes #124.

For example, the implicit qualification of `zero()` in `.zero() as Int` now has type `Metatype<Int>` rather than `Int`.