### PR TITLE
Fix the lowering of conditional statements

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -526,26 +526,32 @@ internal struct IREmitter {
   @discardableResult
   private mutating func lowerAsStatement(_ s: If.ID) -> ControlFlow {
     let onFailure = insertionContext.function!.addBlock()
-    let tail = insertionContext.function!.addBlock()
+    let after = insertionContext.function!.addBlock()
 
     // Lower the conditions and the success branch.
     for c in program[s].conditions {
       insertionContext.point = .end(of: lowerCondition(c, onFailure: onFailure))
     }
 
-    if lower(program[s].success) == .next {
-      lowering(after: program[s].success, { $0._br(tail) })
+    switch lower(program[s].success) {
+    case .next:
+      lowering(after: program[s].success, { $0._br(after) })
+    case .return(let r):
+      lowering(r, { $0._return() })
     }
 
     // Lower the failure branch.
     insertionContext.point = .end(of: onFailure)
-    if lower(StatementIdentity(uncheckedFrom: program[s].failure.erased)) == .next {
-      lowering(after: program[s].failure, { $0._br(tail) })
+    switch lower(StatementIdentity(uncheckedFrom: program[s].failure.erased)) {
+    case .next:
+      lowering(after: program[s].failure, { $0._br(after) })
+    case .return(let r):
+      lowering(r, { $0._return() })
     }
 
-    // If neither branch returns control-flow (e.g., both branches return), then the tail won't
-    // have any predecessor and will be removed during dead code elimination.
-    insertionContext.point = .end(of: tail)
+    // If neither branch returns control-flow (e.g., both branches return), then the "after" block
+    // won't have any predecessor and will be removed during dead code elimination.
+    insertionContext.point = .end(of: after)
     return .next
   }
 

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -643,6 +643,7 @@ public struct IRFunction: Sendable {
       bindings.remove(value: .register(i))
       let n = (i != blocks[b].last) ? slots.address(after: i.address) : nil
       a = n.map(AnyInstructionIdentity.init(address:))
+      slots.remove(at: i.address)
     }
     blocks.remove(at: b)
   }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
@@ -19,17 +19,35 @@ extension IRFunction {
   internal mutating func removeUnreachableBlocks() {
     // Nothing to do if the function has no definition.
     guard let e = entry else { return }
+
+    /// Returns `true` iff `b` is unreachable from the function's entry.
     func isUnreachable(_ b: IRBlock.ID, in cfg: ControlFlowGraph) -> Bool {
       (b != e) && cfg.predecessors(of: b).isEmpty
     }
 
     var cfg = controlFlow()
     var work = blocks.addresses.filter({ (b) in isUnreachable(b, in: cfg) })
-    while let a = work.popLast() {
-      for b in successors(of: a) {
-        cfg.remove(a, fromPredecessorsOf: b)
-        if isUnreachable(b, in: cfg) {
-          work.append(b)
+
+    // `work` acts as a stack containing the basic blocks that should be eventually removed. At
+    // each iteration, we can either remove a block or grow the stack with successors that have
+    // to be removed first. The algorithm terminates because the stack can only grow after having
+    // removed relations from the control flow graph; otherwise it is popped.
+    while let a = work.last {
+      // `a` can be remove if it has no outgoing edges. Note that we may get here after `a` has
+      // already been visited once.
+      if cfg.successors(of: a).isEmpty {
+        removeBlock(a)
+        work.removeLast()
+      }
+
+      // If `a` has successors `b`, then `a` can be removed if all these these successors have at
+      // least one other predecessors. In this case, `a` is not a dominator and therefore it cannot
+      // contain definitions used elsewhere. Otherwise, all successors dominated that are dominated
+      // by `a` must be removed first.
+      else {
+        for b in successors(of: a) {
+          cfg.remove(a, fromPredecessorsOf: b)
+          if isUnreachable(b, in: cfg) { work.append(b) }
         }
       }
     }

--- a/Tests/CompilerTests/positive/control-flow.hylo
+++ b/Tests/CompilerTests/positive/control-flow.hylo
@@ -1,0 +1,18 @@
+//! stage:lowering
+
+fun twenty_either_way(c0: Bool, c1: Bool) -> Int {
+  if c0 {
+    sink let x = 20
+    return x
+  } else if c1 {
+    sink let y = 20
+    return y
+  } else {
+    sink let z = 20
+    return z
+  }
+
+  if true { return 0 }
+}
+
+public fun main() {}


### PR DESCRIPTION
This patch fixes #120. Specifically:

- It fixes a bug that would leave instructions in the function after a block has been removed.
- It fixes a bug that would leave unreachable blocks after dead code elimination.
- It fixes a bug that would emit invalid IR for conditional statements featuring early returns.
