### PR TITLE
Bundle DLLs on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,24 +31,20 @@ jobs:
   build-distributable:
     name: Build distributable for ${{ matrix.target }}
     needs: prepare-draft-release
-    strategy:
+    strategy: &distributable-strategy
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
-            target: linux-x64
-          - os: ubuntu-24.04-arm
-            target: linux-arm64
-          - os: macos-15
-            target: macos-arm64
-          - os: macos-15-intel
-            target: macos-x64
-          - os: windows-2025
-            target: windows-x64
-          - os: windows-11-arm
-            target: windows-arm64
+          - { os: ubuntu-24.04,     target: linux-x64 }
+          - { os: ubuntu-24.04-arm, target: linux-arm64 }
+          - { os: macos-15,         target: macos-arm64 }
+          - { os: macos-15-intel,   target: macos-x64 }
+          - { os: windows-2025,     target: windows-x64 }
+          - { os: windows-11-arm,   target: windows-arm64 }
 
     runs-on: ${{ matrix.os }}
+    env: &distributable-env
+      ARTIFACT_NAME: hylo-${{ github.ref_name }}-${{ matrix.target }}
 
     steps:
       - uses: actions/checkout@v6
@@ -85,31 +81,24 @@ jobs:
 
       - name: Locate distributable
         id: locate-distributable
-        env:
-          TAG: ${{ github.ref_name }}
-          TARGET: ${{ matrix.target }}
         run: |
           $ErrorActionPreference = 'Stop'
           $binPath = (swift build -c release --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY --show-bin-path).Trim()
           $binaryName = if ($env:RUNNER_OS -eq 'Windows') { 'hc.exe' } else { 'hc' }
-          $binaryPath = Join-Path $binPath $binaryName
-          $assetBaseName = "hylo-$env:TAG-$env:TARGET"
-          $archivePath = Join-Path $env:RUNNER_TEMP "$assetBaseName.tar.zst"
           "bin_path=$binPath" >> $env:GITHUB_OUTPUT
-          "binary_path=$binaryPath" >> $env:GITHUB_OUTPUT
-          "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
+          "binary_path=$(Join-Path $binPath $binaryName)" >> $env:GITHUB_OUTPUT
         shell: pwsh
 
-      - name: Verify distributable
-        run: |
-          $ErrorActionPreference = 'Stop'
-          & "${{ steps.locate-distributable.outputs.binary_path }}" --help | Out-Null
-        shell: pwsh
+      - name: Bundle Windows DLL dependencies
+        if: runner.os == 'Windows'
+        uses: hylo-lang/swift-windows-dll-bundler@c16562d38c058b71f62b2c3b92d5bf0aa47f4768 # v1.0.0
+        with:
+          executable: ${{ steps.locate-distributable.outputs.binary_path }}
 
       - name: Archive distributable
         run: |
           $ErrorActionPreference = 'Stop'
-          $archivePath = "${{ steps.locate-distributable.outputs.archive_path }}"
+          $archivePath = Join-Path $env:RUNNER_TEMP "$env:ARTIFACT_NAME.tar.zst"
           $binPath = "${{ steps.locate-distributable.outputs.bin_path }}"
           if (Test-Path $archivePath) {
             Remove-Item -Force $archivePath
@@ -117,14 +106,47 @@ jobs:
           tar --zstd -cf $archivePath -C $binPath .
         shell: pwsh
 
+      - name: Upload distributable artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ runner.temp }}/${{ env.ARTIFACT_NAME }}.tar.zst
+          if-no-files-found: error
+          retention-days: 2
+
+  verify-and-publish-distributable:
+    name: Verify and publish distributable for ${{ matrix.target }}
+    needs: build-distributable
+    strategy: *distributable-strategy
+    runs-on: ${{ matrix.os }}
+    env: *distributable-env
+
+    steps:
+      - name: Download distributable artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ runner.temp }}/dist
+
+      - name: Verify distributable in a Swift-free environment
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $archive = Join-Path $env:RUNNER_TEMP "dist/$env:ARTIFACT_NAME.tar.zst"
+          $extractDir = Join-Path $env:RUNNER_TEMP 'extracted'
+          New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+          tar --zstd -xf $archive -C $extractDir
+
+          $binaryName = if ($env:RUNNER_OS -eq 'Windows') { 'hc.exe' } else { 'hc' }
+          $binary = Join-Path $extractDir $binaryName
+          & $binary --help
+        shell: pwsh
+
       - name: Upload distributable to draft release
         env:
           GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
           $ErrorActionPreference = 'Stop'
-          gh release upload $env:TAG "${{ steps.locate-distributable.outputs.archive_path }}" --repo $env:REPOSITORY --clobber
+          $archive = Join-Path $env:RUNNER_TEMP "dist/$env:ARTIFACT_NAME.tar.zst"
+          gh release upload $env:TAG $archive --repo '${{ github.repository }}' --clobber
         shell: pwsh
-
-


### PR DESCRIPTION
It turned out that static linking the standard library is still not yet supported on Windows:
- https://github.com/swiftlang/swift/issues/83446
- https://github.com/swiftlang/swift-package-manager/issues/10041

The workaround is to bundle the required DLLs on Windows for the time being with the https://github.com/hylo-lang/swift-windows-dll-bundler action. This PR also adds a binary verification step to the release, so that we check on all platforms whether hc can be invoked.

Succeeded draft release creation: https://github.com/hylo-lang/hylo-new/actions/runs/25643152899/job/75267661993?pr=152