### PR TITLE
Adds fat arrow operators to given conformance declarations with context parameters

### DIFF
--- a/Sources/FrontEnd/Parser/Lexer.swift
+++ b/Sources/FrontEnd/Parser/Lexer.swift
@@ -222,7 +222,7 @@ public struct Lexer: IteratorProtocol, Sequence {
     case "&": tag = .ampersand
     case "=": tag = .assign
     case "->": tag = .arrow
-    case "=>": tag = .fatarrow
+    case "=>": tag = .thickArrow
     case "==": tag = .equal
     default: tag = .operator
     }

--- a/Sources/FrontEnd/Parser/Lexer.swift
+++ b/Sources/FrontEnd/Parser/Lexer.swift
@@ -222,8 +222,8 @@ public struct Lexer: IteratorProtocol, Sequence {
     case "&": tag = .ampersand
     case "=": tag = .assign
     case "->": tag = .arrow
-    case "==": tag = .equal
     case "=>": tag = .fatarrow
+    case "==": tag = .equal
     default: tag = .operator
     }
     return .init(tag: tag, site: span(start ..< position))

--- a/Sources/FrontEnd/Parser/Lexer.swift
+++ b/Sources/FrontEnd/Parser/Lexer.swift
@@ -223,6 +223,7 @@ public struct Lexer: IteratorProtocol, Sequence {
     case "=": tag = .assign
     case "->": tag = .arrow
     case "==": tag = .equal
+    case "=>": tag = .fatarrow
     default: tag = .operator
     }
     return .init(tag: tag, site: span(start ..< position))

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -470,7 +470,7 @@ public struct Parser {
     // Parse the context parameters and conformer of a conformance declaration.
     let parameters = try parseOptionalContextClause(in: &file)
     if !parameters.isEmpty {
-      _ = try take(.fatarrow) ?? expected("'=>'")
+      _ = try take(.thickArrow) ?? expected("'=>'")
     }
     let lhs = try parseExpression(in: &file)
 

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -469,6 +469,9 @@ public struct Parser {
 
     // Parse the context parameters and conformer of a conformance declaration.
     let parameters = try parseOptionalContextClause(in: &file)
+    if !parameters.isEmpty {
+      _ = try take(.fatarrow) ?? expected("'=>'")
+    }
     let lhs = try parseExpression(in: &file)
 
     // If the next token is `=`, we're parsing a given binding declaration whose `let` introducer

--- a/Sources/FrontEnd/Parser/Token.swift
+++ b/Sources/FrontEnd/Parser/Token.swift
@@ -58,6 +58,7 @@ public struct Token: Hashable, Sendable {
     case assign
     case conversion
     case equal
+    case fatarrow
     case star
     case `operator`
 

--- a/Sources/FrontEnd/Parser/Token.swift
+++ b/Sources/FrontEnd/Parser/Token.swift
@@ -58,7 +58,7 @@ public struct Token: Hashable, Sendable {
     case assign
     case conversion
     case equal
-    case fatarrow
+    case thickArrow
     case star
     case `operator`
 

--- a/StandardLibrary/Sources/Core/Copyable.hylo
+++ b/StandardLibrary/Sources/Core/Copyable.hylo
@@ -12,4 +12,4 @@ public trait Copyable refines Movable {
 public given Void is Copyable {}
 
 /// A witness that a tuple is `Copyable` when its elements are too.
-public given <T is Copyable, U is Copyable> {T, ...U} is Copyable {}
+public given <T is Copyable, U is Copyable> => {T, ...U} is Copyable {}

--- a/StandardLibrary/Sources/Core/Deinitializable.hylo
+++ b/StandardLibrary/Sources/Core/Deinitializable.hylo
@@ -12,4 +12,4 @@ public trait Deinitializable {
 public given Void is Deinitializable {}
 
 /// A witness that a tuple is `Deinitializable` when its elements are too.
-public given <T is Deinitializable, U is Deinitializable> {T, ...U} is Deinitializable {}
+public given <T is Deinitializable, U is Deinitializable> => {T, ...U} is Deinitializable {}

--- a/StandardLibrary/Sources/Core/Movable.hylo
+++ b/StandardLibrary/Sources/Core/Movable.hylo
@@ -24,4 +24,4 @@ extension T : Movable {
 public given Void is Movable {}
 
 /// A witness that a tuple is `Movable` when its elements are too.
-public given <T is Movable, U is Movable> {T, ...U} is Movable {}
+public given <T is Movable, U is Movable> => {T, ...U} is Movable {}

--- a/StandardLibrary/Sources/Core/Optional.hylo
+++ b/StandardLibrary/Sources/Core/Optional.hylo
@@ -10,4 +10,4 @@ public enum Optional<T> {
 
 }
 
-public given <T is Deinitializable> Optional<T> is Deinitializable {}
+public given <T is Deinitializable> => Optional<T> is Deinitializable {}

--- a/Tests/CompilerTests/negative/generic-requirement.diagnostics.expected
+++ b/Tests/CompilerTests/negative/generic-requirement.diagnostics.expected
@@ -1,3 +1,3 @@
 negative/generic-requirement.hylo:13.1-6: error: no implementation of 'f(x:)'
-given<T> S<T> is P {
+given<T> => S<T> is P {
 ~~~~~

--- a/Tests/CompilerTests/negative/generic-requirement.diagnostics.expected
+++ b/Tests/CompilerTests/negative/generic-requirement.diagnostics.expected
@@ -1,3 +1,3 @@
 negative/generic-requirement.hylo:13.1-6: error: no implementation of 'f(x:)'
-given<T> => S<T> is P {
+given <T> => S<T> is P {
 ~~~~~

--- a/Tests/CompilerTests/negative/generic-requirement.hylo
+++ b/Tests/CompilerTests/negative/generic-requirement.hylo
@@ -10,7 +10,7 @@ given Void is P {
 }
 
 struct S<T> {}
-given<T> S<T> is P {
+given<T> => S<T> is P {
   // This one isn't.
   public fun f(_ x: T) {}
 }

--- a/Tests/CompilerTests/negative/generic-requirement.hylo
+++ b/Tests/CompilerTests/negative/generic-requirement.hylo
@@ -10,7 +10,7 @@ given Void is P {
 }
 
 struct S<T> {}
-given<T> => S<T> is P {
+given <T> => S<T> is P {
   // This one isn't.
   public fun f(_ x: T) {}
 }

--- a/Tests/CompilerTests/negative/no-given-1.hylo
+++ b/Tests/CompilerTests/negative/no-given-1.hylo
@@ -10,12 +10,12 @@ fun f<where A is Q>() {}
 
 fun g() {
   given B is P {}
-  given <where A is P> A is Q {}
+  given <where A is P> => A is Q {}
   f()
 }
 
 fun h() {
-  given <T where T is P> T is Q {}
+  given <T where T is P> => T is Q {}
   f()
 }
 

--- a/Tests/CompilerTests/negative/synthetic-conformance.diagnostics.expected
+++ b/Tests/CompilerTests/negative/synthetic-conformance.diagnostics.expected
@@ -1,5 +1,5 @@
 negative/synthetic-conformance.hylo:20.1-6: error: no implementation of 'deinit'
-given <X> Box<X> is Deinitializable {}
+given <X> => Box<X> is Deinitializable {}
 ~~~~~
 negative/synthetic-conformance.hylo:23.42-57: error: no implementation of 'deinit'
 struct NotStructurallyDeinitializable is Deinitializable {

--- a/Tests/CompilerTests/negative/synthetic-conformance.hylo
+++ b/Tests/CompilerTests/negative/synthetic-conformance.hylo
@@ -14,10 +14,10 @@ struct B is Deinitializable {
 }
 
 // Conformance is synthesizable using the where clause.
-given <X where X is Deinitializable> Box<X> is Deinitializable {}
+given <X where X is Deinitializable> => Box<X> is Deinitializable {}
 
 // Conformance is not synthesizable.
-given <X> Box<X> is Deinitializable {}
+given <X> => Box<X> is Deinitializable {}
 
 // A struct whose contents isn't structurally deinitializable.
 struct NotStructurallyDeinitializable is Deinitializable {

--- a/Tests/CompilerTests/negative/trait-refinement.diagnostics.expected
+++ b/Tests/CompilerTests/negative/trait-refinement.diagnostics.expected
@@ -1,6 +1,6 @@
 negative/trait-refinement.hylo:36.1-6: error: no given instance of 'Base<B<T>>' in this scope
-given <T> B<T> is Derived {}
+given <T> => B<T> is Derived {}
 ~~~~~
 negative/trait-refinement.hylo:39.1-6: error: no given instance of 'Derived<C<T>>' in this scope
-given <T> C<T> is FurtherDerived {}
+given <T> => C<T> is FurtherDerived {}
 ~~~~~

--- a/Tests/CompilerTests/negative/trait-refinement.hylo
+++ b/Tests/CompilerTests/negative/trait-refinement.hylo
@@ -25,15 +25,15 @@ struct A<T> {}
 struct B<T> {}
 struct C<T> {}
 
-given <T> A<T> is Base {
+given <T> => A<T> is Base {
   fun f() {}
 }
 
 // This one is OK.
-given <T> A<T> is Derived {}
+given <T> => A<T> is Derived {}
 
 // This one is missing an instance of `Base<B<T>>`.
-given <T> B<T> is Derived {}
+given <T> => B<T> is Derived {}
 
 // This one is missing an instance of `Derived<C<T>>`
-given <T> C<T> is FurtherDerived {}
+given <T> => C<T> is FurtherDerived {}

--- a/Tests/CompilerTests/positive/context-bound.hylo
+++ b/Tests/CompilerTests/positive/context-bound.hylo
@@ -6,7 +6,7 @@ struct A<T> {
   var x: T
 }
 
-given <T is P> A<T> is P {
+given <T is P> => A<T> is P {
   fun f() { self.x.f() }
 }
 

--- a/Tests/CompilerTests/positive/generic-call-2.hylo
+++ b/Tests/CompilerTests/positive/generic-call-2.hylo
@@ -12,7 +12,7 @@ given Int is P {
   fun i() -> Int32 { 24 }
 }
 
-given <where Int is P> Int is Q {
+given <where Int is P> => Int is Q {
   fun i() -> Int32 { 42 }
 }
 

--- a/Tests/CompilerTests/positive/generic-given.hylo
+++ b/Tests/CompilerTests/positive/generic-given.hylo
@@ -7,15 +7,15 @@ struct B<T> {}
 struct C<T> {}
 
 // Requirement implemented in primary declaration.
-given <T> A<T> is P {}
+given <T> => A<T> is P {}
 
 // Requirement implemented in the conformance declaration.
-given <T> B<T> is P {
+given <T> => B<T> is P {
   fun g() {}
 }
 
 // Requirement implemented in extension.
-given <T> C<T> is P {}
+given <T> => C<T> is P {}
 extension <T> C<T> {
   fun g() {}
 }

--- a/Tests/CompilerTests/positive/generic-member.hylo
+++ b/Tests/CompilerTests/positive/generic-member.hylo
@@ -16,7 +16,7 @@ trait P<T> {
   static fun sh(x: T)
 }
 
-given <T> A<T> is P<T> {
+given <T> => A<T> is P<T> {
   public fun h(x: T) {}
   public static fun sh(x: T) {}
 }

--- a/Tests/CompilerTests/positive/local-given.hylo
+++ b/Tests/CompilerTests/positive/local-given.hylo
@@ -11,12 +11,12 @@ fun f<where B is P>() {
 
 fun g() {
   given A is P {}
-  given <where A is P> B is P {}
+  given <where A is P> => B is P {}
   f()
 }
 
 fun h() {
   given B is Q {}
-  given <T where T is Q> T is P {}
+  given <T where T is Q> => T is P {}
   f()
 }

--- a/Tests/CompilerTests/positive/nullary-conformance.hylo
+++ b/Tests/CompilerTests/positive/nullary-conformance.hylo
@@ -3,7 +3,7 @@
 trait P {}
 
 given a : Void is P {}
-given b : <T where T is P> Int is P {}
+given b : <T where T is P> => Int is P {}
 
 fun use<T is P>(x: T) {}
 


### PR DESCRIPTION
Adds fat arrow operators to given conformance declarations with context parameters. Given conformance declarations with context parameters now have the syntax:
```
'given' '<' generic-parameters where-clause? '>' '=>' expression
```

This PR adds '=>' as an operator token type. Closes #194