### PR TITLE
Add 'Copyable' to the standard library

### DIFF
--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1447,6 +1447,9 @@ extension Program {
     /// `Hylo.Equatable`.
     case equatable = "Equatable"
 
+    /// `Hylo.Copyable`
+    case copyable = "Copyable"
+
     /// `Hylo.Movable`.
     case movable = "Movable"
 
@@ -1463,7 +1466,8 @@ extension Program {
     case expressibleByFloatingPointLiteral = "ExpressibleByFloatingPointLiteral"
 
     /// `Hylo.ExpressibleByFloatingPointLiteral.init(floating_point_literal:)`.
-    case expressibleByFloatingPointLiteralInit = "ExpressibleByFloatingPointLiteral.init(floating_point_literal:)"
+    case expressibleByFloatingPointLiteralInit =
+      "ExpressibleByFloatingPointLiteral.init(floating_point_literal:)"
 
   }
 

--- a/Sources/FrontEnd/Typer/Solver.swift
+++ b/Sources/FrontEnd/Typer/Solver.swift
@@ -541,8 +541,8 @@ internal struct Solver {
   private func invalidTupleMember(_ k: TupleMemberConstraint) -> GoalOutcome {
     .failure { (ss, _, tp, ds) in
       let t = tp.program.types.reify(k.parent, applying: ss)
-      let m = tp.program.format("type '%T' has no member '\(k.member.value)'", [t])
-      ds.insert(.init(.error, m, at: k.site))
+      let n = Parsed(Name(identifier: "\(k.member.value)"), at: k.member.site)
+      ds.insert(tp.program.undefinedSymbol(n, memberOf: t))
     }
   }
 

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -2823,7 +2823,7 @@ public struct Typer {
   /// viable candidate.
   ///
   /// If binding succeeds, `o` is extended with either a assignment mapping `n` to a declaration
-  /// reference or an overload constrain mapping `n` to one of the viable candidates. If binding
+  /// reference or an overload constraint mapping `n` to one of the viable candidates. If binding
   /// failed, `o` is left unchanged and a diagnostic is returned.
   ///
   /// - Requires: `candidates` is not empty.

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -370,7 +370,7 @@ public struct Typer {
 
   /// Type checks `d`.
   private mutating func check(_ d: ConformanceDeclaration.ID) {
-    let t = declaredType(of: d)
+    let typeOfWitness = declaredType(of: d)
 
     check(program[d].contextParameters)
 
@@ -387,9 +387,9 @@ public struct Typer {
     // The type of the declaration has the form `<T...> A... ==> P<B...>` where `P<B...>` is the
     // type of the declared witness and the rest forms a context. Requirements are resolved as
     // members of the type `B` where type parameters occur as skolems.
-    let witnessSansContext = program.types.contextAndHead(t).head
-    guard let witness = program.types.seenAsTraitApplication(witnessSansContext) else {
-      assert(t[.hasError])
+    let typeOfWitnessSansContext = program.types.contextAndHead(typeOfWitness).head
+    guard let witness = program.types.seenAsTraitApplication(typeOfWitnessSansContext) else {
+      assert(typeOfWitness[.hasError])
       return
     }
 
@@ -498,19 +498,18 @@ public struct Typer {
     func anonymousImplementation(of requirement: DeclarationIdentity) -> SummonResult? {
       let requiredType = expectedImplementationType(of: requirement)
 
-      var summonings = summon(requiredType, in: .init(node: d))
-      let i = summonings.stablePartition { (c) in
-        c.witness.declaration == requirement
-      }
+      // The conformance declaration is removed from the givens available to resolve the required
+      // type to avoid creating cycles through nested givens. For example, if `Q` refines `P` and
+      // `d` is declaring a conformance to `Q`, we cannot use `d` to resolve `P<Self>`.
+      declarationsOnStack.insert(.init(d))
+      defer { declarationsOnStack.remove(.init(d)) }
 
-      let s = program.spanForDiagnostic(about: d)
-      if i == 1 {
-        return summonings[0]
-      } else if i == 0 {
-        report(program.noGivenInstance(of: requiredType, at: s))
-        return nil
+      let summonings = summon(requiredType, in: .init(node: d))
+      if let pick = summonings.uniqueElement {
+        return pick
       } else {
-        report(program.multipleGivenInstances(of: requiredType, at: s))
+        let s = program.spanForDiagnostic(about: d)
+        report(program.noUniqueGivenInstance(of: requiredType, found: summonings, at: s))
         return nil
       }
     }
@@ -3473,7 +3472,7 @@ public struct Typer {
     }
 
     // Do not memoize the result if it has been computed while givens were on stack.
-    if !t[.hasVariable] && !declarationsOnStack.contains(where: program.isImplicit) {
+    if !t[.hasVariable] && !hasImplicitOnStack() {
       cache.scopeToSummoned[scopeOfUse, default: [:]][t] = result
     }
 
@@ -3817,7 +3816,6 @@ public struct Typer {
     var threads = [formThread(matching: root, to: goal, in: .empty)]
 
     if canDeriveCoercions(root.type, goal, in: scopeOfUse, where: .empty) {
-    // if canDeriveCoercions(in: scopeOfUse, where: .empty) {
       // Either the type of the elaborated witness is unifiable with the queried type or we need to
       // assume a coercion. Implicit resolution will figure out the "cheapest" alternative.
       let (environment, coercion) = ResolutionThread.Environment.empty.assuming(
@@ -3847,7 +3845,7 @@ public struct Typer {
       let t = declaredType(of: g)
       let u = program.types.contextAndHead(t)
 
-      // Can the given can match any type (e.g., `<T> T`)?
+      // Can the given match any type (e.g., `<T> T`)?
       if u.context.parameters.contains(where: { (p) in p == u.head }) {
         return true
       }
@@ -4770,6 +4768,11 @@ public struct Typer {
     default:
       return true
     }
+  }
+
+  /// Returns `true` iff there is a declaration introducing an implicit that is being typed.
+  private func hasImplicitOnStack() -> Bool {
+    declarationsOnStack.contains(where: program.isImplicit)
   }
 
 }

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -853,6 +853,8 @@ public struct Typer {
       return true
     case program.standardLibraryDeclaration(.equatable):
       return true
+    case program.standardLibraryDeclaration(.copyable):
+      return true
     case program.standardLibraryDeclaration(.movable):
       return true
     default:

--- a/StandardLibrary/Sources/Core/Bool.hylo
+++ b/StandardLibrary/Sources/Core/Bool.hylo
@@ -37,6 +37,8 @@ public struct Bool is Deinitializable {
 
 public given Bool is Movable {}
 
+public given Bool is Copyable {}
+
 public given Bool is Equatable {
 
   public fun infix== (other: Self) -> Bool {

--- a/StandardLibrary/Sources/Core/Copyable.hylo
+++ b/StandardLibrary/Sources/Core/Copyable.hylo
@@ -1,0 +1,15 @@
+/// A type whose instances can be copied.
+@_symbol("Copyable")
+public trait Copyable refines Movable {
+
+  /// Returns a copy of `self`.
+  @_symbol("Copyable.copy(:)")
+  fun copy() -> Self
+
+}
+
+/// A witness that `Void` is `Copyable`.
+public given Void is Copyable {}
+
+/// A witness that a tuple is `Copyable` when its elements are too.
+public given <T is Copyable, U is Copyable> {T, ...U} is Copyable {}

--- a/StandardLibrary/Sources/Core/Numbers/Float32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Float32.hylo
@@ -18,6 +18,8 @@ public given Float32 is ExpressibleByFloatingPointLiteral { /* built-in */ }
 
 public given Float32 is Movable {}
 
+public given Float32 is Copyable {}
+
 public given Float32 is Equatable {
 
   public fun infix== (other: Self) -> Bool {

--- a/StandardLibrary/Sources/Core/Numbers/Float64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Float64.hylo
@@ -18,6 +18,8 @@ public given Float64 is ExpressibleByFloatingPointLiteral { /* built-in */ }
 
 public given Float64 is Movable {}
 
+public given Float64 is Copyable {}
+
 public given Float64 is Equatable {
 
   public fun infix== (other: Self) -> Bool {

--- a/StandardLibrary/Sources/Core/Numbers/Int.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int.hylo
@@ -24,6 +24,8 @@ public given Int is ExpressibleByIntegerLiteral { /* built-in */ }
 
 public given Int is Movable {}
 
+public given Int is Copyable {}
+
 public given Int is Equatable {
 
   public fun infix== (other: Self) -> Bool {

--- a/Tests/CompilerTests/negative/missing-associated-type-conformance.hylo
+++ b/Tests/CompilerTests/negative/missing-associated-type-conformance.hylo
@@ -10,8 +10,8 @@ trait P {
 }
 
 given A is P {
-  type X = A
-  public fun x() -> X { A() }
+  type X = B
+  public fun x() -> X { B() }
 }
 
 given B is P {


### PR DESCRIPTION
This patch adds `Copyable` to the standard library, making changes to the resolution of implicit givens to avoid recursive definitions.