### PR TITLE
Fix testing on Xcode

### DIFF
--- a/Sources/BackEnd/LLVM/CodeGenerationContext.swift
+++ b/Sources/BackEnd/LLVM/CodeGenerationContext.swift
@@ -7,7 +7,9 @@ extension Program {
   /// Compiles the IR of `m` for target `t`.
   ///
   /// - Requires: `m` has been lowered and all required passes have been run.
-  public func compileToLLVM(_ m: FrontEnd.Module.ID, target t: consuming TargetMachine) throws -> SwiftyLLVM.Module {
+  public func compileToLLVM(
+    _ m: FrontEnd.Module.ID, target t: consuming TargetMachine
+  ) throws -> SwiftyLLVM.Module {
     var llvm = try SwiftyLLVM.Module("MainModule", targetMachine: t)
 
     // FIXME: Emitting trivial main function for now. Replace with actual code generation.

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -138,7 +138,7 @@ public struct Driver {
   /// - Requires:
   ///   - `module` has been lowered and all required transformation passes have been run.
   ///   - `module` has not been lowered to LLVM IR yet.
-  public mutating func lowerToLLVM(_ module: Module.ID) throws -> PhaseResult {
+  public mutating func compileToLLVM(_ module: Module.ID) throws -> PhaseResult {
     precondition(
       llvmModules[module] == nil, "LLVM IR already generated for '\(moduleName(module))'")
 

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -45,9 +45,7 @@ public struct Driver {
   /// The program being compiled by the driver.
   public var program: Program
 
-  /// The corresponding LLVM module for each Hylo module.
-  ///
-  /// Populated by `lowerToLLVM(_:)`.
+  /// A map from a Hylo module to its corresponding LLVM module, populated by `lowerToLLVM(_:)`.
   private var llvmModules: [Module.ID: LLVMModuleBox] = [:]
 
   /// Creates an instance with the given properties.
@@ -141,31 +139,24 @@ public struct Driver {
   ///   - `module` has been lowered and all required transformation passes have been run.
   ///   - `module` has not been lowered to LLVM IR yet.
   public mutating func lowerToLLVM(_ module: Module.ID) throws -> PhaseResult {
-    precondition(llvmModules[module] == nil,
-      "LLVM code is already generated for module \(moduleName(module))")
+    precondition(
+      llvmModules[module] == nil, "LLVM IR already generated for '\(moduleName(module))'")
 
     let elapsed = try ContinuousClock().measure {
-      var m = try program.compileToLLVM(
-        module,
-        target: TargetMachine(
-          target: target, optimization: optimization, relocation: relocation, codeModel: codeModel))
+      let t = TargetMachine(
+        target: target, optimization: optimization, relocation: relocation, codeModel: codeModel)
+      var m = try program.compileToLLVM(module, target: t)
 
-      #if DEBUG
-        try m.verify()
-      #endif
-
+      try m.verifyInDebugBuilds()
       m.runDefaultModulePasses()
-
-      #if DEBUG
-        try m.verify()
-      #endif
+      try m.verifyInDebugBuilds()
 
       llvmModules[module] = LLVMModuleBox(consume m)
     }
     return .init(elapsed: elapsed, containsError: program[module].containsError)
   }
 
-  /// Generates executable from `module`, linking the standard library unless `noStandardLibrary` is true.
+  /// Generates an executable from `module` and its dependencies.
   ///
   /// - Requires: `module` has been lowered to LLVM.
   /// - Throws: if the parent folder of `output` doesn't exist.
@@ -182,8 +173,8 @@ public struct Driver {
         // modulesToLink.append(program.modules[.standardLibrary]!.identity)
       }
 
-      try FileManager.default.withUniqueTemporaryDirectory { objectDirectory in
-        let objects = try writeObjectFiles(for: modulesToLink, into: objectDirectory)
+      try FileManager.default.withUniqueTemporaryDirectory { (d) in
+        let objects = try writeObjectFiles(for: modulesToLink, into: d)
         try linkExecutable(from: objects, writingTo: output)
       }
     }
@@ -211,12 +202,11 @@ public struct Driver {
   public func writeObjectFiles(
     for modules: [Module.ID], into destinationDirectory: URL
   ) throws -> [URL] {
-    let objectFiles = try modules.map { (module) in
-      let object = destinationDirectory.appendingPathComponent(moduleName(module) + ".o", isDirectory: false)
-      try llvmModules[module]!.module.write(.objectFile, to: object.path)
-      return object
+    try modules.map { (m) in
+      let o = destinationDirectory.appendingPathComponent(moduleName(m) + ".o", isDirectory: false)
+      try llvmModules[m]!.module.write(.objectFile, to: o.path)
+      return o
     }
-    return objectFiles
   }
 
   /// Loads `module`, whose sources are in `root`, into `program`.
@@ -250,7 +240,8 @@ public struct Driver {
       let m = """
         Failed to parse module archive of '\(module)' at '\(moduleCachePath, default: "nil")'.
 
-        Maybe the archive is compiled using a different version of the compiler. Try erasing the module cache.
+        Maybe the archive is compiled using a different version of the compiler.
+        Try erasing the module cache.
         """
       throw Error(message: m)
     }
@@ -276,8 +267,8 @@ public struct Driver {
 
   /// Loads the standard library with `load(_:withSourcesAt:)`.
   /// 
-  /// Use the `USE_BUNDLED_STANDARD_LIBRARY` compiler flag to control whether the 
-  /// bundled or local standard library is used. Defaults to local.
+  /// Use the `USE_BUNDLED_STANDARD_LIBRARY` compiler flag to control whether the  bundled or local
+  /// standard library is used. Defaults to local.
   public mutating func loadStandardLibrary() async throws {
     let sourceRoot: URL
     #if USE_BUNDLED_STANDARD_LIBRARY // Set compiler flag in distributable builds.
@@ -315,13 +306,14 @@ public struct Driver {
     arguments += objectFiles.map(\.path)
 
     #if os(macOS)
-    let sdk = try Process.executionOutput(
-      try Host.findNativeExecutable(invokedAs: "xcrun"), arguments: ["--sdk", "macosx", "--show-sdk-path"])
+    let xcrun = try Host.findNativeExecutable(invokedAs: "xcrun")
+    let sdk = try Process.executionOutput(xcrun, arguments: ["--sdk", "macosx", "--show-sdk-path"])
       .trimmingCharacters(in: .whitespacesAndNewlines)
     arguments += ["-isysroot", sdk, "-lSystem"]
     #endif
 
-    _ = try Process.executionOutput(try Host.findNativeExecutable(invokedAs: "clang"), arguments: arguments)
+    let clang = try Host.findNativeExecutable(invokedAs: "clang")
+    _ = try Process.executionOutput(clang, arguments: arguments)
   }
 
   /// The name of `module`.
@@ -374,6 +366,17 @@ public struct Driver {
       self.containsError = containsError
     }
 
+  }
+
+}
+
+extension SwiftyLLVM.Module {
+
+  /// Verifies the IR is `self` if this function has been compiled in debug mode.
+  fileprivate func verifyInDebugBuilds() throws {
+    var isDebug = false
+    assert({ isDebug = true ; return isDebug }())
+    if isDebug { try self.verify() }
   }
 
 }

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -240,7 +240,7 @@ public struct Driver {
       let m = """
         Failed to parse module archive of '\(module)' at '\(moduleCachePath, default: "nil")'.
 
-        Maybe the archive is compiled using a different version of the compiler.
+        Maybe the archive was compiled with a different version of the compiler. \
         Try erasing the module cache.
         """
       throw Error(message: m)

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -300,7 +300,7 @@ public struct Driver {
   ///
   /// - Throws: if the parent folder of `output` doesn't exist.
   private func linkExecutable(from objectFiles: [URL], writingTo output: URL) throws {
-    var arguments = ["-fuse-ld=lld", "-o", output.path]
+    var arguments = ["-o", output.path]
     arguments += librarySearchPaths.map({ "-L\($0.path)" })
     arguments += librariesToLink.map({ "-l\($0)" })
     arguments += objectFiles.map(\.path)

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -372,7 +372,7 @@ public struct Driver {
 
 extension SwiftyLLVM.Module {
 
-  /// Verifies the IR is `self` if this function has been compiled in debug mode.
+  /// Verifies the IR in `self` iff this function has been compiled in debug mode.
   fileprivate func verifyInDebugBuilds() throws {
     var isDebug = false
     assert({ isDebug = true ; return isDebug }())

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -183,7 +183,7 @@ private typealias Module = FrontEnd.Module
       let a = try driver.program.archive(module: module)
       note("module archive size: \(a.count)")
 
-      try await perform("code generation", for: module, { try driver.lowerToLLVM(module) })
+      try await perform("code generation", for: module, { try driver.compileToLLVM(module) })
       if outputType == .llvm {
         try emitLLVM(module, from: driver, name: product)
         return

--- a/Tests/BackEndTests/SimpleFunctionEmitterTest.swift
+++ b/Tests/BackEndTests/SimpleFunctionEmitterTest.swift
@@ -24,6 +24,7 @@ final class SimpleFunctionEmitterTest: XCTestCase {
 
     // LLVM Lowering.
     if (try driver.lowerToLLVM(m)).containsError { return XCTFail("Failed to lower to LLVM") }
+
     XCTAssertEqual(
       driver.llvmIR(of: m),
       """
@@ -37,15 +38,13 @@ final class SimpleFunctionEmitterTest: XCTestCase {
       """)
 
     XCTAssertTrue(try driver.assembly(of: m).contains("main:"))
-    
-    let outputDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
-      UUID().uuidString, isDirectory: true)
-    try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: false)
 
-    let executable = outputDirectory.appendingPathComponent(driver.program[m].name)
-    _ = try driver.generateExecutable(from: m, writingTo: executable)
+    let output = try FileManager.default.withUniqueTemporaryDirectory { (d) in
+      let executable = d.appendingPathComponent(driver.program[m].name)
+      _ = try driver.generateExecutable(from: m, writingTo: executable)
+      return try Process.executionOutput(executable)
+    }
 
-    let output = try Process.executionOutput(executable)
     XCTAssertEqual(output.trimming(while: \.isWhitespace), "")
   }
 

--- a/Tests/BackEndTests/SimpleFunctionEmitterTest.swift
+++ b/Tests/BackEndTests/SimpleFunctionEmitterTest.swift
@@ -23,7 +23,7 @@ final class SimpleFunctionEmitterTest: XCTestCase {
     if t.containsError { return XCTFail("Failed to apply transformation passes") }
 
     // LLVM Lowering.
-    if (try driver.lowerToLLVM(m)).containsError { return XCTFail("Failed to lower to LLVM") }
+    if (try driver.compileToLLVM(m)).containsError { return XCTFail("Failed to lower to LLVM") }
 
     XCTAssertEqual(
       driver.llvmIR(of: m),

--- a/Tests/CompilerTests/CompilerTests.swift
+++ b/Tests/CompilerTests/CompilerTests.swift
@@ -4,7 +4,6 @@ import FrontEnd
 import StandardLibrary
 import Utilities
 import XCTest
-typealias Host = Utilities.Host
 
 /// The driver for generated compiler tests.
 ///
@@ -13,8 +12,7 @@ typealias Host = Utilities.Host
 /// manually invoking `hc-tests`.
 final class CompilerTests: XCTestCase {
 
-  /// Iff true, intermediate compilation artifacts are saved even if test cases pass.
-  let alwaysSaveArtifacts = false
+  private typealias Host = Utilities.Host
 
   /// The input of a compiler test.
   struct TestDescription {
@@ -47,8 +45,8 @@ final class CompilerTests: XCTestCase {
 
     /// Returns where to save test-case level observations with `tag`.
     ///
-    /// Package-based tests save observations at "<package-root>/<tag>.observed" while
-    /// single-file tests save observations at "<source-file>.<tag>.observed".
+    /// Package-based tests save observations at "<package-root>/<tag>.observed" while single-file
+    /// tests save observations at "<source-file>.<tag>.observed".
     ///
     /// - Requires: `tag` is a valid file name on all supported operating systems.
     func testCaseLevelObservationDestination(tag: String) throws -> URL {
@@ -61,40 +59,23 @@ final class CompilerTests: XCTestCase {
 
     /// Returns where to save the generated executable upon failure.
     func executableDestination() -> URL {
+      let suffix = Host.nativeExecutableSuffix
       if isPackage {
-        root.appending(component: ".executable\(Host.nativeExecutableSuffix)")
+        return root.appending(component: ".executable\(suffix)")
       } else {
-        root.deletingPathExtension().appendingPathExtension("executable\(Host.nativeExecutableSuffix)")
+        return root.deletingPathExtension().appendingPathExtension("executable\(suffix)")
       }
     }
 
-    /// Saves `contents` into a file at its test-case level observation destination
-    /// as specified by `testCaseLevelObservationDestination(tag:)`.
+    /// Saves `contents` into a file at its test-case level observation destination as specified by
+    /// `testCaseLevelObservationDestination(tag:)`.
     ///
     /// - Requires: `tag` is a valid file name on all supported operating systems.
     func saveTestCaseLevelObservation(_ contents: String, tag: String) throws {
-      try contents.write(to: testCaseLevelObservationDestination(tag: tag), atomically: true, encoding: .utf8)
+      let destination = try testCaseLevelObservationDestination(tag: tag)
+      try contents.write(to: destination, atomically: true, encoding: .utf8)
     }
 
-  }
-
-  /// A temporary folder for caching compilation artifacts during testing.
-  ///
-  /// An new directory is generated every time this property is initialized and removed once all
-  /// tests have run.
-  private static let moduleCachePath: (url: URL, delete: @Sendable () -> Void) = {
-    let m = FileManager.default
-    let u = try! m.url(
-      for: .itemReplacementDirectory,
-      in: .userDomainMask,
-      appropriateFor: m.currentDirectoryURL,
-      create: true)
-    return (u, { try? FileManager.default.removeItem(at: u) })
-  }()
-
-  /// Deletes cached compilation artifacts.
-  override class func tearDown() {
-    moduleCachePath.delete()
   }
 
   /// The intermediate artifacts of a module's compilation.
@@ -134,30 +115,6 @@ final class CompilerTests: XCTestCase {
 
   }
 
-  /// Whether the test case has recorded any failures or uncaught exceptions.
-  var testFailed: Bool {
-    if let testRun, testRun.totalFailureCount > 0 { true } else { false }
-  }
-
-  /// The test case currently being run.
-  private var testCase: TestDescription? = nil
-
-  /// The intermediate compilation artifacts.
-  private var artifacts: Artifacts = .init()
-
-  /// Saves any available compilation artifacts on test failure
-  /// or if `alwaysSaveArtifacts` is true to facilitate diagnosis.
-  func saveArtifactsIfNeeded() throws {
-    if testFailed || alwaysSaveArtifacts, let testCase {
-      try artifacts.save(into: testCase)
-    }
-  }
-
-  /// Run by XCTest after each test case.
-  override func tearDownWithError() throws {
-    try saveArtifactsIfNeeded()
-  }
-
   /// The result of a successful compilation.
   private struct CompilationResult {
 
@@ -170,6 +127,77 @@ final class CompilerTests: XCTestCase {
     /// The expected diagnostics for each source file.
     let expectedDiagnostics: [FileName: String]
 
+  }
+
+  /// An error thrown to signal test failure with given reason.
+  private enum TestFailure: Error {
+
+    /// The test failed because an executable could not be located.
+    case missingExecutableOutput
+
+    /// The test failed because of a compilation error.
+    case compilationError(String)
+
+    /// The test failed because its description was invalid.
+    case invalidTestDescription(String)
+
+    var localizedDescription: String {
+      switch self {
+      case .missingExecutableOutput:
+        return "missing executable output"
+      case .compilationError(let message):
+        return "Compilation failure:\n\(message)"
+      case .invalidTestDescription(let d):
+        return "Invalid test description (\(d))"
+      }
+    }
+
+  }
+
+  /// A temporary folder for caching compilation artifacts during testing.
+  ///
+  /// An new directory is generated every time this property is initialized and removed once all
+  /// tests have run.
+  private static let moduleCachePath: (url: URL, delete: @Sendable () -> Void) = {
+    let m = FileManager.default
+    let u = try! m.url(
+      for: .itemReplacementDirectory,
+      in: .userDomainMask,
+      appropriateFor: m.currentDirectoryURL,
+      create: true)
+    return (u, { try? FileManager.default.removeItem(at: u) })
+  }()
+
+  /// `true` iff intermediate compilation artifacts must be saved for successful tests.
+  private let artifactsAreSavedOnSuccess: Bool = false
+
+  /// The test case currently being run.
+  private var testCase: TestDescription? = nil
+
+  /// The intermediate compilation artifacts.
+  private var artifacts: Artifacts = .init()
+
+  /// `true` iff the test case has recorded a failure or an uncaught exception.
+  private var testFailed: Bool {
+    (testRun?.totalFailureCount ?? 0) > 0
+  }
+
+  /// Deletes cached compilation artifacts.
+  override class func tearDown() {
+    moduleCachePath.delete()
+  }
+
+  /// Run by XCTest after each test case.
+  override func tearDownWithError() throws {
+    try saveArtifactsIfNeeded()
+  }
+
+  /// Saves any available compilation artifacts on test failure or if `artifactsAreSavedOnSuccess`
+  /// is `true` to facilitate diagnosis.
+  private func saveArtifactsIfNeeded() throws {
+    if testFailed || artifactsAreSavedOnSuccess, let c = testCase {
+      try artifacts.save(into: c)
+    }
   }
 
   /// Compiles `input` expecting no compilation error.
@@ -186,7 +214,8 @@ final class CompilerTests: XCTestCase {
   func negative(_ input: TestDescription) async throws {
     do {
       let r = try await compile(input)
-      XCTAssert(r.driver.program.containsError, "program compiled but an error was expected.\nSource: \(input.root.path)\n")
+      let m = "program compiled but an error was expected.\nSource: \(input.root.path)\n"
+      XCTAssert(r.driver.program.containsError, m)
       assertExpectations(r.expectedDiagnostics, r.driver.program.diagnostics)
     } catch let error as TestFailure {
       XCTFail(error.localizedDescription + "\nSource: \(input.root.path)\n")
@@ -199,7 +228,8 @@ final class CompilerTests: XCTestCase {
   private func compile(_ input: TestDescription) async throws -> CompilationResult {
     self.testCase = input
 
-    var driver = try Driver(moduleCachePath: CompilerTests.moduleCachePath.url, targetSpecification: .native())
+    var driver = try Driver(
+      moduleCachePath: CompilerTests.moduleCachePath.url, targetSpecification: .native())
 
     if input.manifest.requiresStandardLibrary {
       try await driver.loadStandardLibrary()
@@ -269,26 +299,6 @@ final class CompilerTests: XCTestCase {
     }
 
     return done()
-  }
-
-  /// An error thrown to signal test failure with given reason.
-  private enum TestFailure: Error {
-
-    case missingExecutableOutput
-    case compilationError(String)
-    case invalidTestDescription(String)
-
-    var localizedDescription: String {
-      switch self {
-      case .missingExecutableOutput:
-        return "missing executable output"
-      case .compilationError(let message):
-        return "Compilation failure:\n\(message)"
-      case .invalidTestDescription(let d):
-        return "Invalid test description (\(d))"
-      }
-    }
-
   }
 
   /// Asserts that the expected `diagnostics` of each source file in `expectations` match those

--- a/Tests/CompilerTests/CompilerTests.swift
+++ b/Tests/CompilerTests/CompilerTests.swift
@@ -278,7 +278,7 @@ final class CompilerTests: XCTestCase {
     if input.manifest.stage == .lowering { return done() }
 
     // LLVM Lowering.
-    if (try driver.lowerToLLVM(m)).containsError { return done() }
+    if (try driver.compileToLLVM(m)).containsError { return done() }
     artifacts.llvmIR = driver.llvmIR(of: m)!
     if input.manifest.stage == .llvmLowering { return done() }
 

--- a/Tests/CompilerTests/DriverTests.swift
+++ b/Tests/CompilerTests/DriverTests.swift
@@ -62,7 +62,8 @@ final class DriverTests: XCTestCase {
           XCTAssertEqual(error.message, """
             Failed to parse module archive of 'Main' at '\(cacheRoot)'.
 
-            Maybe the archive is compiled using a different version of the compiler. Try erasing the module cache.
+            Maybe the archive was compiled with a different version of the compiler. \
+            Try erasing the module cache.
             """)
 
           XCTAssertEqual("\(error)", error.message)


### PR DESCRIPTION
It is not trivial to pass custom search paths to Xcode's test driver, which would be necessary to locate `lld` properly on arbitrary systems. As the use of `lld` is not a high-priority yet, it is simpler to just remove `lld` until we spend time on addressing this issue.

This patch also makes a few adjustments to the code to improve consistency.