### PR TITLE
Port conditional compilation support from old compiler.

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -452,6 +452,8 @@ internal struct IREmitter {
       return lower(program.castUnchecked(s, to: Assignment.self))
     case Block.self:
       return lower(program.castUnchecked(s, to: Block.self))
+    case ConditionalCompilation.self:
+      return lower(program.castUnchecked(s, to: ConditionalCompilation.self))
     case Discard.self:
       return lower(program.castUnchecked(s, to: Discard.self))
     case If.self:
@@ -513,6 +515,11 @@ internal struct IREmitter {
   /// Generates the IR of `s`.
   private mutating func lower(_ s: Block.ID) -> ControlFlow {
     lower(statements: program[s].statements)
+  }
+
+  /// Generates the IR of `s`.
+  private mutating func lower(_ s: ConditionalCompilation.ID) -> ControlFlow {
+    lower(statements: program[s].expansion(for: program.compilationConditions))
   }
 
   /// Generates the IR of `s`.

--- a/Sources/FrontEnd/Module.swift
+++ b/Sources/FrontEnd/Module.swift
@@ -212,6 +212,9 @@ public struct Module: Sendable {
   /// The position of `self` in the containing program.
   public let identity: Module.ID
 
+  /// Conditions for selecting conditional compilation branches.
+  private let compilationConditions: ConditionalCompilationFactors
+
   /// The dependencies of the module.
   public private(set) var dependencies: [Module.Name] = []
 
@@ -221,10 +224,11 @@ public struct Module: Sendable {
   /// The IR functions in the module.
   public internal(set) var ir: IR = .init()
 
-  /// Creates an empty module with the given name and identity.
-  public init(name: Name, identity: Module.ID) {
+  /// Creates an empty module with the given name, identity, and compilation conditions.
+  public init(name: Name, identity: Module.ID, compilationConditions: ConditionalCompilationFactors) {
     self.name = name
     self.identity = identity
+    self.compilationConditions = compilationConditions
   }
 
   /// `true` iff `self` is Hylo's standard library.
@@ -276,7 +280,7 @@ public struct Module: Sendable {
     if let f = sources.index(forKey: s.name) {
       return (inserted: false, identity: .init(module: identity, offset: f))
     } else {
-      let p = Parser(s)
+      let p = Parser(s, compilationConditions: compilationConditions)
       var f = Module.SourceContainer(
         identity: .init(module: identity, offset: sources.count), source: s)
       p.parseTopLevelDeclarations(in: &f)
@@ -484,6 +488,9 @@ extension Module: Archivable {
     /// A mapping from file name to its contents.
     internal var sources = OrderedDictionary<FileName, SourceFile>()
 
+    /// Conditions for selecting conditional compilation branches.
+    internal var compilationConditions: ConditionalCompilationFactors
+
     /// Returns the result of calling `action` on `self` wrapped in `Any`.
     internal mutating func withWrapped<T>(_ action: (inout Any) throws -> T) rethrows -> T {
       try withUnsafeMutablePointer(to: &self) { (this) in
@@ -523,7 +530,8 @@ extension Module: Archivable {
         ctx.modules[Module.ID(i + 1)] = ctx.identities[d]
       }
 
-      var me = Self(name: name, identity: ctx.identities[name]!)
+      var me = Self(name: name, identity: ctx.identities[name]!,
+        compilationConditions: ctx.compilationConditions)
 
       // <source count> <identity> <contents> ...
       let count = try Int(archive.readUnsignedLEB128())

--- a/Sources/FrontEnd/Parser/Lexer.swift
+++ b/Sources/FrontEnd/Parser/Lexer.swift
@@ -196,6 +196,10 @@ public struct Lexer: IteratorProtocol, Sequence {
 
     let tag: Token.Tag
     switch take(while: \.isIdentifierTail) {
+    case "if": tag = .poundIf
+    case "else": tag = .poundElse
+    case "elseif": tag = .poundElseif
+    case "endif": tag = .poundEndif
     case "": tag = .error
     default: tag = .poundLiteral
     }

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -45,10 +45,14 @@ public struct Parser {
   /// The context in which the parser is being used.
   private var context: Context = .default
 
+  /// Conditions for selecting conditional compilation branches.
+  private let compilationConditions: ConditionalCompilationFactors
+
   /// Creates an instance parsing `source`.
-  public init(_ source: SourceFile) {
+  public init(_ source: SourceFile, compilationConditions: ConditionalCompilationFactors) {
     self.tokens = Lexer(tokenizing: source)
     self.position = .init(source.startIndex, in: source)
+    self.compilationConditions = compilationConditions
   }
 
   // MARK: Declarations
@@ -1019,7 +1023,7 @@ public struct Parser {
     let start = nextTokenStart()
 
     let vs = try inBraces { (m0) in
-      try m0.semicolonSeparated(until: .rightBrace) { (m1) in
+      try m0.semicolonSeparated(until: Token.hasTag(.rightBrace)) { (m1) in
         try m1.parseVariant(introducedBy: head, in: &file)
       }
     }
@@ -1143,7 +1147,7 @@ public struct Parser {
   ) throws -> [DeclarationIdentity] {
     try entering(.typeBody(.init(T.self))) { (m0) in
       try m0.inBraces { (m1) in
-        try m1.semicolonSeparated(until: .rightBrace) { (m2) in
+        try m1.semicolonSeparated(until: Token.hasTag(.rightBrace)) { (m2) in
           let d = try m2.parseDeclaration(in: &file)
           if !isValid(file.tag(of: d)) {
             m2.report(.init("declaration is not allowed here", at: .empty(at: file[d].site.start)))
@@ -1678,7 +1682,7 @@ public struct Parser {
     let i = try take(.match) ?? expected("'match'")
     let s = try parseExpression(in: &file)
     let b = try inBraces { (m0) in
-      try m0.semicolonSeparated(until: .rightBrace) { (m1) in
+      try m0.semicolonSeparated(until: Token.hasTag(.rightBrace)) { (m1) in
         try m1.parsePatternMatchCase(in: &file)
       }
     }
@@ -1698,7 +1702,7 @@ public struct Parser {
     let i = try take(.case) ?? expected("'case'")
     let p = try parsePattern(in: &file)
     let b = try inBraces { (m0) in
-      try m0.semicolonSeparated(until: .rightBrace) { (m1) in
+      try m0.semicolonSeparated(until: Token.hasTag(.rightBrace)) { (m1) in
         try m1.parseStatement(in: &file)
       }
     }
@@ -2176,6 +2180,7 @@ public struct Parser {
   ///
   ///     statement ::=
   ///       assignment-statement
+  ///       conditional-compilation-statement
   ///       discard-statement
   ///       return-statement
   ///       declaration
@@ -2188,6 +2193,8 @@ public struct Parser {
     defer { ensureStatementDelimiter() }
 
     switch head.tag {
+    case .poundIf:
+      return try .init(parseConditionalCompilation(in: &file))
     case .underscore:
       return try .init(parseDiscardStement(in: &file))
     case .return:
@@ -2199,6 +2206,287 @@ public struct Parser {
     default:
       return try parseAssignmentOrExpression(in: &file)
     }
+  }
+
+  /// Parses a conditional compilation statement.
+  ///
+  ///     conditional-compilation-statement ::=
+  ///       '#if' conditional-compilation-tail
+  ///     conditional-compilation-statement-tail ::=
+  ///       conditional-compilation-condition '{' statement-list '}' conditional-compilation-fallback
+  ///     conditional-compilation-fallback ::=
+  ///       '#elseif' conditional-compilation-tail
+  ///       '#else' '{' statement-list '}' `#endif`
+  ///       `#endif`
+  ///     conditional-compilation-condition ::=
+  ///       `true`
+  ///       `false`
+  ///       `operatingSystem` `(` identifier `)`
+  ///       `architecture` `(` identifier `)`
+  ///       `feature` `(` identifier `)`
+  ///       `compiler` `(` identifier `)`
+  ///       `compilerVersion` `(` comparison `)`
+  ///       `hyloVersion` `(` comparison `)`
+  ///       `not` `(` conditional-compilation-condition `)`
+  ///       `and` `(` conditional-compilation-condition `,` conditional-compilation-condition `)`
+  ///       `or` `(` conditional-compilation-condition `,` conditional-compilation-condition `)`
+  ///     comparison ::=
+  ///       `>=` semantic-version
+  ///       `<` semantic-version
+  ///     semantic-version ::=
+  ///       decimal-number '.' decimal-number '.' decimal-number
+  ///
+  private mutating func parseConditionalCompilation(
+    in file: inout Module.SourceContainer
+  ) throws -> ConditionalCompilation.ID {
+    let i = try take(.poundIf) ?? expected("'#if'")
+    return try parseConditionalCompilationTail(head: i, in: &file)
+  }
+
+  /// Parses the conditional compilation tail after `head`, which is either `#if` or `#elseif`.
+  /// 
+  /// If `canBeActive` is `false`, the caller has already determined that the condition of this
+  /// branch cannot hold.
+  private mutating func parseConditionalCompilationTail(
+    head: Token, canBeActive: Bool = true,
+    in file: inout Module.SourceContainer
+  ) throws -> ConditionalCompilation.ID {
+    let c = try parseConditionalCompilationCondition(in: &file)
+    let active = canBeActive && c.holds(for: compilationConditions)
+    let b = try parseConditionalCompilationStatements(
+      skipParsing: !active && c.mayNotNeedParsing, in: &file)
+    let t = try parseConditionalCompilationFallback(
+      active: !active, skipParsing: active && c.mayNotNeedParsing, in: &file)
+    return file.insert(ConditionalCompilation(
+      introducer: head, condition: c, statements: b, fallback: t, site: span(from: head)))
+  }
+
+  /// Parses a conditional compilation body.
+  ///
+  /// If `skipParsing` is `true`, all the tokens are skipped until the next `#elseif`, `#else`, or
+  /// `#endif` that matches the current nesting level.
+  private mutating func parseConditionalCompilationStatements(
+    skipParsing: Bool,
+    in file: inout Module.SourceContainer
+  ) throws -> [StatementIdentity] {
+    if skipParsing {
+      try skipConditionalCompilationBranch(stoppingAtElse: true)
+      return []
+    } else {
+      return try semicolonSeparated(
+        until: Token.oneOf([.poundElse, .poundElseif, .poundEndif])
+      ) { (m) in
+        try m.parseStatement(in: &file)
+      }
+    }
+  }
+
+  /// Skips the branch body of a conditional compilation statement, including any nested conditional
+  /// compilation statements.
+  ///
+  /// If `stoppingAtElse` is `true`, the skipping stops at the next `#elseif` or `#else` that
+  /// matches the current nesting level. Otherwise, it stops at the next `#endif` that matches the
+  /// current nesting level.
+  private mutating func skipConditionalCompilationBranch(stoppingAtElse: Bool) throws {
+    var innerCompilerConditions = 0
+    discard(while: { (head) in
+      switch head.tag {
+      case .poundEndif:
+        innerCompilerConditions -= 1
+      case .poundIf:
+        innerCompilerConditions += 1
+      case .poundElse, .poundElseif:
+        // Check if we need to stop at the corresponding #else[if].
+        if stoppingAtElse && innerCompilerConditions == 0 {
+          innerCompilerConditions -= 1
+        }
+      default:
+        break
+      }
+      return innerCompilerConditions >= 0
+    })
+  }
+
+  /// Parses a conditional compilation fallback.
+  ///
+  /// `active` is `true` iff the caller has already determined that the condition of the current
+  /// branch does hold. `skipParsing` is `true` iff the caller has determined that the branch does
+  /// not need parsing.
+  private mutating func parseConditionalCompilationFallback(
+    active: Bool,
+    skipParsing: Bool,
+    in file: inout Module.SourceContainer
+  ) throws -> [StatementIdentity] {
+    if skipParsing {
+      try skipConditionalCompilationBranch(stoppingAtElse: false)
+      guard take(.poundEndif) != nil else { throw expected("'#endif'") }
+      return []
+    }
+
+    if let head = take(.poundElseif) {
+      return [.init(try parseConditionalCompilationTail(head: head, canBeActive: active, in: &file))]
+    }
+    else if take(.poundElse) != nil {
+      let b = try parseConditionalCompilationStatements(skipParsing: false, in: &file)
+      guard take(.poundEndif) != nil else { throw expected("'#endif'") }
+      return b
+    }
+    else if take(.poundEndif) != nil {
+      return []
+    }
+    else {
+      throw expected("'#elseif', '#else', or '#endif'")
+    }
+  }
+
+  /// Parses a conditional compilation condition.
+  private mutating func parseConditionalCompilationCondition(
+    in file: inout Module.SourceContainer
+  ) throws -> ConditionalCompilation.Condition {
+    return try condition(withInfixConnectiveStrongerOrEqualTo: .disjunction)
+
+    /// A conjunction (`&&`) or disjunction (`||`) operator.
+    enum Connective: Int {
+
+      /// The logical disjunction.
+      case disjunction
+
+      /// The logical conjunction.
+      case conjunction
+
+    }
+
+    /// Parses a logical connective from `state`.
+    func parseConnective(in file: inout Module.SourceContainer) -> Connective? {
+      guard let t = peek(), t.tag == .`operator` else { return nil }
+      var r: Connective
+      switch t.text {
+      case "||":
+        r = .disjunction
+      case "&&":
+        r = .conjunction
+      default:
+        return nil
+      }
+
+      // Consume the token and "succeed".
+      _ = take()
+      return r
+    }
+
+    /// Parses a condition as a proposition, a negation, or an infix sentence whose operator has
+    /// a precedence at least as strong as `p`.
+    func condition(
+      withInfixConnectiveStrongerOrEqualTo p: Connective
+    ) throws -> ConditionalCompilation.Condition {
+      var left = try parseConditionalCompilationUnaryExpression(in: &file)
+
+      while true {
+        // Tentatively parse a connective.
+        var backup = self
+        guard let c = parseConnective(in: &file) else { return left }
+
+        // Backtrack if the connective we got hasn't strong enough precedence.
+        if (c.rawValue < p.rawValue) {
+          swap(&self, &backup)
+          return left
+        }
+
+        // If we parsed `||` the RHS must be a conjunction. Otherwise it must be a proposition or
+        // negation. In either case we'll come back here to parse the remainder of the expression.
+        switch c {
+        case .disjunction:
+          let right = try condition(withInfixConnectiveStrongerOrEqualTo: .conjunction)
+          left = .or(left, right)
+        case .conjunction:
+          let right = try parseConditionalCompilationUnaryExpression(in: &file)
+          left = .and(left, right)
+        }
+      }
+
+      return left
+    }
+  }
+
+  /// Parses a conditional compilation condition unary expression.
+  private mutating func parseConditionalCompilationUnaryExpression(
+    in file: inout Module.SourceContainer
+  ) throws -> ConditionalCompilation.Condition {
+    if let t = take(oneOf: [.`true`, .`false`]) {
+      return t.text == "true" ? .`true` : .`false`
+    }
+
+    if peek()?.text == "!" {
+      _ = take(.`operator`)
+      return .not(try parseConditionalCompilationCondition(in: &file))
+    }
+
+    if let name = take(.name) {
+      let expectVersionNumber: Bool
+      switch name.text {
+      case "compiler_version", "hylo_version":
+        expectVersionNumber = true
+      default:
+        expectVersionNumber = false
+      }
+
+      if expectVersionNumber {
+        guard take(.leftParenthesis) != nil else { throw expected("'('") }
+
+        let o = try parseOperator()
+        let comparison: ConditionalCompilation.VersionComparison
+        let s = try parseSemanticVersion(in: &file)
+        guard take(.rightParenthesis) != nil else { throw expected("')'") }
+        switch o.text {
+        case ">=":
+          comparison = .greaterOrEqual(s)
+        case "<":
+          comparison = .less(s)
+        default:
+          throw expected("'>=' or '<'", at: o)
+        }
+        switch name.text {
+        case "compiler_version":
+          return .compilerVersion(comparison: comparison)
+        case "hylo_version":
+          return .hyloVersion(comparison: comparison)
+        default:
+          unreachable()
+        }
+      } else {
+        // We have the form #if identifier(identifier), and our current parsing state starts at '('.
+        guard take(.leftParenthesis) != nil else { throw expected("'('") }
+        let x = try take(.name) ?? expected("identifier")
+        guard take(.rightParenthesis) != nil else { throw expected("')'") }
+
+        switch name.text {
+        case "os": return .operatingSystem(.init(x))
+        case "arch": return .architecture(.init(x))
+        case "feature": return .feature(.init(x))
+        case "compiler": return .compiler(.init(x))
+        default:
+          throw expected("'os', 'arch', 'feature', or 'compiler'", at: name.site)
+        }
+      }
+    } else {
+      throw expected("compiler condition")
+    }
+  }
+
+  /// Parses a semantic version.
+  private mutating func parseSemanticVersion(
+    in file: inout Module.SourceContainer
+  ) throws -> SemanticVersion {
+    let major = Int((try take(.integerLiteral) ?? expected("integer literal")).text)!
+    var minor = 0
+    var patch = 0
+    if take(.dot) != nil {
+      minor = Int((try take(.integerLiteral) ?? expected("integer literal")).text)!
+      if take(.dot) != nil {
+        patch = Int((try take(.integerLiteral) ?? expected("integer literal")).text)!
+      }
+    }
+    return SemanticVersion(major: major, minor: minor, patch: patch)
   }
 
   /// Parses a discard statement.
@@ -2282,7 +2570,7 @@ public struct Parser {
     in file: inout Module.SourceContainer
   ) throws -> [StatementIdentity] {
     try inBraces { (m0) in
-      try m0.semicolonSeparated(until: .rightBrace) { (m1) in
+      try m0.semicolonSeparated(until: Token.hasTag(.rightBrace)) { (m1) in
         try m1.parseStatement(in: &file)
       }
     }
@@ -2640,17 +2928,17 @@ public struct Parser {
 
   /// Parses a list of instances of `T` separated by newlines or semicolons.
   private mutating func semicolonSeparated<T>(
-    until rightDelimiter: Token.Tag?, _ parse: (inout Self) throws -> T
+    until stopCondition: (Token) -> Bool, _ parse: (inout Self) throws -> T
   ) throws -> [T] {
     var xs: [T] = []
     while let head = peek() {
       discard(while: { (t) in t.tag == .semicolon })
-      if head.tag == rightDelimiter { break }
+      if stopCondition(head) { break }
       do {
         try xs.append(parse(&self))
       } catch let e as ParseError {
         report(e)
-        recover(at: { (t) in t.tag == rightDelimiter || t.tag == .semicolon })
+        recover(at: { (t) in stopCondition(t) || t.tag == .semicolon })
       }
     }
     return xs

--- a/Sources/FrontEnd/Parser/Token.swift
+++ b/Sources/FrontEnd/Parser/Token.swift
@@ -52,6 +52,10 @@ public struct Token: Hashable, Sendable {
 
     // Pound keywords and literals
     case poundLiteral
+    case poundElse
+    case poundElseif
+    case poundEndif
+    case poundIf
 
     // Operators
     case ampersand

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -31,9 +31,13 @@ public struct Program: Sendable {
   // this case, the absence of some standard library declarations won't be treated as an error.
   private var allowPartialStandardLibrary: Bool = false
 
+  /// Conditions for selecting conditional compilation branches.
+  public let compilationConditions: ConditionalCompilationFactors
+
   /// Creates an empty program.
-  public init(allowPartialStandardLibrary: Bool = false) {
+  public init(allowPartialStandardLibrary: Bool = false, compilationConditions: ConditionalCompilationFactors = .init()) {
     self.allowPartialStandardLibrary = allowPartialStandardLibrary
+    self.compilationConditions = compilationConditions
   }
 
   /// `true` if the program has errors.
@@ -66,7 +70,7 @@ public struct Program: Sendable {
       return m
     } else {
       let m = modules.count
-      modules[name] = Module(name: name, identity: m)
+      modules[name] = Module(name: name, identity: m, compilationConditions: compilationConditions)
       return m
     }
   }
@@ -1598,7 +1602,7 @@ extension Program {
     // Configure the serialization context.
     let c = Module.SerializationContext(
       identities: .init(uniqueKeysWithValues: modules.values.map({ (m) in (m.name, m.identity) })),
-      types: types)
+      types: types, compilationConditions: compilationConditions)
 
     // Serialize the module.
     var ctx: Any = c
@@ -1625,7 +1629,8 @@ extension Program {
 
     // Reserve an identity for the new module.
     let m = modules.count
-    var c = Module.SerializationContext(identities: [name: m], types: .init())
+    var c = Module.SerializationContext(identities: [name: m], types: .init(),
+      compilationConditions: compilationConditions)
     types.reserveCapacity(max(types.underestimatedCount << 1, 10000))
 
     // Configure the serialization context.

--- a/Sources/FrontEnd/Syntax/ConditionalCompilationFactors.swift
+++ b/Sources/FrontEnd/Syntax/ConditionalCompilationFactors.swift
@@ -1,0 +1,48 @@
+import Utilities
+
+/// The factors that influence conditional compilation.
+public struct ConditionalCompilationFactors: Sendable {
+
+  /// The target operating system.
+  public let operatingSystem: Platform.OperatingSystem
+
+  /// The target architecture.
+  public let architecture: Platform.Architecture
+
+  /// The version of the compiler.
+  public let compilerVersion: SemanticVersion
+
+  /// The version of the Hylo language recognized by the compiler.
+  public let hyloVersion: SemanticVersion
+
+  /// `true` if the standard library exposes only non-OS-dependent parts.
+  public let freestanding: Bool
+
+  public init(
+    operatingSystem os: Platform.OperatingSystem = Platform.hostOperatingSystem,
+    architecture a: Platform.Architecture = Platform.hostArchitecture,
+    compilerVersion cv: SemanticVersion = SemanticVersion(major: 0, minor: 1, patch: 0),
+    hyloVersion hv: SemanticVersion = SemanticVersion(major: 0, minor: 1, patch: 0),
+    freestanding f: Bool = false
+  ) {
+    self.operatingSystem = os
+    self.architecture = a
+    self.compilerVersion = cv
+    self.hyloVersion = hv
+    self.freestanding = f
+  }
+
+}
+
+extension ConditionalCompilationFactors: Showable {
+
+  /// Returns a textual representation of `self` using `printer`.
+  public func show(using printer: inout TreePrinter) -> String {
+    "operatingSystem=\(operatingSystem), "
+      + "architecture=\(architecture), "
+      + "compilerVersion=\(compilerVersion), "
+      + "hyloVersion=\(hyloVersion), "
+      + "freestanding=\(freestanding)"
+  }
+
+}

--- a/Sources/FrontEnd/Syntax/SemanticVersion.swift
+++ b/Sources/FrontEnd/Syntax/SemanticVersion.swift
@@ -1,0 +1,36 @@
+import Archivist
+
+/// A semantic version number.
+@Archivable
+public struct SemanticVersion: Equatable, Sendable {
+
+  /// The major version component of the semantic version.
+  public let major: Int
+
+  /// The minor version component of the semantic version.
+  public let minor: Int
+
+  /// The patch version component of the semantic version.
+  public let patch: Int
+
+  /// Creates an instance with the given major, minor, and patch components.
+  public init(major: Int, minor: Int, patch: Int) {
+    self.major = major
+    self.minor = minor
+    self.patch = patch
+  }
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)
+  }
+
+}
+
+extension SemanticVersion: Showable {
+
+  /// Returns a textual representation of `self` using `printer`.
+  public func show(using printer: inout TreePrinter) -> String {
+    "\(major).\(minor).\(patch)"
+  }
+
+}

--- a/Sources/FrontEnd/Syntax/Statements/ConditionalCompilation.swift
+++ b/Sources/FrontEnd/Syntax/Statements/ConditionalCompilation.swift
@@ -1,0 +1,213 @@
+import Archivist
+
+/// A conditional-compilation statement.
+@Archivable
+public struct ConditionalCompilation: Equatable, Statement {
+
+  /// A comparison test for semantic version.
+  @Archivable
+  public enum VersionComparison: Equatable, Sendable {
+
+    /// Represents "_ >= payload".
+    case greaterOrEqual(SemanticVersion)
+
+    /// Represents "_ < payload".
+    case less(SemanticVersion)
+
+    /// Evaluate the comparison predicate for `lhs`.
+    func evaluate(for lhs: SemanticVersion) -> Bool {
+      switch self {
+      case .greaterOrEqual(let target):
+        return !(lhs < target)
+      case .less(let target):
+        return lhs < target
+      }
+    }
+
+  }
+
+  /// A condition in a conditional compilation statement.
+  @Archivable
+  public indirect enum Condition: Equatable, Sendable {
+
+    /// Always holds.
+    case `true`
+
+    /// Never holds.
+    case `false`
+
+    /// Holds iff the operating system for which the code is compiled matches the payload.
+    case operatingSystem(Parsed<String>)
+
+    /// Holds iff the processor architecture for which the code is compiled matches the payload.
+    case architecture(Parsed<String>)
+
+    /// Holds iff the payload matches any of the feature enabled in the compiler.
+    case feature(Parsed<String>)
+
+    /// Holds iff the name of the compiler processing the file matches the payload.
+    case compiler(Parsed<String>)
+
+    /// Holds iff the version of the compiler processing the file, satisfies the `comparison`.
+    case compilerVersion(comparison: VersionComparison)
+
+    /// Holds iff the version of Hylo for which this file is compiled, satisfies `comparison`.
+    case hyloVersion(comparison: VersionComparison)
+
+    /// Holds iff the payload doesn't.
+    case not(Condition)
+
+    /// Holds iff both conditions in the payload do.
+    case and(Condition, Condition)
+
+    /// Holds iff either condition in the payload does.
+    case or(Condition, Condition)
+
+    /// `true` iff the body of the conditional-compilation shouldn't be parsed.
+    public var mayNotNeedParsing: Bool {
+      switch self {
+      case .compiler:
+        return true
+      case .compilerVersion:
+        return true
+      case .hyloVersion:
+        return true
+      case .not(let c):
+        return c.mayNotNeedParsing
+      case .and(let l, let r):
+        return l.mayNotNeedParsing && r.mayNotNeedParsing
+      case .or(let l, let r):
+        return l.mayNotNeedParsing || r.mayNotNeedParsing
+      default:
+        return false
+      }
+    }
+
+    /// Returns `true` iff `self` holds for the current process.
+    public func holds(for factors: ConditionalCompilationFactors) -> Bool {
+      switch self {
+      case .`true`:
+        return true
+      case .`false`:
+        return false
+      case .operatingSystem(let id):
+        return id.value == factors.operatingSystem.description
+      case .architecture(let id):
+        return id.value == factors.architecture.description
+      case .feature(let id):
+        return id.value == "freestanding" && factors.freestanding
+      case .compiler(let id):
+        return id.value == "hc"
+      case .compilerVersion(let comparison):
+        return comparison.evaluate(for: factors.compilerVersion)
+      case .hyloVersion(let comparison):
+        return comparison.evaluate(for: factors.hyloVersion)
+      case .not(let c):
+        return !c.holds(for: factors)
+      case .and(let l, let r):
+        return l.holds(for: factors) && r.holds(for: factors)
+      case .or(let l, let r):
+        return l.holds(for: factors) || r.holds(for: factors)
+      }
+    }
+
+  }
+
+  /// The introducer of this expression.
+  public let introducer: Token
+
+  /// The condition.
+  public let condition: Condition
+
+  /// The statements in the block.
+  public let statements: [StatementIdentity]
+
+  /// The statements to be used if the condition is false.
+  public let fallback: [StatementIdentity]
+
+  /// The site from which `self` was parsed.
+  public let site: SourceSpan
+
+  /// Creates an instance with the given properties.
+  public init(
+    introducer: Token,
+    condition: Condition,
+    statements: [StatementIdentity],
+    fallback: [StatementIdentity],
+    site: SourceSpan
+  ) {
+    self.introducer = introducer
+    self.site = site
+    self.condition = condition
+    self.statements = statements
+    self.fallback = fallback
+  }
+
+  /// Returns the statements that this expands to.
+  public func expansion(for factors: ConditionalCompilationFactors) -> [StatementIdentity] {
+    condition.holds(for: factors) ? statements : fallback
+  }
+
+}
+
+extension ConditionalCompilation.VersionComparison: Showable {
+
+  /// Returns a textual representation of `self` using `printer`.
+  public func show(using printer: inout TreePrinter) -> String {
+    switch self {
+    case .greaterOrEqual(let v):
+      return ">= \(printer.show(v))"
+    case .less(let v):
+      return "< \(printer.show(v))"
+    }
+  }
+
+}
+
+extension ConditionalCompilation.Condition: Showable {
+
+  /// Returns a textual representation of `self` using `printer`.
+  public func show(using printer: inout TreePrinter) -> String {
+    switch self {
+    case .`true`:
+      return "true"
+    case .`false`:
+      return "false"
+    case .operatingSystem(let id):
+      return "os(\(id))"
+    case .architecture(let id):
+      return "arch(\(id))"
+    case .feature(let id):
+      return "feature(\(id))"
+    case .compiler(let id):
+      return "compiler(\(id))"
+    case .compilerVersion(let comparison):
+      return "compilerVersion(\(printer.show(comparison)))"
+    case .hyloVersion(let comparison):
+      return "hyloVersion(\(printer.show(comparison)))"
+    case .not(let c):
+      return "!(\(printer.show(c)))"
+    case .and(let l, let r):
+      return "(\(printer.show(l)) && \(printer.show(r)))"
+    case .or(let l, let r):
+      return "(\(printer.show(l)) || \(printer.show(r)))"
+    }
+  }
+
+}
+
+extension ConditionalCompilation: Showable {
+
+  /// Returns a textual representation of `self` using `printer`.
+  public func show(using printer: inout TreePrinter) -> String {
+    var result = "#if \(printer.show(condition)) {\n"
+    for s in statements { result.append(printer.show(s).indented + "\n") }
+    if !fallback.isEmpty {
+      result.append("} else {\n")
+      for s in fallback { result.append(printer.show(s).indented + "\n") }
+    }
+    result.append("}")
+    return result
+  }
+
+}

--- a/Sources/FrontEnd/Syntax/SyntaxTag.swift
+++ b/Sources/FrontEnd/Syntax/SyntaxTag.swift
@@ -79,6 +79,7 @@ public struct SyntaxTag: Sendable {
     // Statements
     Assignment.self,
     Block.self,
+    ConditionalCompilation.self,
     Discard.self,
     Return.self,
     Yield.self,

--- a/Sources/FrontEnd/Syntax/SyntaxVisitor.swift
+++ b/Sources/FrontEnd/Syntax/SyntaxVisitor.swift
@@ -138,6 +138,8 @@ extension Program {
       traverse(castUnchecked(n, to: Assignment.self), calling: &v)
     case Block.self:
       traverse(castUnchecked(n, to: Block.self), calling: &v)
+    case ConditionalCompilation.self:
+      traverse(castUnchecked(n, to: ConditionalCompilation.self), calling: &v)
     case Discard.self:
       traverse(castUnchecked(n, to: Discard.self), calling: &v)
     case Return.self:
@@ -388,6 +390,11 @@ extension Program {
   /// Visits the children of `n` in pre-order, calling back `v` when a node is entered or left.
   public func traverse<T: SyntaxVisitor>(_ n: Block.ID, calling v: inout T) {
     visit(self[n].statements, calling: &v)
+  }
+
+  /// Visits the children of `n` in pre-order, calling back `v` when a node is entered or left.
+  public func traverse<T: SyntaxVisitor>(_ n: ConditionalCompilation.ID, calling v: inout T) {
+    visit(self[n].expansion(for: compilationConditions), calling: &v)
   }
 
   /// Visits the children of `n` in pre-order, calling back `v` when a node is entered or left.

--- a/Sources/Utilities/Platform.swift
+++ b/Sources/Utilities/Platform.swift
@@ -29,4 +29,30 @@ public enum Platform: Sendable {
 
   }
 
+
+  #if os(macOS)
+    /// The host operating system.
+    public static let hostOperatingSystem: OperatingSystem = .macOS
+  #elseif os(Linux)
+    /// The host operating system.
+    public static let hostOperatingSystem: OperatingSystem = .linux
+  #elseif os(Windows)
+    /// The host operating system.
+    public static let hostOperatingSystem: OperatingSystem = .windows
+  #endif
+
+  #if arch(i386)
+    /// The host architecture.
+    public static let hostArchitecture: Architecture = .i386
+  #elseif arch(x86_64)
+    /// The host architecture.
+    public static let hostArchitecture: Architecture = .x86_64
+  #elseif arch(arm)
+    /// The host architecture.
+    public static let hostArchitecture: Architecture = .arm
+  #elseif arch(arm64)
+    /// The host architecture.
+    public static let hostArchitecture: Architecture = .arm64
+  #endif
+
 }

--- a/Tests/FrontEndTests/Parser/LexerTests.swift
+++ b/Tests/FrontEndTests/Parser/LexerTests.swift
@@ -179,6 +179,14 @@ final class LexerTests: XCTestCase {
     XCTAssertNil(scanner.next())
   }
 
+  func testPoundKeywords() throws {
+    var scanner = Lexer(tokenizing: "#if #else #elseif #endif")
+    try assertNext(from: &scanner, is: .poundIf, withValue: "#if")
+    try assertNext(from: &scanner, is: .poundElse, withValue: "#else")
+    try assertNext(from: &scanner, is: .poundElseif, withValue: "#elseif")
+    try assertNext(from: &scanner, is: .poundEndif, withValue: "#endif")
+  }
+
   func testPoundLiteral() throws {
     var scanner = Lexer(tokenizing: "#a #0 #")
     try assertNext(from: &scanner, is: .poundLiteral, withValue: "#a")

--- a/Tests/FrontEndTests/Parser/ParserTests.swift
+++ b/Tests/FrontEndTests/Parser/ParserTests.swift
@@ -1,0 +1,520 @@
+import XCTest
+
+@testable import FrontEnd
+
+final class ParserTests: XCTestCase {
+
+  /// Tests that the parser can parse a simple program without error.
+  func testParse() throws {
+    let input = """
+      public fun main() {
+        print("Hello, World!")
+      }
+      """
+    let m = try testModule(contents: input)
+    XCTAssertFalse(m.containsError, "Parsing failed with error: \(m.diagnostics)")
+  }
+
+  // MARK: Conditional compilation
+
+  /// Tests that a simple conditional compilation statement is parsed correctly.
+  func testSimpleConditionalCompilation() throws {
+    let input = """
+      #if os(macOs)
+      foo()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    assert(c.condition, isOsOf: "macOs")
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 0)
+  }
+
+  /// Tests the parsing of a conditional compilation statement with a `true` condition.
+  func testConditionalCompilationTrue() throws {
+    let input = """
+      #if true
+      foo()
+      #else
+      awgr()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(c.condition, .`true`)
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 1)
+  }
+
+  /// Tests the parsing of a conditional compilation statement with a `false` condition.
+  func testConditionalCompilationFalse() throws {
+    let input = """
+      #if false
+      awgr()
+      #else
+      foo()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(c.condition, .`false`)
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 1)
+  }
+
+  /// Tests the parsing of a conditional compilation statement with an `os` condition.
+  func testConditionalCompilationOs() throws {
+    let input =
+      """
+      #if os(macOs)
+      foo()
+      #elseif os(Linux)
+      bar()
+      #elseif os(Windows)
+      bazz()
+      #else
+      awgr()
+      #endif
+      """
+    let (c, m) = try parseConditionalCompilation(input)
+    assert(c.condition, isOsOf: "macOs")
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 1)
+
+    let c2 = try XCTUnwrap(m[c.fallback[0]] as? ConditionalCompilation)
+    assert(c2.condition, isOsOf: "Linux")
+    XCTAssertEqual(c2.statements.count, 1)
+    XCTAssertEqual(c2.fallback.count, 1)
+
+    let c3 = try XCTUnwrap(m[c2.fallback[0]] as? ConditionalCompilation)
+    assert(c3.condition, isOsOf: "Windows")
+    XCTAssertEqual(c3.statements.count, 1)
+    XCTAssertEqual(c3.fallback.count, 1)
+  }
+
+  /// Tests the parsing of a conditional compilation statement with an `arch` condition.
+  func testConditionalCompilationArch() throws {
+    let input =
+      """
+      #if arch(x86_64)
+      foo()
+      #elseif arch(i386)
+      bar()
+      #elseif arch(arm64)
+      bazz()
+      #elseif arch(arm)
+      fizz()
+      #else
+      awgr()
+      #endif
+      """
+    let (c, m) = try parseConditionalCompilation(input)
+    assert(c.condition, isArchitectureOf: "x86_64")
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 1)
+
+    let c2 = try XCTUnwrap(m[c.fallback[0]] as? ConditionalCompilation)
+    assert(c2.condition, isArchitectureOf: "i386")
+    XCTAssertEqual(c2.statements.count, 1)
+    XCTAssertEqual(c2.fallback.count, 1)
+
+    let c3 = try XCTUnwrap(m[c2.fallback[0]] as? ConditionalCompilation)
+    assert(c3.condition, isArchitectureOf: "arm64")
+    XCTAssertEqual(c3.statements.count, 1)
+    XCTAssertEqual(c3.fallback.count, 1)
+
+    let c4 = try XCTUnwrap(m[c3.fallback[0]] as? ConditionalCompilation)
+    assert(c4.condition, isArchitectureOf: "arm")
+    XCTAssertEqual(c4.statements.count, 1)
+    XCTAssertEqual(c4.fallback.count, 1)
+  }
+
+  /// Tests the parsing of a conditional compilation statement with a `feature` condition.
+  func testConditionalCompilationFeature() throws {
+    let input =
+      """
+      #if feature(useLibC)
+      foo()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    assert(c.condition, isFeatureOf: "useLibC")
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 0)
+  }
+
+  /// Tests the parsing of a conditional compilation statement with a `compiler` condition.
+  func testConditionalCompilationCompiler() throws {
+    let input = """
+      #if compiler(hc)
+      foo()
+      #else
+      awgr()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    assert(c.condition, isCompilerOf: "hc")
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 0)  // Body not parsed
+  }
+
+  /// Tests the parsing of a conditional compilation statement with a `compiler_version`
+  /// greater-or-equal condition.
+  func testConditionalCompilationCompilerVersionGreater() throws {
+    let input = """
+      #if compiler_version(>= 0 . 1)
+      foo()
+      #else
+      awgr()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(
+      c.condition,
+      .compilerVersion(
+        comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 0)  // Body not parsed
+  }
+
+  /// Tests the parsing of a conditional compilation statement with a `compiler_version`
+  /// less-than condition.
+  func testConditionalCompilationCompilerVersionLess() throws {
+    let input = """
+      #if compiler_version(< 100 . 1 . 2)
+      foo()
+      #else
+      awgr()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(
+      c.condition,
+      .compilerVersion(
+        comparison: .less(SemanticVersion(major: 100, minor: 1, patch: 2))))
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 0)  // Body not parsed
+  }
+
+  /// Tests the parsing of a conditional compilation statement with a `hylo_version`
+  /// greater-or-equal condition.
+  func testConditionalCompilationHyloVersionGreater() throws {
+    let input = """
+      #if hylo_version(>= 0 . 1)
+      foo()
+      #else
+      awgr()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(
+      c.condition,
+      .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 0)  // Body not parsed
+  }
+
+  /// Tests the parsing of a conditional compilation statement with a `hylo_version`
+  /// less-than condition.
+  func testConditionalCompilationHyloVersionLess() throws {
+    let input = """
+      #if hylo_version(< 100 . 1 . 2)
+      foo()
+      #else
+      awgr()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(
+      c.condition,
+      .hyloVersion(
+        comparison: .less(SemanticVersion(major: 100, minor: 1, patch: 2))))
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 0)  // Body not parsed
+  }
+
+  /// Tests the parsing of disabled blocks in a conditional compilation statement.
+  func testConditionalCompilationParsingInsideDisabledBlocks() throws {
+    let input = """
+      public fun main() {
+        #if false
+        <parse error>
+        #endif
+      }
+      """
+    let m = try testModule(contents: input)
+    XCTAssertTrue(m.containsError)
+  }
+
+  /// Tests that parsing can be skipped for a `hylo_version` condition evaluating to `false`.
+  func testConditionalCompilationParsingInsideVersionBlocks() throws {
+    let input = """
+      #if hylo_version(< 0 . 1)
+      <don't show parse error here>
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(
+      c.condition,
+      .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
+    XCTAssertEqual(c.statements.count, 0)  // Body not parsed
+    XCTAssertEqual(c.fallback.count, 0)
+  }
+
+  /// Tests that parsing can be skipped over nested conditional compilation blocks.
+  func testConditionalCompilationParsingSkipsParsingOverNestedBlocks() throws {
+    let input = """
+      #if hylo_version(< 0 . 1)
+      <don't show parse error here>
+      #if hylo_version(< 0 . 1)
+      <don't show parse error here>
+      #endif
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(
+      c.condition,
+      .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
+    XCTAssertEqual(c.statements.count, 0)  // Body not parsed
+    XCTAssertEqual(c.fallback.count, 0)
+  }
+
+  /// Tests that parsing can be skipped over nested conditional compilation blocks, until `#elseif`.
+  func testConditionalCompilationParsingSkipsParsingOverNestedBlocks2() throws {
+    let input = """
+      #if hylo_version(< 0 . 1)
+      <don't show parse error here>
+      #if hylo_version(< 0 . 1)
+      <don't show parse error here>
+      #endif
+      #elseif os(bla)
+      #endif
+      """
+    let (c, m) = try parseConditionalCompilation(input)
+    XCTAssertEqual(c.statements.count, 0)  // Body not parsed
+    XCTAssertEqual(c.fallback.count, 1)
+
+    let c2 = try XCTUnwrap(m[c.fallback.first!] as? ConditionalCompilation)
+    assert(c2.condition, isOsOf: "bla")
+    XCTAssertEqual(c2.statements.count, 0)
+    XCTAssertEqual(c2.fallback.count, 0)
+  }
+
+  /// Tests that parsing can be skipped in `#else` blocks.
+  func testConditionalCompilationParsingSkipsParsingOverNestedBlocksInElse() throws {
+    let input = """
+      #if hylo_version(>= 0 . 1)
+      #else
+      <don't show parse error here>
+      #if hylo_version(< 0 . 1)
+      <don't show parse error here>
+      #endif
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(
+      c.condition,
+      .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
+    XCTAssertEqual(c.statements.count, 0)  // Body not parsed
+    XCTAssertEqual(c.fallback.count, 0)
+  }
+
+  /// Tests that parsing can be skipped over nested conditional compilation blocks in `#else` blocks.
+  func testConditionalCompilationParsingSkipsParsingOverNestedBlocksInElse2() throws {
+    let input = """
+      #if hylo_version(>= 0 . 1)
+      #elseif compiler_version(>= 0 . 1)
+      <don't show parse error here>
+      #if hylo_version(< 0 . 1)
+      <don't show parse error here>
+      #endif
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(
+      c.condition,
+      .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
+    XCTAssertEqual(c.statements.count, 0)
+    XCTAssertEqual(c.fallback.count, 0)
+  }
+
+  /// Tests that parsing is not skipped in `os` conditions.
+  func testConditionalCompilationChecksParsing() throws {
+    let input = """
+      public fun main() {
+        #if os(abracadabra)
+        <expecting error here>
+        #endif
+      }
+      """
+    let m = try testModule(contents: input)
+    XCTAssertTrue(m.containsError)
+  }
+
+  /// Tests parsing in negated `os` conditions.
+  func testConditionalCompilationNotOperatorOnFalse() throws {
+    let input = """
+      #if !os(abracadabra)
+      foo()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    // We should expand to the body of the #if
+    XCTAssertEqual(c.expansion(for: ConditionalCompilationFactors()).count, 1)
+  }
+
+  /// Tests parsing in negated `true` conditions.
+  func testConditionalCompilationNotOperatorOnTrue() throws {
+    let input = """
+      #if !true
+      foo()
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    // We should expand to nothing.
+    XCTAssertEqual(c.expansion(for: ConditionalCompilationFactors()).count, 0)
+  }
+
+  /// Tests conditional compilation with double negation.
+  func testConditionalCompilationNotNot() throws {
+    let input = """
+        #if ! !true
+        foo()
+        #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    // We should expand to the body.
+    XCTAssertEqual(c.expansion(for: ConditionalCompilationFactors()).count, 1)
+  }
+
+  /// Tests that parsing can be skipped after a negation in a conditional compilation statement.
+  func testConditionalCompilationSkipParsingAfterNot() throws {
+    let input = """
+      #if !compiler_version(< 0 . 1)
+      foo()
+      #else
+      <won't parse>
+      #endif
+      """
+    let (c, _) = try parseConditionalCompilation(input)
+    XCTAssertEqual(c.statements.count, 1)
+    XCTAssertEqual(c.fallback.count, 0)  // don't parse the #else part
+  }
+
+  /// Tests the parsing of a conditional compilation statement with complex infix conditions.
+  func testConditionalCompilationInfix() throws {
+    let input = """
+      #if os(macOS) || os(Linux) && hylo_version(< 1 . 0 . 0) || os(Windows)
+      do_something()
+      #endif
+      """
+
+    let (c, _) = try parseConditionalCompilation(input)
+    guard case .or(
+      .or(
+        .operatingSystem(let os1),
+        .and(
+          .operatingSystem(let os2),
+          .hyloVersion(comparison: .less(SemanticVersion(major: 1, minor: 0, patch: 0))))),
+      .operatingSystem(let os3)) = c.condition else {
+      XCTFail("Expected a complex infix condition")
+      return
+    }
+    XCTAssertEqual(os1.value, "macOS")
+    XCTAssertEqual(os2.value, "Linux")
+    XCTAssertEqual(os3.value, "Windows")
+  }
+
+  /// Parses `input` as a conditional compilation statement.
+  ///
+  /// Returns the corresponding `ConditionalCompilation` and the module it was parsed in.
+  func parseConditionalCompilation(
+    _ input: String, file: StaticString = #filePath, line: UInt = #line
+  ) throws -> (ConditionalCompilation, Module) {
+    let contents = """
+      public fun main() {
+      \(input)
+      }
+      """
+    let m = try testModule(contents: contents)
+    XCTAssertFalse(
+      m.containsError, "Parsing failed with error: \(m.diagnostics)", file: file, line: line)
+    let body = try bodyOfFirstFunction(m)
+    XCTAssertEqual(body.count, 1)
+    let c = try XCTUnwrap(
+      m[body[0]] as? ConditionalCompilation, "Expected a conditional compilation statement",
+      file: file, line: line)
+    return (c, m)
+  }
+
+  /// Asserts that `c` is an `os` condition with the given operating system name.
+  func assert(
+    _ c: ConditionalCompilation.Condition, isOsOf n: String, file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    if case .operatingSystem(let os) = c {
+      XCTAssertEqual(os.value, n, file: file, line: line)
+    } else {
+      XCTFail("Expected os(_) condition", file: file, line: line)
+    }
+  }
+
+  /// Asserts that `c` is an `architecture` condition with the given architecture name.
+  func assert(
+    _ c: ConditionalCompilation.Condition, isArchitectureOf n: String,
+    file: StaticString = #filePath, line: UInt = #line
+  ) {
+    if case .architecture(let a) = c {
+      XCTAssertEqual(a.value, n, file: file, line: line)
+    } else {
+      XCTFail("Expected architecture(_) condition", file: file, line: line)
+    }
+  }
+
+  /// Asserts that `c` is a `feature` condition with the given feature name.
+  func assert(
+    _ c: ConditionalCompilation.Condition, isFeatureOf n: String, file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    if case .feature(let f) = c {
+      XCTAssertEqual(f.value, n, file: file, line: line)
+    } else {
+      XCTFail("Expected feature(_) condition", file: file, line: line)
+    }
+  }
+
+  /// Asserts that `c` is a `compiler` condition with the given compiler name.
+  func assert(
+    _ c: ConditionalCompilation.Condition, isCompilerOf n: String, file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    if case .compiler(let t) = c {
+      XCTAssertEqual(t.value, n, file: file, line: line)
+    } else {
+      XCTFail("Expected compiler(_) condition", file: file, line: line)
+    }
+  }
+
+  // MARK: Utilities
+
+  /// Returns a test module that contains `input` as a source file.
+  func testModule(contents input: String) throws -> Module {
+    let s = SourceFile(name: .local(URL(string: "file:///tmp/test.hylo")!), contents: input)
+    var p = Program(allowPartialStandardLibrary: true)
+    let m = p.demandModule(Module.Name("M0"))
+    let r = p[m].addSource(s)
+    XCTAssertTrue(r.inserted, "Failed to insert source into module")
+    return p[m]
+  }
+
+  /// Returns the body of the first function in `m`.
+  ///
+  /// - Requires: the first top-level declaration in `m` is a function declaration.
+  func bodyOfFirstFunction(_ m: Module) throws -> [StatementIdentity] {
+    XCTAssertEqual(m.sources.count, 1, "Expected exactly one source")
+    let s = m.sources.values.first!
+    XCTAssertEqual(s.roots.count, 1, "Expected exactly one top-level declaration")
+    let x = m[s.roots.first!]
+    XCTAssertTrue(x is FunctionDeclaration, "Expected a function declaration")
+    return (x as! FunctionDeclaration).body!
+  }
+
+}


### PR DESCRIPTION
Add support for conditional compilation support at statement level. Add parser tests.
Add tests for conditional compilation.

Known issues: parsing of semantic versions requires spaces around dot (to not take floating literals).

Limitation: in this patch, we don't allow the user to configure the compilation factors.