### PR TITLE
Implement IR lowering for bundles

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -856,7 +856,7 @@ internal struct IREmitter {
   }
 
   /// Generates the IR using `d` as a callee that is optionally qualified by `qualification`,
-  /// achoring new instructions to `anchor`.
+  /// anchoring new instructions to `anchor`.
   ///
   /// This method implements `loweredCallee(_:output:)` for a use of `d` expressed explicitly in
   /// sources or synthesized during compilation. `mutationMarker` is, if defined, is the mutation
@@ -1069,8 +1069,7 @@ internal struct IREmitter {
       in: program.parent(containing: e))
   }
 
-  /// Generates the IR for using `e` as a callee, achoring new instructions to the anchor
-  /// represented by `site` and `scope`.
+  /// Generates the IR for using `e` as a callee, anchoring new instructions at `site` and `scope`.
   ///
   /// This method implements `loweredCallee(_:output:)` for witness expressions.
   private mutating func loweredCallee(

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -800,18 +800,18 @@ internal struct IREmitter {
 
   }
 
-  /// Generates the IR for using `e`, which occurs as a callee.
+  /// Generates the IR for using `e` as a callee.
   ///
   /// Let `f` be the result of this method. `f.value` is the IR function implementing the callee
   /// expressed by `e`. This function may be partially applied if `e` is a bound member and/or if
   /// it involves implicit arguments, in which case `f.arguments` contain these arguments.
   ///
-  /// If `f` is an ordinary function rather than a subscript, `r` is the place in which the result
-  /// of the call is written (i.e., the target of `lower(store:to:)`). In this case, if `e` is the
-  /// application of a new expression, then `r` is appended to `f.arguments` and `f.result` is a
-  /// new alloca. Otherwise, `f.result` is assigned to `r`.
+  /// If `e` denotes an ordinary function rather than a subscript, then `r` is the place in which
+  /// the result of the call is written (i.e., the target of `lower(store:to:)`). Moreover, if `e`
+  /// is the application of a new expression, then `r` is appended to `f.arguments` and `f.result`
+  /// is a new alloca. Otherwise, `f.result` is assigned to `r`.
   ///
-  /// If `f` is a subscript, then `r` and `f.result` are a poison values.
+  /// If `f` is a subscript, then `r` and `f.result` are poison values.
   private mutating func loweredCallee(
     _ e: ExpressionIdentity, output r: IRValue
   ) -> LoweredCallee {
@@ -841,21 +841,28 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR for using `e`, which occurs as a callee.
+  /// Generates the IR for using `e` as a callee.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for name expressions. `mutationMarker` is,
+  /// is the mutation marker that prefixes the callee's expression.
   private mutating func loweredCallee(
-    _ e: NameExpression.ID, output result: IRValue, markedForMutationBy mutationMarker: Token?,
+    _ e: NameExpression.ID, output r: IRValue, markedForMutationBy mutationMarker: Token?,
   ) -> LoweredCallee {
     let d = program.declaration(referredToBy: e)
     let a = Anchor(site: program[e].site, scope: program.parent(containing: e))
     return loweredCallee(
       d, qualifiedBy: program[e].qualification, markedForMutationBy: mutationMarker,
-      output: result, at: a)
+      output: r, at: a)
   }
 
-  /// Generates the IR at `anchor` for using `d`, which occurs as a callee that is optionally
-  /// qualified by `q`.
+  /// Generates the IR using `d` as a callee that is optionally qualified by `qualification`,
+  /// achoring new instructions to `anchor`.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for a use of `d` expressed explicitly in
+  /// sources or synthesized during compilation. `mutationMarker` is, if defined, is the mutation
+  /// marker that prefixes the expression denoting the use of `d`.
   private mutating func loweredCallee(
-    _ d: DeclarationReference, qualifiedBy q: ExpressionIdentity?,
+    _ d: DeclarationReference, qualifiedBy qualification: ExpressionIdentity?,
     markedForMutationBy mutationMarker: Token?,
     output result: IRValue,
     at anchor: Anchor
@@ -871,7 +878,7 @@ internal struct IREmitter {
         referringTo: d, boundTo: nil, markedForMutationBy: mutationMarker, output: result)
 
       // The qualification may define type arguments.
-      if let ts = q.flatMap({ (e) in argumentsFromStaticQualification(e) }) {
+      if let ts = qualification.flatMap({ (e) in argumentsFromStaticQualification(e) }) {
         let g = lowering(at: anchor.site, in: anchor.scope, { $0._type_apply(f.value, to: ts) })
         return f.substituting(value: g)
       } else {
@@ -880,7 +887,7 @@ internal struct IREmitter {
 
     case .member(let d):
       // The callee refers to a bound member.
-      let receiver = lowered(lvalue: q!)
+      let receiver = lowered(lvalue: qualification!)
       let f = loweredCallee(
         referringTo: d, boundTo: receiver, markedForMutationBy: mutationMarker, output: result)
 
@@ -896,7 +903,7 @@ internal struct IREmitter {
 
     case .inherited(let w, let m, let statically):
       // The callee refers to a member declared in extension.
-      let receiver = statically ? nil : lowered(lvalue: q!)
+      let receiver = statically ? nil : lowered(lvalue: qualification!)
 
       // Is the member declared in an extension?
       if let parent = program.extensionContaining(m) {
@@ -932,7 +939,11 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR for a callee referring to `d`, optionally bound to `receiver`.
+  /// Generates the IR using `d` as a callee that is optionally bound to `receiver`.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for a use of `d` expressed explicitly in
+  /// sources or synthesized during compilation. `mutationMarker` is, if defined, is the mutation
+  /// marker that prefixes the expression denoting the use of `d`.
   private mutating func loweredCallee(
     referringTo d: DeclarationIdentity, boundTo receiver: IRValue?,
     markedForMutationBy mutationMarker: Token?,
@@ -958,7 +969,10 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR for a callee referring to `f`, optionally bound to `receiver`.
+  /// Generates the IR for using `f` as a callee that is optionally bound to `receiver`.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for a use of `d` expressed explicitly in
+  /// sources or synthesized during compilation.
   private mutating func loweredCallee(
     referringTo f: IRFunction.ID, boundTo receiver: IRValue?, output result: IRValue
   ) -> LoweredCallee {
@@ -966,7 +980,10 @@ internal struct IREmitter {
     return LoweredCallee(value: v, arguments: Array(contentsOf: receiver), result: result)
   }
 
-  /// Generates the IR for using `f` as a callee, optionally bound to `receiver`.
+  /// Generates the IR for using `f` as a callee that is optionally bound to `receiver`.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for a use of `d` expressed explicitly in
+  /// sources or synthesized during compilation.
   private mutating func loweredCallee(
     referringTo f: FunctionBundleDeclaration.ID, boundTo receiver: IRValue?,
     markedForMutationBy mutationMarker: Token?,
@@ -994,7 +1011,9 @@ internal struct IREmitter {
     }
   }
 
-  /// Implements `loweredCallee(_:writingTo)` for new expressions.
+  /// Generates the IR for using `e` as a callee.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for new expressions.
   private mutating func loweredCallee(
     _ e: New.ID, output result: IRValue
   ) -> LoweredCallee {
@@ -1014,7 +1033,9 @@ internal struct IREmitter {
     return LoweredCallee(value: g, arguments: xs, result: r)
   }
 
-  /// Implements `loweredCallee(_:writingTo)` for static calls.
+  /// Generates the IR for using `e` as a callee.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for static calls.
   private mutating func loweredCallee(
     _ e: StaticCall.ID, output result: IRValue
   ) -> LoweredCallee {
@@ -1036,7 +1057,9 @@ internal struct IREmitter {
     return poly.substituting(value: mono)
   }
 
-  /// Implements `loweredCallee(_:writingTo)` for synthetic expressions.
+  /// Generates the IR for using `e` as a callee.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for synthetic expressions.
   private mutating func loweredCallee(
     _ e: SyntheticExpression.ID, output result: IRValue
   ) -> LoweredCallee {
@@ -1046,7 +1069,10 @@ internal struct IREmitter {
       in: program.parent(containing: e))
   }
 
-  /// Implements `loweredCallee(_:writingTo)` for witness expressions.
+  /// Generates the IR for using `e` as a callee, achoring new instructions to the anchor
+  /// represented by `site` and `scope`.
+  ///
+  /// This method implements `loweredCallee(_:output:)` for witness expressions.
   private mutating func loweredCallee(
     _ e: WitnessExpression, output result: IRValue, at site: SourceSpan, in scope: ScopeIdentity
   ) -> LoweredCallee {

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -868,8 +868,8 @@ internal struct IREmitter {
       if let parent = program.extensionContaining(m) {
         let target = loweredCallee(referringTo: m, boundTo: receiver, output: result)
         return lowering(at: anchor.site, in: anchor.scope) { (me) in
-          /// References to members in extensions are expressed using a witness representing the
-          /// type and term arguments passed to parameters declared on the extension itself.
+          // References to members in extensions are expressed using a witness representing the
+          // type and term arguments passed to parameters declared on the extension itself.
           let (e, ts, xs) = me._emit(decompose: w)
           assert(e.value == .reference(.init(parent)))
 

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -261,7 +261,8 @@ internal struct IREmitter {
 
           let o = me.currentFunction.returnRegister ?? .poison(.place(.error))
           let f = me.loweredCallee(
-            implementation, qualifiedBy: nil, output: o, at: me.currentAnchor)
+            implementation, qualifiedBy: nil, markedForMutationBy: nil,
+            output: o, at: me.currentAnchor)
           me._emitCallToRequirementImplementation(f)
         }
       }
@@ -814,33 +815,49 @@ internal struct IREmitter {
   private mutating func loweredCallee(
     _ e: ExpressionIdentity, output r: IRValue
   ) -> LoweredCallee {
-    switch program.tag(of: e) {
+    var callee = e
+    var mutationMarker: Token? = nil
+    if let n = program.cast(e, to: InoutExpression.self) {
+      callee = program[n].lvalue
+      mutationMarker = program[n].marker
+    }
+
+    switch program.tag(of: callee) {
     case NameExpression.self:
-      return loweredCallee(program.castUnchecked(e, to: NameExpression.self), output: r)
+      let n = program.castUnchecked(callee, to: NameExpression.self)
+      return loweredCallee(n, output: r, markedForMutationBy: mutationMarker)
+
     case New.self:
-      return loweredCallee(program.castUnchecked(e, to: New.self), output: r)
+      return loweredCallee(program.castUnchecked(callee, to: New.self), output: r)
+
     case StaticCall.self:
-      return loweredCallee(program.castUnchecked(e, to: StaticCall.self), output: r)
+      return loweredCallee(program.castUnchecked(callee, to: StaticCall.self), output: r)
+
     case SyntheticExpression.self:
-      return loweredCallee(program.castUnchecked(e, to: SyntheticExpression.self), output: r)
+      return loweredCallee(program.castUnchecked(callee, to: SyntheticExpression.self), output: r)
+
     default:
-      program.unexpected(e)
+      program.unexpected(callee)
     }
   }
 
   /// Generates the IR for using `e`, which occurs as a callee.
   private mutating func loweredCallee(
-    _ e: NameExpression.ID, output result: IRValue
+    _ e: NameExpression.ID, output result: IRValue, markedForMutationBy mutationMarker: Token?,
   ) -> LoweredCallee {
     let d = program.declaration(referredToBy: e)
     let a = Anchor(site: program[e].site, scope: program.parent(containing: e))
-    return loweredCallee(d, qualifiedBy: program[e].qualification, output: result, at: a)
+    return loweredCallee(
+      d, qualifiedBy: program[e].qualification, markedForMutationBy: mutationMarker,
+      output: result, at: a)
   }
 
   /// Generates the IR at `anchor` for using `d`, which occurs as a callee that is optionally
   /// qualified by `q`.
   private mutating func loweredCallee(
-    _ d: DeclarationReference, qualifiedBy q: ExpressionIdentity?, output result: IRValue,
+    _ d: DeclarationReference, qualifiedBy q: ExpressionIdentity?,
+    markedForMutationBy mutationMarker: Token?,
+    output result: IRValue,
     at anchor: Anchor
   ) -> LoweredCallee {
     switch d {
@@ -850,7 +867,8 @@ internal struct IREmitter {
 
     case .direct(let d):
       // The callee refers to a function directly.
-      let f = loweredCallee(referringTo: d, boundTo: nil, output: result)
+      let f = loweredCallee(
+        referringTo: d, boundTo: nil, markedForMutationBy: mutationMarker, output: result)
 
       // The qualification may define type arguments.
       if let ts = q.flatMap({ (e) in argumentsFromStaticQualification(e) }) {
@@ -863,7 +881,8 @@ internal struct IREmitter {
     case .member(let d):
       // The callee refers to a bound member.
       let receiver = lowered(lvalue: q!)
-      let f = loweredCallee(referringTo: d, boundTo: receiver, output: result)
+      let f = loweredCallee(
+        referringTo: d, boundTo: receiver, markedForMutationBy: mutationMarker, output: result)
 
       // If the reference is bound to a generic type, its type arguments have to be extracted from
       // the receiver's expression.
@@ -881,7 +900,9 @@ internal struct IREmitter {
 
       // Is the member declared in an extension?
       if let parent = program.extensionContaining(m) {
-        let target = loweredCallee(referringTo: m, boundTo: receiver, output: result)
+        let target = loweredCallee(
+          referringTo: m, boundTo: receiver, markedForMutationBy: mutationMarker, output: result)
+
         return lowering(at: anchor.site, in: anchor.scope) { (me) in
           // References to members in extensions are expressed using a witness representing the
           // type and term arguments passed to parameters declared on the extension itself.
@@ -913,7 +934,9 @@ internal struct IREmitter {
 
   /// Generates the IR for a callee referring to `d`, optionally bound to `receiver`.
   private mutating func loweredCallee(
-    referringTo d: DeclarationIdentity, boundTo receiver: IRValue?, output result: IRValue
+    referringTo d: DeclarationIdentity, boundTo receiver: IRValue?,
+    markedForMutationBy mutationMarker: Token?,
+    output result: IRValue
   ) -> LoweredCallee {
     switch program.tag(of: d) {
     case EnumCaseDeclaration.self:
@@ -921,13 +944,14 @@ internal struct IREmitter {
         constructor: program.castUnchecked(d, to: EnumCaseDeclaration.self))
       return loweredCallee(referringTo: f, boundTo: receiver, output: result)
 
-    case FunctionDeclaration.self:
+    case FunctionDeclaration.self, VariantDeclaration.self:
       let f = demandLoweredDeclaration(functionOrConformance: d)
       return loweredCallee(referringTo: f, boundTo: receiver, output: result)
 
-    case VariantDeclaration.self:
-      let f = demandLoweredDeclaration(functionOrConformance: d)
-      return loweredCallee(referringTo: f, boundTo: receiver, output: result)
+    case FunctionBundleDeclaration.self:
+      let b = program.castUnchecked(d, to: FunctionBundleDeclaration.self)
+      return loweredCallee(
+        referringTo: b, boundTo: receiver, markedForMutationBy: mutationMarker, output: result)
 
     default:
       program.unexpected(d)
@@ -942,6 +966,34 @@ internal struct IREmitter {
     return LoweredCallee(value: v, arguments: Array(contentsOf: receiver), result: result)
   }
 
+  /// Generates the IR for using `f` as a callee, optionally bound to `receiver`.
+  private mutating func loweredCallee(
+    referringTo f: FunctionBundleDeclaration.ID, boundTo receiver: IRValue?,
+    markedForMutationBy mutationMarker: Token?,
+    output result: IRValue
+  ) -> LoweredCallee {
+    let usedMutably = mutationMarker != nil
+
+    // Is there more than one variant applicable?
+    let ks = program.effects(f).intersection(usedMutably ? .inplace : .functional)
+    if let k = ks.uniqueElement {
+      let v = program.variant(k, of: f)!
+      let f = demandLoweredDeclaration(functionOrConformance: .init(v))
+      return loweredCallee(referringTo: f, boundTo: receiver, output: result)
+    }
+
+    // Otherwise, construct a bundle reference that will be reified later.
+    else {
+      let types = accumulatedGenericParameters(visibleFrom: .init(node: f))
+      let (terms, output) = prototype(function: .init(f), usedMutably: usedMutably)
+
+      let s = IRFunction.Signature(types: types, terms: terms, output: output)
+      let t = program.types.demand(s)
+      let v = IRValue.bundle(f, t, ks)
+      return LoweredCallee(value: v, arguments: Array(contentsOf: receiver), result: result)
+    }
+  }
+
   /// Implements `loweredCallee(_:writingTo)` for new expressions.
   private mutating func loweredCallee(
     _ e: New.ID, output result: IRValue
@@ -949,7 +1001,7 @@ internal struct IREmitter {
     // When the callee is a new expression (e.g., `T.new(x)`), then `result` is passed as the first
     // argument of the underlying initializer. The return type of the initializer is a unit value.
     let r = lowering(e, { (me) in me._alloca(.void) })
-    let f = loweredCallee(program[e].target, output: result)
+    let f = loweredCallee(program[e].target, output: result, markedForMutationBy: nil)
 
     // The qualification may define type arguments.
     let g = if let ts = argumentsFromStaticQualification(program[e].qualification) {
@@ -1262,7 +1314,7 @@ internal struct IREmitter {
       tp.accumulatedGenericParameters(visibleFrom: scopeOfDeclaration)
     }
 
-    let (terms, output) = prototype(d)
+    let (terms, output) = prototype(functionOrConformance: d)
     return program[module].ir.addFunction(
       IRFunction(name: name, output: output, typeParameters: types, termParameters: terms))
   }
@@ -1281,7 +1333,7 @@ internal struct IREmitter {
     if let i = program[module].ir.functions.index(forKey: name) {
       return i
     } else {
-      let (ps, o) = prototype(requirement, applying: arguments)
+      let (ps, o) = prototype(functionOrConformance: requirement, applying: arguments)
       return program[module].ir.addFunction(
         IRFunction(name: name, output: o, typeParameters: [], termParameters: ps))
     }
@@ -1346,12 +1398,12 @@ internal struct IREmitter {
 
   /// Returns the term parameters and return type of `d`'s lowered representation.
   private mutating func prototype(
-    _ d: DeclarationIdentity, applying substitutions: TypeArguments = .init()
+    functionOrConformance d: DeclarationIdentity, applying substitutions: TypeArguments = .init()
   ) -> ([IRParameter], IRFunction.Output) {
     if let n = program.cast(d, to: ConformanceDeclaration.self) {
       return prototype(conformance: n, applying: substitutions)
     } else {
-      return prototype(functionOrVariant: d, applying: substitutions)
+      return prototype(function: d, usedMutably: false, applying: substitutions)
     }
   }
 
@@ -1391,16 +1443,16 @@ internal struct IREmitter {
   /// and captures of `d`, in that order. Type parameters are not included. Those are only lowered
   /// to term parameters in existentialized functions.
   private mutating func prototype(
-    functionOrVariant d: DeclarationIdentity, applying substitutions: TypeArguments = .init()
+    function d: DeclarationIdentity, usedMutably: Bool,
+    applying substitutions: TypeArguments = .init(),
   ) -> ([IRParameter], IRFunction.Output) {
-    assert(program.isInstance(d, of: FunctionDeclaration.self, VariantDeclaration.self))
-
-    let abstraction = program.types.seenAsTermAbstraction(program.type(assignedTo: d))!
+    let typeOfDeclaration = program.types.contextAndHead(program.type(assignedTo: d))
+    let shape = program.types.seenAsTermAbstraction(typeOfDeclaration.head)!
     var terms: [IRParameter] = []
 
     // Parameters of memberwise initializers have no explicit declarations.
     if program.isMemberwiseInitializer(d) {
-      for p in program.types[abstraction].inputs {
+      for p in program.types[shape].inputs {
         let t = program.types.dealiased(p.type)
         let u = program.types.substitute(substitutions, in: t)
         terms.append(IRParameter(type: u, access: p.access, declaration: nil))
@@ -1439,19 +1491,21 @@ internal struct IREmitter {
         let t = program.type(assignedTo: p, assuming: RemoteType.self)
         let u = program.types.dealiased(program.types[t].projectee)
         let v = program.types.substitute(substitutions, in: u)
-        let k = program.types[t].access.unlessAuto(program.types[abstraction].effect)
+        let k = program.types[t].access.unlessAuto(program.types[shape].effect)
+        assert((k != .auto) || program.tag(of: d) == FunctionBundleDeclaration.self)
         terms.append(IRParameter(type: v, access: k, declaration: .init(p)))
       }
     }
 
     // Return register comes last.
-    let r = program.types.dealiased(program.types[abstraction].output)
-    let s = program.types.substitute(substitutions, in: r)
-    if program.types[abstraction].style == .parenthesized {
-      terms.append(IRParameter(type: s, access: .set, declaration: nil))
+    let r = program.types.resultOfApplying(typeOfDeclaration.head, mutably: usedMutably)!
+    let s = program.types.dealiased(r)
+    let t = program.types.substitute(substitutions, in: s)
+    if program.types[shape].style == .parenthesized {
+      terms.append(IRParameter(type: t, access: .set, declaration: nil))
       return (terms, .indirect)
     } else {
-      return (terms, .remote(program.types[abstraction].effect, s))
+      return (terms, .remote(program.types[shape].effect, t))
     }
   }
 
@@ -1706,6 +1760,7 @@ internal struct IREmitter {
 
   /// Inserts an `access` instruction.
   internal mutating func _access(_ k: AccessEffectSet, from source: IRValue) -> IRValue {
+    assert(!k.isEmpty)
     assert(currentFunction.isPlace(source))
     return insert(IRAccess(capabilities: k, source: source, anchor: currentAnchor))!
   }
@@ -1760,10 +1815,7 @@ internal struct IREmitter {
 
     var last = result
     if formAccesses {
-      let parameters = program.types[t].inputs
-      for i in 0 ..< arguments.count {
-        arguments[i] = _access(.init(parameters[i].access), from: arguments[i])
-      }
+      _emitArgumentAccesses(&arguments, toApplyOrProject: callee, typed: t)
       last = _access([.set], from: result)
     }
 
@@ -1860,10 +1912,7 @@ internal struct IREmitter {
     assert(program.types[t].inputs.count == arguments.count)
 
     if formAccesses {
-      let parameters = program.types[t].inputs
-      for i in 0 ..< arguments.count {
-        arguments[i] = _access(.init(parameters[i].access), from: arguments[i])
-      }
+      _emitArgumentAccesses(&arguments, toApplyOrProject: callee, typed: t)
     }
 
     let s = IRProject(
@@ -2214,6 +2263,23 @@ internal struct IREmitter {
     }
   }
 
+  /// Forms an access on each of the lvalues in `arguments`, which are the arguments passed to the
+  /// function `f` that has type `t`.
+  ///
+  /// `f` may have `auto` parameters iff it refers to a bundle. In this case, the effect of the
+  /// variants that may be eventually selected during bundle reification will be used when forming
+  /// an access for an `auto` parameter.
+  private mutating func _emitArgumentAccesses(
+    _ arguments: inout [IRValue], toApplyOrProject f: IRValue, typed t: Arrow.ID
+  ) {
+    let effectsForAuto = if case .bundle(_, _, let k) = f { k } else { AccessEffectSet() }
+    let parameters = program.types[t].inputs
+    for i in 0 ..< arguments.count {
+      let k = AccessEffectSet(parameters[i].access, unlessAuto: effectsForAuto)
+      arguments[i] = _access(k, from: arguments[i])
+    }
+  }
+
   /// Generates the IR for casting `source` to a place of type `target`.
   internal mutating func _emitCast(
     _ source: IRValue, to target: AnyTypeIdentity
@@ -2493,6 +2559,15 @@ internal struct IREmitter {
     }
   }
 
+  /// Returns generic parameters captured by `s` and the scopes semantically containing `s`.
+  private mutating func accumulatedGenericParameters(
+    visibleFrom s: ScopeIdentity
+  ) -> [GenericParameter.ID] {
+    program.withTyper(typing: s.module) { (tp) in
+      tp.accumulatedGenericParameters(visibleFrom: s)
+    }
+  }
+
 }
 
 extension Program {
@@ -2516,6 +2591,8 @@ extension Program {
     of d: DeclarationIdentity
   ) -> ParametersAndCaptures {
     switch tag(of: d) {
+    case FunctionBundleDeclaration.self:
+      return parametersAndCaptures(of: castUnchecked(d, to: FunctionBundleDeclaration.self))
     case FunctionDeclaration.self:
       return parametersAndCaptures(of: castUnchecked(d, to: FunctionDeclaration.self))
     case VariantDeclaration.self:

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -49,6 +49,8 @@ internal struct IREmitter {
       lower(program.castUnchecked(d, to: EnumDeclaration.self))
     case ExtensionDeclaration.self:
       lower(program.castUnchecked(d, to: ExtensionDeclaration.self))
+    case FunctionBundleDeclaration.self:
+      lower(program.castUnchecked(d, to: FunctionBundleDeclaration.self))
     case FunctionDeclaration.self:
       lower(program.castUnchecked(d, to: FunctionDeclaration.self))
     case ImportDeclaration.self:
@@ -311,19 +313,35 @@ internal struct IREmitter {
     }
   }
 
+  /// Generates the IR of variants in `d`.
+  private mutating func lower(_ d: FunctionBundleDeclaration.ID) {
+    for m in program[d].variants {
+      let f = demandLoweredDeclaration(functionOrConformance: .init(m))
+      assert(!program[module].ir[f].isDefined, "function already lowered")
+      defining(f) { (me) in
+        let s = me.program[m].effect.site
+        me.lowerDefinition(me.program[m].body, of: m, introducedAt: s)
+      }
+    }
+  }
+
   /// Generates the IR of `d`.
   private mutating func lower(_ d: FunctionDeclaration.ID) {
     let f = demandLoweredDeclaration(functionOrConformance: .init(d))
     defining(f) { (me) in
-      me.lowerDefinition(d)
+      let s = me.program[d].introducer.site
+      me.lowerDefinition(me.program[d].body, of: d, introducedAt: s)
     }
   }
 
-  /// Generates the body of `d`, assuming the insertion context is configured to generate IR into
-  /// the its lowered form.
-  private mutating func lowerDefinition(_ d: FunctionDeclaration.ID) {
+  /// Generates the definition of `d`, which is introduced at `introducerSite` and whose body is
+  /// `definition`, assuming the insertion context is configured to generate IR into the its
+  /// lowered form of `d`.
+  private mutating func lowerDefinition<T: Declaration & Scope>(
+    _ definition: [StatementIdentity]?, of d: T.ID, introducedAt introducerSite: SourceSpan
+  ) {
     // Is there a body to lower?
-    guard let body = program[d].body else {
+    guard let body = definition else {
       assert(!program.requiresDefinition(.init(d)), "ill-formed syntax")
       // TODO: FFI
       return
@@ -341,14 +359,14 @@ internal struct IREmitter {
       // accessing the storage of a trivially initializable object (e.g., an empty struct).
       if (p.access == .set) && (v != currentFunction.returnRegister) {
         if program.isTriviallyInitializable(p.type, in: .init(node: d)) {
-          lowering(at: program[d].introducer.site, in: .init(node: d)) { (me) in
+          lowering(at: introducerSite, in: .init(node: d)) { (me) in
             me._assume_state(v, initialized: true)
           }
         }
       }
     }
 
-    switch lower(body: body) {
+    switch lower(statements: body) {
     case .return(let r):
       lowering(r, { $0._return() })
 
@@ -392,18 +410,18 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR of `body`, which is the definition of an abstraction.
-  private mutating func lower(body: [StatementIdentity]) -> ControlFlow {
-    for i in body.indices {
-      switch lower(body[i]) {
+  /// Generates the IR each statement in `statements`.
+  private mutating func lower(statements: [StatementIdentity]) -> ControlFlow {
+    for i in statements.indices {
+      switch lower(statements[i]) {
       case .next:
         // Just move to the next instruction.
         continue
 
       case let c:
         // The last statement transferred control flow; we can skip the remaining statements.
-        if (i + 1) < body.count {
-          report(.warning, "code will never be executed", about: body[i + 1])
+        if (i + 1) < statements.count {
+          report(.warning, "code will never be executed", about: statements[i + 1])
         }
         return c
       }
@@ -479,7 +497,7 @@ internal struct IREmitter {
 
   /// Generates the IR of `s`.
   private mutating func lower(_ s: Block.ID) -> ControlFlow {
-    lower(body: program[s].statements)
+    lower(statements: program[s].statements)
   }
 
   /// Generates the IR of `s`.
@@ -898,13 +916,17 @@ internal struct IREmitter {
     referringTo d: DeclarationIdentity, boundTo receiver: IRValue?, output result: IRValue
   ) -> LoweredCallee {
     switch program.tag(of: d) {
+    case EnumCaseDeclaration.self:
+      let f = demandLoweredDeclaration(
+        constructor: program.castUnchecked(d, to: EnumCaseDeclaration.self))
+      return loweredCallee(referringTo: f, boundTo: receiver, output: result)
+
     case FunctionDeclaration.self:
       let f = demandLoweredDeclaration(functionOrConformance: d)
       return loweredCallee(referringTo: f, boundTo: receiver, output: result)
 
-    case EnumCaseDeclaration.self:
-      let f = demandLoweredDeclaration(
-        constructor: program.castUnchecked(d, to: EnumCaseDeclaration.self))
+    case VariantDeclaration.self:
+      let f = demandLoweredDeclaration(functionOrConformance: d)
       return loweredCallee(referringTo: f, boundTo: receiver, output: result)
 
     default:
@@ -1259,8 +1281,7 @@ internal struct IREmitter {
     if let i = program[module].ir.functions.index(forKey: name) {
       return i
     } else {
-      let d = program.castUnchecked(requirement, to: FunctionDeclaration.self)
-      let (ps, o) = prototype(d, applying: arguments)
+      let (ps, o) = prototype(requirement, applying: arguments)
       return program[module].ir.addFunction(
         IRFunction(name: name, output: o, typeParameters: [], termParameters: ps))
     }
@@ -1327,18 +1348,41 @@ internal struct IREmitter {
   private mutating func prototype(
     _ d: DeclarationIdentity, applying substitutions: TypeArguments = .init()
   ) -> ([IRParameter], IRFunction.Output) {
-    switch program.tag(of: d) {
-    case ConformanceDeclaration.self:
-      let n = program.castUnchecked(d, to: ConformanceDeclaration.self)
-      return prototype(n, applying: substitutions)
-
-    case FunctionDeclaration.self:
-      let n = program.castUnchecked(d, to: FunctionDeclaration.self)
-      return prototype(n, applying: substitutions)
-
-    default:
-      program.unexpected(d)
+    if let n = program.cast(d, to: ConformanceDeclaration.self) {
+      return prototype(conformance: n, applying: substitutions)
+    } else {
+      return prototype(functionOrVariant: d, applying: substitutions)
     }
+  }
+
+  /// Returns the term parameters and return type of `d`'s lowered representation.
+  ///
+  /// `d` declares a conformance. The result includes the usings of `d`. If `d` an an abstract
+  /// given (i.e., a given declared as a trait requirement) these usings are preceded by an
+  /// additional parameter accepting an instance of the containing trait.
+  private mutating func prototype(
+    conformance d: ConformanceDeclaration.ID, applying substitutions: TypeArguments = .init()
+  ) -> ([IRParameter], IRFunction.Output) {
+    let witness = program.types.contextAndHead(program.type(assignedTo: d))
+
+    var terms: [IRParameter] = []
+
+    // If the conformance declares an abstract given, accept a witness of conformance of the
+    // enclosing trait.
+    if let enclosure = program.traitRequiring(d) {
+      let s = program.withTyper(typing: module) { (tp) in tp.typeOfTraitSelf(in: enclosure) }
+      let t = program.types.dealiased(s)
+      let u = program.types.substitute(substitutions, in: t)
+      terms.append(IRParameter(type: u, access: .let, declaration: nil))
+    }
+
+    for p in witness.context.usings {
+      let t = program.types.dealiased(p)
+      let u = program.types.substitute(substitutions, in: t)
+      terms.append(IRParameter(type: u, access: .let, declaration: nil))
+    }
+
+    return (terms, .remote(.let, witness.head))
   }
 
   /// Returns the term parameters and return type of `d`'s lowered representation.
@@ -1347,12 +1391,12 @@ internal struct IREmitter {
   /// and captures of `d`, in that order. Type parameters are not included. Those are only lowered
   /// to term parameters in existentialized functions.
   private mutating func prototype(
-    _ d: FunctionDeclaration.ID, applying substitutions: TypeArguments = .init()
+    functionOrVariant d: DeclarationIdentity, applying substitutions: TypeArguments = .init()
   ) -> ([IRParameter], IRFunction.Output) {
+    assert(program.isInstance(d, of: FunctionDeclaration.self, VariantDeclaration.self))
+
     let abstraction = program.types.seenAsTermAbstraction(program.type(assignedTo: d))!
     var terms: [IRParameter] = []
-
-    precondition(program.tag(of: d) == FunctionDeclaration.self, "TODO")
 
     // Parameters of memberwise initializers have no explicit declarations.
     if program.isMemberwiseInitializer(d) {
@@ -1395,7 +1439,8 @@ internal struct IREmitter {
         let t = program.type(assignedTo: p, assuming: RemoteType.self)
         let u = program.types.dealiased(program.types[t].projectee)
         let v = program.types.substitute(substitutions, in: u)
-        terms.append(IRParameter(type: v, access: program.types[t].access, declaration: .init(p)))
+        let k = program.types[t].access.unlessAuto(program.types[abstraction].effect)
+        terms.append(IRParameter(type: v, access: k, declaration: .init(p)))
       }
     }
 
@@ -1408,36 +1453,6 @@ internal struct IREmitter {
     } else {
       return (terms, .remote(program.types[abstraction].effect, s))
     }
-  }
-
-  /// Returns the term parameters and return type of `d`'s lowered representation.
-  ///
-  /// `d` declares a conformance. The result includes the usings of `d`. If `d` an an abstract
-  /// given (i.e., a given declared as a trait requirement) these usings are preceded by an
-  /// additional parameter accepting an instance of the containing trait.
-  private mutating func prototype(
-    _ d: ConformanceDeclaration.ID, applying substitutions: TypeArguments = .init()
-  ) -> ([IRParameter], IRFunction.Output) {
-    let witness = program.types.contextAndHead(program.type(assignedTo: d))
-
-    var terms: [IRParameter] = []
-
-    // If the conformance declares an abstract given, accept a witness of conformance of the
-    // enclosing trait.
-    if let enclosure = program.traitRequiring(d) {
-      let s = program.withTyper(typing: module) { (tp) in tp.typeOfTraitSelf(in: enclosure) }
-      let t = program.types.dealiased(s)
-      let u = program.types.substitute(substitutions, in: t)
-      terms.append(IRParameter(type: u, access: .let, declaration: nil))
-    }
-
-    for p in witness.context.usings {
-      let t = program.types.dealiased(p)
-      let u = program.types.substitute(substitutions, in: t)
-      terms.append(IRParameter(type: u, access: .let, declaration: nil))
-    }
-
-    return (terms, .remote(.let, witness.head))
   }
 
   // MARK: Context
@@ -2084,6 +2099,9 @@ internal struct IREmitter {
     case .typeApplication(let f, let a):
       let x0 = _emit(witness: f)
       result = _type_apply(x0, to: a)
+    case .abstract:
+      assert(w.type == currentFunction.result(of: .parameter(0))?.type)
+      result = .parameter(0)
     default:
       fatalError()
     }

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -196,7 +196,8 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR of the subscript that projects the witness declared by `d`.
+  /// Generates the IR of the subscript that projects the witness declared by `d`, assuming the
+  /// insertion context is configured to generate IR into the its lowered form.
   private mutating func lowerDefinition(_ d: ConformanceDeclaration.ID) {
     insertionContext.anchor = .init(site: program[d].introducer.site, scope: .init(node: d))
     let (_, w) = currentFunction.output.remote!
@@ -312,14 +313,15 @@ internal struct IREmitter {
 
   /// Generates the IR of `d`.
   private mutating func lower(_ d: FunctionDeclaration.ID) {
-    withClearContext({ (me) in me.lowerInClearContext(d) })
+    let f = demandLoweredDeclaration(functionOrConformance: .init(d))
+    defining(f) { (me) in
+      me.lowerDefinition(d)
+    }
   }
 
-  /// Generates the IR of `d` assuming the insertion context is clear.
-  private mutating func lowerInClearContext(_ d: FunctionDeclaration.ID) {
-    let f = demandLoweredDeclaration(functionOrConformance: .init(d))
-    assert(!program[module].ir[f].isDefined, "function already lowered")
-
+  /// Generates the body of `d`, assuming the insertion context is configured to generate IR into
+  /// the its lowered form.
+  private mutating func lowerDefinition(_ d: FunctionDeclaration.ID) {
     // Is there a body to lower?
     guard let body = program[d].body else {
       assert(!program.requiresDefinition(.init(d)), "ill-formed syntax")
@@ -327,10 +329,7 @@ internal struct IREmitter {
       return
     }
 
-    // Lower the function's definition.
-    insertionContext.function = program[module].ir[f]
-    insertionContext.point = .end(of: insertionContext.function!.addBlock())
-    for (i, p) in insertionContext.function!.termParameters.enumerated() {
+    for (i, p) in currentFunction.termParameters.enumerated() {
       let v = IRValue.parameter(i)
 
       // Configure the base frame with the function's parameters.
@@ -340,7 +339,7 @@ internal struct IREmitter {
 
       // Assume `p` is initialized if it's a `set` parameter other than the return register
       // accessing the storage of a trivially initializable object (e.g., an empty struct).
-      if (p.access == .set) && (v != insertionContext.function!.returnRegister) {
+      if (p.access == .set) && (v != currentFunction.returnRegister) {
         if program.isTriviallyInitializable(p.type, in: .init(node: d)) {
           lowering(at: program[d].introducer.site, in: .init(node: d)) { (me) in
             me._assume_state(v, initialized: true)
@@ -366,8 +365,6 @@ internal struct IREmitter {
         me._return()
       })
     }
-
-    program[module].ir[f] = insertionContext.function.sink()
   }
 
   /// Generates the IR of the members in `d`.

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -83,6 +83,20 @@ public struct IRFunction: Sendable {
     /// The types of the term parameters and return value.
     public let head: Arrow
 
+    /// Creates the signature of a function accepting the given parameters and returning results
+    /// as described by `output`.
+    public init(types: [GenericParameter.ID], terms: [IRParameter], output: Output) {
+      self.context = types
+
+      let ps = terms.map({ (p) in Parameter(access: p.access, type: p.type) })
+      switch output {
+      case .indirect:
+        self.head = Arrow(style: .parenthesized, inputs: ps.dropLast(), output: ps.last!.type)
+      case .remote(let k, let o):
+        self.head = Arrow(style: .bracketed, effect: k, inputs: ps, output: o.erased)
+      }
+    }
+
   }
 
   /// The name of the function.
@@ -228,17 +242,7 @@ public struct IRFunction: Sendable {
 
   /// Returns the type of `self`, computing it using `p`.
   public func signature() -> Signature {
-    let ps = termParameters.map({ (p) in Parameter(access: p.access, type: p.type) })
-
-    var a: Arrow
-    switch output {
-    case .indirect:
-      a = Arrow(style: .parenthesized, inputs: Array(ps.dropLast()), output: ps.last!.type)
-    case .remote(let k, let o):
-      a = Arrow(style: .bracketed, effect: k, inputs: ps, output: o.erased)
-    }
-
-    return .init(context: typeParameters, head: a)
+    .init(types: typeParameters, terms: termParameters, output: output)
   }
 
   /// Returns the tag of `i`.
@@ -379,6 +383,8 @@ public struct IRFunction: Sendable {
     case .floatingPoint(_, let t):
       return (t.erased, false)
     case .function(_, let t):
+      return (t, true)
+    case .bundle(_, let t, _):
       return (t, true)
     case .type(_, let t):
       return (t.erased, false)

--- a/Sources/FrontEnd/IR/IRValue.swift
+++ b/Sources/FrontEnd/IR/IRValue.swift
@@ -21,6 +21,9 @@ public enum IRValue: Hashable, Sendable {
   /// A reference to a lowered function.
   indirect case function(IRFunction.Name, AnyTypeIdentity)
 
+  /// A reference to a function or subscript bundle not yet reified.
+  indirect case bundle(FunctionBundleDeclaration.ID, AnyTypeIdentity, AccessEffectSet)
+
   /// A type witness.
   indirect case type(AnyTypeIdentity, TypeWitness.ID)
 
@@ -81,6 +84,8 @@ extension IRValue: Showable {
       return "\(printer.show(t)) \(n)"
     case .function(let n, _):
       return printer.show(n)
+    case .bundle(let n, _, let k):
+      return "\(printer.program.debugName(of: .init(n)))@{\(list: k)}"
     case .type(let t, _):
       return printer.show(t)
     case .poison:

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -731,9 +731,15 @@ public struct Program: Sendable {
     var ts: [AssociatedTypeDeclaration.ID] = []
     var ms: [DeclarationIdentity] = .init(minimumCapacity: self[concept].members.count)
     for m in self[concept].members {
-      if let a = cast(m, to: AssociatedTypeDeclaration.self) {
-        ts.append(a)
-      } else {
+      switch tag(of: m) {
+      case AssociatedTypeDeclaration.self:
+        ts.append(castUnchecked(m))
+
+      case FunctionBundleDeclaration.self:
+        let b = castUnchecked(m, to: FunctionBundleDeclaration.self)
+        ms.append(contentsOf: self[b].variants.map(DeclarationIdentity.init(_:)))
+
+      default:
         ms.append(m)
       }
     }

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1469,7 +1469,7 @@ extension Program {
     /// `Hylo.Deinitializable`.
     case deinitializable = "Deinitializable"
 
-    /// `Hyloe.Deinitializable.deinit`.
+    /// `Hylo.Deinitializable.deinit`.
     case deinitializableDeinit = "Deinitializable.deinit(:)"
 
     /// `Hylo.Equatable`.

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1250,10 +1250,26 @@ public struct Program: Sendable {
   /// does not declare a bundle or `d` does not contain such a variant.
   public func variant(_ k: AccessEffect, of d: DeclarationIdentity) -> VariantDeclaration.ID? {
     if let b = cast(d, to: FunctionBundleDeclaration.self) {
-      return self[b].variants.first(where: { (v) in self[v].effect.value == k })
+      return variant(k, of: b)
     } else {
       return nil
     }
+  }
+
+  /// Returns the declaration of the variant with effect `k` in the bundle `d`, if any.
+  public func variant(
+    _ k: AccessEffect, of d: FunctionBundleDeclaration.ID
+  ) -> VariantDeclaration.ID? {
+    self[d].variants.first(where: { (v) in self[v].effect.value == k })
+  }
+
+  /// Returns the call effects of variants declared in `d`.
+  public func effects(_ d: FunctionBundleDeclaration.ID) -> AccessEffectSet {
+    var s = AccessEffectSet()
+    for v in self[d].variants {
+      s.insert(self[v].effect.value)
+    }
+    return s
   }
 
   /// Returns the annotations applied to `n`.

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -261,6 +261,12 @@ public struct Program: Sendable {
     modules.values[n.module].tag(of: n)
   }
 
+  /// Returns `true` iff `n` identities an instance of one of the types in `ts`.
+  public func isInstance<T: SyntaxIdentity>(_ n: T, of ts: any Syntax.Type...) -> Bool {
+    let lhs = tag(of: n)
+    return ts.contains(where: { (rhs) in lhs == rhs })
+  }
+
   /// `true` iff `f` has gone through scoping.
   public func isScoped(_ f: SourceFile.ID) -> Bool {
     self[f].syntaxToParent.count == self[f].syntax.count

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -261,12 +261,6 @@ public struct Program: Sendable {
     modules.values[n.module].tag(of: n)
   }
 
-  /// Returns `true` iff `n` identities an instance of one of the types in `ts`.
-  public func isInstance<T: SyntaxIdentity>(_ n: T, of ts: any Syntax.Type...) -> Bool {
-    let lhs = tag(of: n)
-    return ts.contains(where: { (rhs) in lhs == rhs })
-  }
-
   /// `true` iff `f` has gone through scoping.
   public func isScoped(_ f: SourceFile.ID) -> Bool {
     self[f].syntaxToParent.count == self[f].syntax.count

--- a/Sources/FrontEnd/Syntax/AccessEffect.swift
+++ b/Sources/FrontEnd/Syntax/AccessEffect.swift
@@ -39,6 +39,12 @@ public enum AccessEffect: UInt8, Sendable {
     (self == .inout) || (self == .set)
   }
 
+  /// Returns `self` iff `self` is not `auto`; otherwise, returns `k`, which is not `auto`.
+  public func unlessAuto(_ k: AccessEffect) -> AccessEffect {
+    assert(k != .auto)
+    return self != .auto ? self : k
+  }
+
 }
 
 extension AccessEffect: Comparable {

--- a/Sources/FrontEnd/Syntax/AccessEffect.swift
+++ b/Sources/FrontEnd/Syntax/AccessEffect.swift
@@ -39,10 +39,9 @@ public enum AccessEffect: UInt8, Sendable {
     (self == .inout) || (self == .set)
   }
 
-  /// Returns `self` iff `self` is not `auto`; otherwise, returns `k`, which is not `auto`.
+  /// Returns `self` iff `self` is not `auto`; otherwise, returns `k`.
   public func unlessAuto(_ k: AccessEffect) -> AccessEffect {
-    assert(k != .auto)
-    return self != .auto ? self : k
+    self != .auto ? self : k
   }
 
 }

--- a/Sources/FrontEnd/Syntax/AccessEffectSet.swift
+++ b/Sources/FrontEnd/Syntax/AccessEffectSet.swift
@@ -18,9 +18,18 @@ public struct AccessEffectSet: Hashable, Sendable {
     self.rawValue = rawValue
   }
 
-  /// Creates an instance containing `k`.
+  /// Creates a singleton containing `k`.
   public init(_ k: AccessEffect) {
     self.rawValue = k.rawValue
+  }
+
+  /// Creates a singleton containing `k` iff it is not `auto`; otherwise, creates a copy of `s`.
+  public init(_ k: AccessEffect, unlessAuto s: AccessEffectSet) {
+    if (k != .auto) {
+      self.init(k)
+    } else {
+      self = s
+    }
   }
 
   /// `true` iff `self` contains no effect.

--- a/Sources/FrontEnd/Syntax/WitnessExpression.swift
+++ b/Sources/FrontEnd/Syntax/WitnessExpression.swift
@@ -11,7 +11,7 @@ public struct WitnessExpression: Hashable, Sendable {
     /// An existing term.
     case identity(ExpressionIdentity)
 
-    /// An abstract given.
+    /// A reference to the witness being declared by a conformance.
     case abstract
 
     /// An instance of a structural conformance synthesized by the compiler.

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -428,17 +428,9 @@ public struct Typer {
             to: program.castUnchecked(r, to: ConformanceDeclaration.self))
         }
 
-      case FunctionDeclaration.self:
+      case FunctionDeclaration.self, VariantDeclaration.self:
         if let i = namedImplementation(of: r) {
           implementations.assign(i, to: r)
-        }
-
-      case FunctionBundleDeclaration.self:
-        let b = program.castUnchecked(r, to: FunctionBundleDeclaration.self)
-        for v in program[b].variants {
-          if let i = namedImplementation(of: .init(v)) {
-            implementations.assign(i, to: r)
-          }
         }
 
       default:

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -1269,13 +1269,12 @@ public struct Typer {
     assert(d.module == module, "dependency is not typed")
 
     initializeContext(program[d].contextParameters)
-    let variants = AccessEffectSet(program[d].variants.map({ (v) in program[v].effect.value }))
     let inputs = declaredTypes(of: program[d].parameters)
     let arrow = declaredArrowType(of: d, taking: inputs)
 
     let (context, head) = program.types.contextAndHead(arrow)
     let shape = program.types.cast(head, to: Arrow.self)!
-    let bundle = demand(Bundle(shape: shape, variants: variants)).erased
+    let bundle = demand(Bundle(shape: shape, variants: program.effects(d))).erased
     let result = program.types.introduce(context, into: bundle)
 
     program[d.module].setType(result, for: d)

--- a/Tests/CompilerTests/positive/bundle-application.hylo
+++ b/Tests/CompilerTests/positive/bundle-application.hylo
@@ -1,0 +1,22 @@
+//! stage:lowering
+
+struct A is Deinitializable & Movable {
+
+  public memberwise init
+
+  public fun f() auto {
+    let   { (A(), ()) }
+    inout { () }
+  }
+
+}
+
+public fun main() {
+  var a = A()
+
+  // Applies the `inout` variant.
+  _ = &a.f()
+
+  // Applies the `let` variant.
+  let (_, _) : {A, Void} = a.f()
+}


### PR DESCRIPTION
This patch implements IR lowering for function and subscript bundles.

The feature is incomplete. In particular, this set of changes does not include access reification, which is necessary to support bundles featuring a `let` variant along with a `sink` one and/or a `set` variant along with an `inout` one.