### PR TITLE
Stand up a minimal inliner

### DIFF
--- a/Sources/FrontEnd/IR/IRBlock.swift
+++ b/Sources/FrontEnd/IR/IRBlock.swift
@@ -49,4 +49,13 @@ public struct IRBlock: Sendable {
     if first == nil { first = i }
   }
 
+  /// Unassigns the first and last instructions of `self`.
+  ///
+  /// Do not call this method directly. The contents of a basic block can only be modified through
+  /// the API of the containing `IRFunction`.
+  internal mutating func clear() {
+    first = nil
+    last = nil
+  }
+
 }

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2057,6 +2057,96 @@ internal struct IREmitter {
     insert(IRYield(projectee: projectee, anchor: currentAnchor))
   }
 
+  /// Inserts the contents of `source` before `boundary`, which is in `target`, substituting the
+  /// operands of copied instructions with `operands` and calling `computeAnchors` to determine
+  /// their anchors.
+  internal mutating func insert(
+    contentsOf source: IRFunction,
+    before boundary: AnyInstructionIdentity, in target: inout IRFunction,
+    substitutingOperandsWith operands: consuming IRSubstitutionTable,
+    computingAnchorsWith computeAnchor: (IRFunction, AnyInstructionIdentity) -> Anchor
+  ) {
+    // Define the block in which the source's entry will be emitted.
+    operands[source.entry!] = target.block(defining: boundary)
+
+    // Where control flow will jump on return.
+    let after: IRBlock.ID? =
+      (source.blocks.count > 1) ? target.split(before: boundary) : nil
+
+    // Initialize the insertion context.
+    var formerContext = InsertionContext(function: target.move())
+    swap(&formerContext, &insertionContext)
+    defer {
+      target = insertionContext.function.sink()
+      swap(&formerContext, &insertionContext)
+    }
+
+    // Create a new basic block in the target for each basic block in the source, except the entry.
+    // Instructions in the latter are inserted after `boundary`.
+    for b in source.blocks.addresses where b != source.entry {
+      operands[b] = insertionContext.function!.addBlock()
+    }
+
+    // Use the dominance relationship to ensure definitions are visited before their uses.
+    let cfg = source.controlFlow()
+    let dominance = DominatorTree(function: source, controlFlow: cfg)
+    for b in dominance.bfs {
+      // Place the insertion point at the end of the basic block corresponding to the one about to
+      // be visited.
+      insertionContext.point = .end(of: operands.blocks[b]!)
+
+      // Insert the contents of the block.
+      _insert(
+        contentsOf: b, in: source,
+        directingReturnsTo: after,
+        substitutingOperandsWith: &operands,
+        computingAnchorsWith: computeAnchor)
+    }
+  }
+
+  /// Inserts the contents of `b`, which is in `source`, at the current insertion point.
+  ///
+  /// The operands of copied instructions are substituted with `operands`, which is extended with
+  /// mappings for each copied instruction defining a register. Return instructions are replaced
+  /// with an unconditional branch to `onReturn` iff the argument is defined. Otherwise, they are
+  /// simply ignored.
+  private mutating func _insert(
+    contentsOf b: IRBlock.ID, in source: IRFunction,
+    directingReturnsTo onReturn: IRBlock.ID?,
+    substitutingOperandsWith operands: inout IRSubstitutionTable,
+    computingAnchorsWith computeAnchor: (IRFunction, AnyInstructionIdentity) -> Anchor,
+  ) {
+    for i in source.instructions(in: b) {
+      insertionContext.anchor = computeAnchor(source, i)
+      let r = IRValue.register(i)
+
+      switch source.tag(of: i) {
+      case IRAccess.self:
+        operands[r] = insert(IRAccess(source.at(i), substituting: operands)!)!
+      case IRAccess.End.self:
+        insert(IRAccess.End(source.at(i), substituting: operands)!)
+      case IRAlloca.self:
+        operands[r] = insert(IRAlloca(source.at(i), substituting: operands)!)!
+      case IRAssumeState.self:
+        insert(IRAssumeState(source.at(i), substituting: operands)!)
+      case IRBranch.self:
+        insert(IRBranch(source.at(i), substituting: operands)!)
+      case IRConditionalBranch.self:
+        insert(IRConditionalBranch(source.at(i), substituting: operands)!)
+      case IRLoad.self:
+        operands[r] = insert(IRLoad(source.at(i), substituting: operands)!)!
+      case IRReturn.self:
+        if let b = onReturn { _br(b) }
+      case IRStore.self:
+        insert(IRStore(source.at(i), substituting: operands)!)
+      case IRSubfield.self:
+        operands[r] = insert(IRSubfield(source.at(i), substituting: operands)!)!
+      case let t:
+        fatalError("unexpected instruction \(t)")
+      }
+    }
+  }
+
   // MARK: Helpers
 
   /// Inserts the IR for extracting the built-in value stored in an instance of `Hylo.Bool`.

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -517,11 +517,15 @@ public struct IRFunction: Sendable {
     _ instruction: T, to b: IRBlock.ID
   ) -> AnyInstructionIdentity {
     assert(!isTerminated(b), "insertion after terminator")
-    return insert(instruction) { (me, i) in
-      let a = me.slots.append(.init(instruction: i, parent: b))
-      let s = AnyInstructionIdentity(address: a)
-      me.blocks[b].setLast(s)
-      return s
+    if let i = blocks[b].last {
+      return insert(instruction, after: i)
+    } else {
+      return insert(instruction) { (me, i) in
+        let a = me.slots.append(.init(instruction: i, parent: b))
+        let s = AnyInstructionIdentity(address: a)
+        me.blocks[b].setLast(s)
+        return s
+      }
     }
   }
 
@@ -530,11 +534,15 @@ public struct IRFunction: Sendable {
   public mutating func prepend<T: Instruction>(
     _ instruction: T, to b: IRBlock.ID
   ) -> AnyInstructionIdentity {
-    insert(instruction) { (me, i) in
-      let a = me.slots.prepend(.init(instruction: i, parent: b))
-      let s = AnyInstructionIdentity(address: a)
-      me.blocks[b].setFirst(s)
-      return s
+    if let i = blocks[b].first {
+      return insert(instruction, before: i)
+    } else {
+      return insert(instruction) { (me, i) in
+        let a = me.slots.prepend(.init(instruction: i, parent: b))
+        let s = AnyInstructionIdentity(address: a)
+        me.blocks[b].setFirst(s)
+        return s
+      }
     }
   }
 

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -57,7 +57,7 @@ public struct IRFunction: Sendable {
     fileprivate private(set) var tag: InstructionTag
 
     /// The basic block containing `instruction`.
-    fileprivate let parent: IRBlock.ID
+    fileprivate var parent: IRBlock.ID
 
     /// Create an instance wrapping `instruction`, which is in `parent`.
     fileprivate init<T: Instruction>(instruction: T, parent: IRBlock.ID) {
@@ -438,6 +438,31 @@ public struct IRFunction: Sendable {
   /// Appends a basic block to this function and returns its identity.
   public mutating func addBlock() -> IRBlock.ID {
     blocks.append(.init())
+  }
+
+  /// Adds a new basic block, moves the instructions before `i` in that block, preserving relative
+  /// order, and returns the new block's identity.
+  ///
+  /// After calling this method, `i` is the first instruction of the new block and all instructions
+  /// preceding `i` are left in their current block, in the same order.
+  public mutating func split(before i: AnyInstructionIdentity) -> IRBlock.ID {
+    let a = block(defining: i)
+    let b = addBlock()
+
+    // Set `i` as the first instruction of the new block.
+    blocks[b].setFirst(i)
+    blocks[b].setLast(blocks[a].last!)
+
+    // Set the instruction before `i` as the last instruction of the block that got split.
+    if let j = instruction(before: i) {
+      blocks[a].setLast(j)
+    } else {
+      blocks[a].clear()
+    }
+
+    // Update the parent block of all instructions after `b`
+    for i in instructions(in: b) { slots[i.address].parent = b }
+    return b
   }
 
   /// Returns the instruction that follows `i`.

--- a/Sources/FrontEnd/IR/Instructions/Instruction.swift
+++ b/Sources/FrontEnd/IR/Instructions/Instruction.swift
@@ -13,8 +13,8 @@ public protocol Instruction: Hashable, Showable, Sendable {
   /// `true` iff `self` extends the lifetime of its operands.
   var isExtendingOperandLifetimes: Bool { get }
 
-  /// Creates a copy of `other`, substituting its properties with `ss`.
-  init(_ other: Self, substituting ss: IRSubstitutionTable)
+  /// Creates a copy of `other`, substituting its properties with `operands`.
+  init(_ other: Self, substituting operands: borrowing IRSubstitutionTable)
 
   /// Asserts that the well-formedness conditions of the instruction hold.
   func assertWellFormed(in parent: IRFunction, using program: inout Program) -> Bool
@@ -25,6 +25,16 @@ extension Instruction {
 
   /// The identity of an instance of `Self`.
   public typealias ID = ConcreteInstructionIdentity<Self>
+
+  /// Creates a copy of `other`, substituting its properties with `operands`, iff `other` is an
+  /// instance of `Self`.
+  public init?(_ other: any Instruction, substituting operands: borrowing IRSubstitutionTable) {
+    if let o = other as? Self {
+      self.init(o, substituting: operands)
+    } else {
+      return nil
+    }
+  }
 
   /// `true` iff `self` is a terminator instruction.
   public var isTerminator: Bool {

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
@@ -13,7 +13,7 @@ extension IRFunction {
         var j = instruction(after: i)!
 
         if let s = at(i) as? IRApply, case .function(let f, _, _) = s.callee {
-          // Should the callee be inliend?
+          // Should the callee be inlined?
           let callee = typer.program[m].ir[f]
           if !callee.isDefined || !typer.program.shouldInline(callee.name, in: m) { break }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
@@ -1,0 +1,81 @@
+extension IRFunction {
+
+  /// Inlines the contents of the callees in `self` that have been resolved statically to a
+  /// declaration annotated with `@inline(always)`.
+  internal mutating func inlineSimpleCallees(emittingInto m: Module.ID, using typer: inout Typer) {
+    var work = Array(blocks)
+    while let b = work.popLast() {
+      // Nothing to do if the block's empty.
+      guard var i = b.first else { continue }
+
+      // Look for calls to inline.
+      while i != b.last {
+        var j = instruction(after: i)!
+
+        if let s = at(i) as? IRApply, case .function(let f, _, _) = s.callee {
+          // Should the callee be inliend?
+          let callee = typer.program[m].ir[f]
+          if !callee.isDefined || !typer.program.shouldInline(callee.name, in: m) { break }
+
+          // Construct a table mapping each parameter to its argument.
+          var table = IRSubstitutionTable()
+          table[callee.returnRegister!] = s.result
+          for (p, a) in s.arguments.enumerated() {
+            table[.parameter(p)] = a
+          }
+
+          // Replace the call with the contents of the callee.
+          remove(i)
+          typer.program.withEmitter(insertingIn: m) { (emitter) in
+            emitter.insert(
+              contentsOf: callee, before: j, in: &self,
+              substitutingOperandsWith: table,
+              computingAnchorsWith: { (f, k) in f.at(k).anchor })
+          }
+        }
+
+        swap(&i, &j)
+      }
+    }
+  }
+
+}
+
+extension Program {
+
+  /// Returns `true` iff `f` refers to a declaration annotated with `@inline(always)`.
+  fileprivate func shouldInline(_ f: IRFunction.Name, in m: Module.ID) -> Bool {
+    switch f {
+    case .lowered(let d):
+      return shouldInline(d, in: m)
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` iff `d` is a declaration annotated with `@inline(always)`.
+  fileprivate func shouldInline(_ d: DeclarationIdentity, in m: Module.ID) -> Bool {
+    switch tag(of: d) {
+    case FunctionDeclaration.self:
+      return shouldInline(castUnchecked(d, to: FunctionDeclaration.self), in: m)
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` iff `d` is a declaration annotated with `@inline(always)`.
+  fileprivate func shouldInline(_ d: FunctionDeclaration.ID, in m: Module.ID) -> Bool {
+    switch tag(of: d) {
+    case FunctionDeclaration.self:
+      if let a = annotation("inline", appliedTo: d) {
+        return InliningPolicy(a) == .always
+      } else {
+        return false
+      }
+
+    default:
+      return false
+    }
+  }
+
+}

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -176,6 +176,16 @@ public struct Program: Sendable {
         // New functions are those that are stored after the end of the current window.
         window = typer.program[m].ir.functions.values.indices[window.endIndex...]
       }
+
+      // Apply mandatory inlining.
+      for i in typer.program[m].ir.functions.values.indices {
+        // Nothing to do if the function has no definition.
+        if !typer.program[m].ir[i].isDefined { continue }
+
+        var f = typer.program[m].ir[i].move()
+        f.inlineSimpleCallees(emittingInto: m, using: &typer)
+        typer.program[m].ir[i].take(definition: f)
+      }
     }
   }
 

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1301,6 +1301,11 @@ public struct Program: Sendable {
     }
   }
 
+  /// Returns the annotation named `k` that is applied to `n`, if any.
+  public func annotation<T: SyntaxIdentity>(_ k: String, appliedTo n: T) -> Annotation? {
+    annotations(n).first(where: { (a) in a.identifier.value == k })
+  }
+
   /// Returns the modifiers applied to `d`.
   public func modifiers(_ d: DeclarationIdentity) -> [Parsed<DeclarationModifier>] {
     if let m = self[d] as? any ModifiableDeclaration {

--- a/Sources/FrontEnd/Syntax/InliningPolicy.swift
+++ b/Sources/FrontEnd/Syntax/InliningPolicy.swift
@@ -1,0 +1,46 @@
+import Utilities
+
+/// When a function should be inlined.
+public enum InliningPolicy {
+
+  /// The function should never be inlined, even in optimized builds.
+  case never
+
+  /// The function should be inlined if possible, based on the optimizer's heuristics.
+  ///
+  /// Inlining occurs only in optimized builds and if the following conditions are met:
+  ///
+  /// * All symbols used in the function are inlineable from the perspective of the caller. In
+  ///   other words, n
+  ///
+  case opportunistic
+
+  /// The function must always be inlined, even in non-optimized builds.
+  case always
+
+  /// Creates an instance parsed from the given annotation.
+  init?(_ a: Annotation) {
+    if a.identifier.value != "inline" { return nil }
+
+    // Is the annotation of the form `@inline`?
+    if a.arguments.isEmpty {
+      self = .always
+    }
+
+    // Is the annotation of the form `@inline(policy)`?
+    else if let x = a.arguments.uniqueElement {
+      switch x.value {
+      case .string("always"):
+        self = .always
+      case .string("never"):
+        self = .never
+      default:
+        return nil
+      }
+    }
+
+    // The annotation is not valid.
+    else { return nil }
+  }
+
+}

--- a/Tests/CompilerTests/positive/inlining.hylo
+++ b/Tests/CompilerTests/positive/inlining.hylo
@@ -1,0 +1,10 @@
+//! stage:lowering
+
+@inline
+fun two() -> Int32 {
+  if true { 2 } else { 3 }
+}
+
+public fun main() -> Int32 {
+  two()
+}

--- a/Tests/CompilerTests/positive/inlining.hylo
+++ b/Tests/CompilerTests/positive/inlining.hylo
@@ -1,10 +1,10 @@
 //! stage:lowering
 
 @inline
-fun two() -> Int32 {
-  if true { 2 } else { 3 }
+fun two(c: Bool) -> Int32 {
+  if c { 2 } else { 3 }
 }
 
 public fun main() -> Int32 {
-  two()
+  two(true)
 }


### PR DESCRIPTION
This patch implements a simple inliner that processes functions annotated with `@inline(always)` (see https://github.com/orgs/hylo-lang/discussions/1895).