### PR TITLE
Store IDs rather than names in 'IRValue.function'

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
+++ b/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
@@ -41,7 +41,7 @@ extension IREmitter {
     // Otherwise, replace the type application's arguments with type witnesses. The way in which
     // this substitution is done depends on the way the type application is used.
     switch f.at(i).callee {
-    case .function(let c, _):
+    case .function(let c, _, _):
       depolymorphize(c, operandOf: i, in: &f, reusing: &witnesses)
 
     default:
@@ -52,14 +52,14 @@ extension IREmitter {
   /// Replaces uses of `i`, which is a type application of the polymorphic function `c`, with their
   /// existentialized forms.
   private mutating func depolymorphize(
-    _ c: IRFunction.Name, operandOf i: IRTypeApply.ID, in f: inout IRFunction,
+    _ c: IRFunction.ID, operandOf i: IRTypeApply.ID, in f: inout IRFunction,
     reusing witnesses: inout [AnyTypeIdentity: IRValue]
   ) {
     let application = f.at(i)
 
     // Demand the declaration of the existentialized version of the callee. Note that the
     // definition of this function may not live in the same module as `f`.
-    let poly = program[module].ir.functions[c]!
+    let poly = program[module].ir[c]
     let mono = demandExistentialized(poly)
 
     // Get the types of the parameters of the original poloymorphic function.

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2579,10 +2579,10 @@ internal struct IREmitter {
 
   /// Returns a reference to the given lowered function.
   internal mutating func functionReference(to f: IRFunction.ID) -> IRValue {
-    let n = program[module].ir[f].name
+    // let n = program[module].ir[f].name
     let s = program[module].ir[f].signature()
     let t = program.types.demand(s)
-    return .function(n, t)
+    return .function(f, module, t)
   }
 
   /// Returns the type arguments defined in the type of `q`, which occurs as qualification for a

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -382,7 +382,7 @@ public struct IRFunction: Sendable {
       return (t.erased, false)
     case .floatingPoint(_, let t):
       return (t.erased, false)
-    case .function(_, let t):
+    case .function(_, _, let t):
       return (t, true)
     case .bundle(_, let t, _):
       return (t, true)

--- a/Sources/FrontEnd/IR/IRValue.swift
+++ b/Sources/FrontEnd/IR/IRValue.swift
@@ -19,7 +19,10 @@ public enum IRValue: Hashable, Sendable {
   indirect case floatingPoint(literal: String, MachineType.ID)
 
   /// A reference to a lowered function.
-  indirect case function(IRFunction.Name, AnyTypeIdentity)
+  ///
+  /// The payload is a triple `(f, m, t)` where `f` is the identity of a function declared (but
+  /// not necessarily defined) in the module `m`, and `t` is the type of that function.
+  indirect case function(IRFunction.ID, Module.ID, AnyTypeIdentity)
 
   /// A reference to a function or subscript bundle not yet reified.
   indirect case bundle(FunctionBundleDeclaration.ID, AnyTypeIdentity, AccessEffectSet)
@@ -82,8 +85,8 @@ extension IRValue: Showable {
       return "\(printer.show(t)) \(n)"
     case .floatingPoint(let n, let t):
       return "\(printer.show(t)) \(n)"
-    case .function(let n, _):
-      return printer.show(n)
+    case .function(let n, let m, _):
+      return printer.show(printer.program[m].ir[n].name)
     case .bundle(let n, _, let k):
       return "\(printer.program.debugName(of: .init(n)))@{\(list: k)}"
     case .type(let t, _):


### PR DESCRIPTION
Although a name uniquely identifies a function, IDs are more convenient during code generation.