### PR TITLE
Add a pass verifying inlining requirements

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1767,22 +1767,23 @@ internal struct IREmitter {
     }
   }
 
-  /// If `d` declares a stored property of in a type whose layout is visible from `scopeOfUse`,
-  /// returns that property's index. Otherwise, returns `nil`.
+  /// If `d` declares a stored property of a type whose layout is visible in `scopeOfUse`, returns
+  /// that property's index; otherwise, returns `nil`.
   ///
   /// The index of a stored property is used in instances of `IndexPath` to represent the location
   /// of a part relative to the location of a whole. For example, if `S` is a struct with two
   /// stored properties `x` and `y`, declared in that order, the index of `y` is 1.
   ///
-  /// The layout of a type if visible if its declaration is in the same module as`scopeOfUse` or
-  /// if its declaration is marked `inlineable`.
+  /// If resilience is enabled in the module containing `d`, the layout of the type declared by `d`
+  /// is visible if `d` is the same module as `scopeOfUse` or if `d` is annotated with `@frozen`.
+  /// Layouts are always visible when resilience is disabled.
   private mutating func storedPropertyIndex(
     of d: DeclarationIdentity, in scopeOfUse: ScopeIdentity
   ) -> Int? {
     guard
       let v = program.cast(d, to: VariableDeclaration.self),
       let p = program.parent(containing: v, as: StructDeclaration.self),
-      program.isInlineable(p, in: scopeOfUse)
+      program.isLayoutVisible(p, in: scopeOfUse)
     else { return nil }
 
     let properties = program.storedProperties(of: p)

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
@@ -1,5 +1,26 @@
 extension IRFunction {
 
+  /// If `self` is exposed and must be inlined, verifies that it only uses exposed symbols.
+  internal func upholdInliningRequirements(in m: Module.ID, using typer: inout Typer) -> Bool {
+    // Nothing to do unless inlining is mandated and the function is exposed.
+    if typer.program.inliningPolicy(of: name) != .always { return true }
+    if typer.program.isPrivate(name, in: m) { return true }
+
+    var success = true
+    for i in instructions() {
+      if let s = at(i) as? IRApply, case .function(let f, _, _) = s.callee {
+        if typer.program.isPrivate(typer.program[m].ir[f].name, in: m) {
+          let d = Diagnostic(
+            .error, "use of non-exposed function in inlined function", at: s.anchor.site)
+          typer.program[m].addDiagnostic(d)
+          success = false
+        }
+      }
+    }
+
+    return success
+  }
+
   /// Inlines the contents of the callees in `self` that have been resolved statically to a
   /// declaration annotated with `@inline(always)`.
   internal mutating func inlineSimpleCallees(emittingInto m: Module.ID, using typer: inout Typer) {
@@ -15,7 +36,7 @@ extension IRFunction {
         if let s = at(i) as? IRApply, case .function(let f, _, _) = s.callee {
           // Should the callee be inlined?
           let callee = typer.program[m].ir[f]
-          if !callee.isDefined || !typer.program.shouldInline(callee.name, in: m) { break }
+          if !callee.isDefined || !typer.program.shouldInline(callee.name) { break }
 
           // Construct a table mapping each parameter to its argument.
           var table = IRSubstitutionTable()
@@ -42,39 +63,29 @@ extension IRFunction {
 
 extension Program {
 
-  /// Returns `true` iff `f` refers to a declaration annotated with `@inline(always)`.
-  fileprivate func shouldInline(_ f: IRFunction.Name, in m: Module.ID) -> Bool {
+  /// Returns the conditions under which the body of `f` should be inlined.
+  fileprivate func inliningPolicy(of f: IRFunction.Name) -> InliningPolicy {
     switch f {
     case .lowered(let d):
-      return shouldInline(d, in: m)
+      return inliningPolicy(of: d) ?? .opportunistic
     default:
-      return false
+      return .opportunistic
     }
   }
 
-  /// Returns `true` iff `d` is a declaration annotated with `@inline(always)`.
-  fileprivate func shouldInline(_ d: DeclarationIdentity, in m: Module.ID) -> Bool {
+  /// Returns the conditions under which the body of `f` should be inlined, if defined.
+  fileprivate func inliningPolicy(of d: DeclarationIdentity) -> InliningPolicy? {
     switch tag(of: d) {
     case FunctionDeclaration.self:
-      return shouldInline(castUnchecked(d, to: FunctionDeclaration.self), in: m)
+      return .some(self[castUnchecked(d, to: FunctionDeclaration.self)].inliningPolicy)
     default:
-      return false
+      return .none
     }
   }
 
-  /// Returns `true` iff `d` is a declaration annotated with `@inline(always)`.
-  fileprivate func shouldInline(_ d: FunctionDeclaration.ID, in m: Module.ID) -> Bool {
-    switch tag(of: d) {
-    case FunctionDeclaration.self:
-      if let a = annotation("inline", appliedTo: d) {
-        return InliningPolicy(a) == .always
-      } else {
-        return false
-      }
-
-    default:
-      return false
-    }
+  /// Returns `true` iff `f` refers to a declaration annotated with `@inline(always)`.
+  fileprivate func shouldInline(_ f: IRFunction.Name) -> Bool {
+    inliningPolicy(of: f) == .always
   }
 
 }

--- a/Sources/FrontEnd/Parser/Lexer.swift
+++ b/Sources/FrontEnd/Parser/Lexer.swift
@@ -163,12 +163,11 @@ public struct Lexer: IteratorProtocol, Sequence {
     case "infix": tag = .infix
     case "init": tag = .`init`
     case "inout": tag = .inout
-    case "internal": tag = .internal
     case "let": tag = .let
+    case "module": tag = .module
     case "match": tag = .match
     case "postfix": tag = .postfix
     case "prefix": tag = .prefix
-    case "private": tag = .private
     case "public": tag = .public
     case "return": tag = .return
     case "set": tag = .set

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -216,7 +216,7 @@ public struct Parser {
   /// Parses a declaration modifier if the next token denotes one.
   ///
   ///     declaration-modifier ::= (one of)
-  ///       static private internal public indirect inlineable
+  ///       static private internal public indirect
   ///
   private mutating func parseOptionalDeclarationModifier() -> Parsed<DeclarationModifier>? {
     // Hard keywords.
@@ -230,10 +230,6 @@ public struct Parser {
       case "indirect" where context.isTypeBody:
         _ = take()
         return .init(.indirect, at: t.site)
-
-      case "inlineable" where !context.isLocal:
-        _ = take()
-        return .init(.inlineable, at: t.site)
 
       default:
         return nil

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -2876,8 +2876,7 @@ extension DeclarationModifier: ExpressibleByTokenTag {
   fileprivate init?(tag: Token.Tag) {
     switch tag {
     case .static: self = .static
-    case .private: self = .private
-    case .internal: self = .internal
+    case .module: self = .module
     case .public: self = .public
     default: return nil
     }

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -174,6 +174,11 @@ public struct Parser {
       return .init(.string(String(s.text.dropFirst().dropLast())), at: s.site)
     }
 
+    // Is it a simple identifier?
+    else if let s = take(.name) {
+      return .init(.string(String(s.text)), at: s.site)
+    }
+
     // Is it a number argument?
     else if let s = take(.integerLiteral) {
       if let n = Int(s.text) {

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -161,6 +161,21 @@ public struct Parser {
       arguments = []
     }
 
+    // Validate the annotation.
+    switch identifier.text {
+    case "inline":
+      if let (x, xs) = arguments.headAndTail {
+        if x.value != .string("always") && x.value != .string("never") {
+          report(expected("'always' or 'never'", at: x.site))
+        } else if let y = xs.first {
+          report(.init("'@inline' accepts at most 1 argument", at: y.site))
+        }
+      }
+
+    default:
+      break
+    }
+
     return Annotation(
       identifier: .init(identifier),
       arguments: arguments,

--- a/Sources/FrontEnd/Parser/Token.swift
+++ b/Sources/FrontEnd/Parser/Token.swift
@@ -25,12 +25,11 @@ public struct Token: Hashable, Sendable {
     case infix
     case `init`
     case `inout`
-    case `internal`
     case `let`
     case match
+    case module
     case postfix
     case prefix
-    case `private`
     case `public`
     case `return`
     case set
@@ -131,7 +130,7 @@ public struct Token: Hashable, Sendable {
   /// `true` iff `self` is a declaration modifier.
   public var isDeclarationModifier: Bool {
     switch tag {
-    case .static, .private, .internal, .public:
+    case .static, .module, .public:
       return true
     default:
       return false

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -140,6 +140,7 @@ public struct Program: Sendable {
 
         if !work[i].function.normalizeLifetimes(emittingInto: m, using: &typer) { continue }
         if !work[i].function.upholdExclusivity(emittingInto: m, using: &typer) { continue }
+        if !work[i].function.upholdInliningRequirements(in: m, using: &typer) { continue }
 
         // This pass cannot fail.
         work[i].function.depolymorphize(emittingInto: m, using: &typer)
@@ -164,8 +165,7 @@ public struct Program: Sendable {
           let module = typer.program[m]
           guard
             case .existentialized(let a) = module.ir[i].name,
-            case .some(let poly) = module.ir.functions.index(forKey: a),
-            module.ir[poly].isDefined
+            case .some(let poly) = module.ir.functions.index(forKey: a), module.ir[poly].isDefined
           else { continue }
 
           typer.program.withEmitter(insertingIn: m) { (emitter) in
@@ -444,12 +444,67 @@ public struct Program: Sendable {
 
   /// Returns `true` iff `n` is a an interface for a function written in another language.
   public func isForeign(_ n: FunctionDeclaration.ID) -> Bool {
-    self[n].annotations.contains(where: { (a) in a.identifier.value == "foreign" })
+    annotation("foreign", appliedTo: n) != nil
   }
 
   /// Returns `true` iff `n` has an external implementation.
   public func isExtern(_ n: FunctionDeclaration.ID) -> Bool {
-    self[n].annotations.contains(where: { (a) in a.identifier.value == "extern" })
+    annotation("extern", appliedTo: n) != nil
+  }
+
+  /// Returns `true` if the contents of `d` is visible in all modules.
+  ///
+  /// The result is `true` if `d` is annotated with `@exposed` and/or `d` and all the scopes
+  /// enclosing it are public.
+  public func isExposed<T: ModifiableDeclaration>(_ d: T.ID) -> Bool {
+    // Is `d` explicitly exposed?
+    if (annotation("exposed", appliedTo: d) != nil) { return true }
+
+    // Otherwise, `d` and its enclosing scopes must be public.
+    if !self[d].is(.public) { return false }
+    var p = parent(containing: d)
+    while let a = p.node {
+      guard let b = self[a] as? (any ModifiableDeclaration), b.is(.public) else { return false }
+      p = parent(containing: a)
+    }
+    return p.isFile
+  }
+
+  /// Returns `true` iff `d` declares symbols that will not appear in the ABI of `m`.
+  public func isPrivate(_ d: DeclarationIdentity, in m: Module.ID) -> Bool {
+    switch tag(of: d) {
+    case BindingDeclaration.self:
+      return isPrivate(castUnchecked(d, to: BindingDeclaration.self), in: m)
+    case FunctionDeclaration.self:
+      return isPrivate(castUnchecked(d, to: FunctionDeclaration.self), in: m)
+    case FunctionBundleDeclaration.self:
+      return isPrivate(castUnchecked(d, to: FunctionBundleDeclaration.self), in: m)
+    case VariantDeclaration.self:
+      return isPrivate(parent(containing: d, as: FunctionBundleDeclaration.self)!, in: m)
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` iff `d` declares symbols that will not appear in the ABI of `m`.
+  public func isPrivate<T: ModifiableDeclaration>(_ d: T.ID, in m: Module.ID) -> Bool {
+    (d.module == m) && !isExposed(d)
+  }
+
+  /// Returns `true` iff `f` will not appear in the ABI of `m`.
+  public func isPrivate(_ f: IRFunction.Name, in m: Module.ID) -> Bool {
+    switch f {
+    case .lowered(let d):
+      return isPrivate(d, in: m)
+    case .initializer(let d):
+      return isPrivate(d, in: m)
+    case .synthesized(let d, _):
+      return isPrivate(d, in: m)
+    case .implementation(_, let d, _):
+      return isPrivate(d, in: m)
+    case .existentialized(let g):
+      return isPrivate(g, in: m)
+    }
   }
 
   /// Returns `true` iff `n` denotes an expression.

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -545,7 +545,7 @@ public struct Program: Sendable {
     _ t: Struct.ID, in s: ScopeIdentity
   ) -> Bool {
     let d = types[t].declaration
-    return isInlineable(d, in: s) && storedProperties(of: d).isEmpty
+    return isLayoutVisible(d, in: s) && storedProperties(of: d).isEmpty
   }
 
   /// Returns `true` iff instances of `t` can always be assumed initialized in `s`.
@@ -563,26 +563,10 @@ public struct Program: Sendable {
     isTriviallyInitializable(types[t].abstraction, in: s)
   }
 
-  /// Returns `true` if the memory layout of `t` is visible from `scopeOfUse`.
-  public mutating func isInlineable(_ t: AnyTypeIdentity, in scopeOfUse: ScopeIdentity) -> Bool {
-    let u = types.dealiased(t)
-    switch types.tag(of: u) {
-    case Enum.self:
-      return isInlineable((types[u] as! Enum).declaration, in: scopeOfUse)
-    case Struct.self:
-      return isInlineable((types[u] as! Struct).declaration, in: scopeOfUse)
-    case Tuple.self:
-      return true
-    default:
-      return false
-    }
-  }
-
-  /// Returns `true` if the definition of `t` is visible from `scopeOfUse`.
-  public func isInlineable<T: ModifiableDeclaration>(
-    _ d: T.ID, in scopeOfUse: ScopeIdentity
-  ) -> Bool {
-    (d.module == scopeOfUse.module) || self[d].is(.inlineable)
+  /// If resilience is enabled in the module containing `d`, returns `true` if `d` is in the same
+  /// module as `scopeOfUse` or if `d` is annotated with `@frozen`; otherwise, returns `true`.
+  public func isLayoutVisible(_ d: StructDeclaration.ID, in scopeOfUse: ScopeIdentity) -> Bool {
+    true
   }
 
   /// Returns `n` if it identifies a node of type `U`; otherwise, returns `nil`.

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -26,9 +26,9 @@ public struct Program: Sendable {
 
   /// `true` iff the program is allowed to have an only partially loaded standard library.
   ///
-  /// If set, this flag signals that the program is being used in a context where the standard
-  // library may not be fully available, such as during testing with minimal standard library. In
-  // this case, the absence of some standard library declarations won't be treated as an error.
+  /// If set, this flag signals that the program is used in a context where the standard library
+  /// may not be fully available, such as during testing with minimal standard library. In this
+  /// case, the absence of some standard library declarations won't be treated as an error.
   private var allowPartialStandardLibrary: Bool = false
 
   /// Creates an empty program.

--- a/Sources/FrontEnd/Syntax/Declarations/ConformanceDeclaration.swift
+++ b/Sources/FrontEnd/Syntax/Declarations/ConformanceDeclaration.swift
@@ -2,7 +2,7 @@ import Archivist
 
 /// The declaration of a conformance of a type to a trait.
 @Archivable
-public struct ConformanceDeclaration: TypeExtendingDeclaration {
+public struct ConformanceDeclaration: TypeExtendingDeclaration, ModifiableDeclaration {
 
   /// The modifiers applied to this declaration.
   public let modifiers: [Parsed<DeclarationModifier>]

--- a/Sources/FrontEnd/Syntax/Declarations/DeclarationModifier.swift
+++ b/Sources/FrontEnd/Syntax/Declarations/DeclarationModifier.swift
@@ -10,11 +10,8 @@ public enum DeclarationModifier: UInt8, Sendable {
   /// Introduces a static member.
   case `static`
 
-  /// Introduces an entity only within its enclosing scope.
-  case `private`
-
   /// Introduces an entity visible up to the module boundary.
-  case `internal`
+  case `module`
 
   /// Introduces an entity visible beyond the module boundary.
   case `public`
@@ -53,7 +50,7 @@ public enum DeclarationModifier: UInt8, Sendable {
   /// Returns `true` iff `self` is an access modifier.
   public var isAccessModifier: Bool {
     switch self {
-    case .private, .internal, .public:
+    case .module, .public:
       return true
     default:
       return false

--- a/Sources/FrontEnd/Syntax/Declarations/DeclarationModifier.swift
+++ b/Sources/FrontEnd/Syntax/Declarations/DeclarationModifier.swift
@@ -16,19 +16,13 @@ public enum DeclarationModifier: UInt8, Sendable {
   /// Introduces an entity visible beyond the module boundary.
   case `public`
 
-  /// Introduces an entity whose contents is visible across resilience boundaries.
-  case inlineable
-
   /// Returns `true` iff `self` can appear after `other` in sources.
   public func canOccurAfter(_ other: DeclarationModifier) -> Bool {
     switch self {
     case .indirect, .static:
       return true
-    case .inlineable:
-      return false
     default:
-      assert(isAccessModifier)
-      return other == .inlineable
+      return false
     }
   }
 
@@ -39,8 +33,6 @@ public enum DeclarationModifier: UInt8, Sendable {
       return (other != self) && (other != .static)
     case .static:
       return (other != self) && (other != .indirect)
-    case .inlineable:
-      return true
     default:
       assert(isAccessModifier)
       return !other.isAccessModifier
@@ -69,12 +61,12 @@ public enum DeclarationModifier: UInt8, Sendable {
 
   /// Returns `true` iff `self` can be applied on an initializer declaration.
   public var isApplicableToInitializer: Bool {
-    isAccessModifier || self == .inlineable
+    isAccessModifier
   }
 
   /// Returns `true` iff `self` can be applied on a type declaration.
   public var isApplicableToTypeDeclaration: Bool {
-    isAccessModifier || self == .inlineable
+    isAccessModifier
   }
 
 }

--- a/Sources/FrontEnd/Syntax/Declarations/FunctionDeclaration.swift
+++ b/Sources/FrontEnd/Syntax/Declarations/FunctionDeclaration.swift
@@ -98,6 +98,15 @@ public struct FunctionDeclaration: RoutineDeclaration, Annotatable, Scope {
     introducer.value == .memberwiseinit
   }
 
+  /// The conditions under which the body of the function should be inlined.
+  public var inliningPolicy: InliningPolicy {
+    if let a = annotations.first(where: { (a) in a.identifier.value == "inline" }) {
+      return InliningPolicy(a)!
+    } else {
+      return .opportunistic
+    }
+  }
+
 }
 
 extension FunctionDeclaration: Showable {

--- a/StandardLibrary/Sources/Core/Bool.hylo
+++ b/StandardLibrary/Sources/Core/Bool.hylo
@@ -3,10 +3,10 @@
 public struct Bool is Deinitializable {
 
   /// The raw value of this instance.
-  internal var value: Builtin.i1
+  module var value: Builtin.i1
 
   /// Creates an instance with its raw value.
-  internal memberwise init
+  module memberwise init
 
   /// Creates an instance equal to `false`.
   public init() {

--- a/StandardLibrary/Sources/Core/Numbers/Float32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Float32.hylo
@@ -2,11 +2,11 @@
 struct Float32 is Deinitializable {
   
   /// The raw value of this instance.
-  internal var value: Builtin.float32
+  module var value: Builtin.float32
 
   /// Creates an instance with its raw value.
-  internal memberwise init
-  
+  module memberwise init
+
   /// Creates an instance with value 0.
   public init() {
     &self.value = Builtin.zeroinitializer_float32()

--- a/StandardLibrary/Sources/Core/Numbers/Float64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Float64.hylo
@@ -2,11 +2,11 @@
 public struct Float64 is Deinitializable {
   
   /// The raw value of this instance.
-  internal var value: Builtin.float64
+  module var value: Builtin.float64
 
   /// Creates an instance with its raw value.
-  internal memberwise init
-  
+  module memberwise init
+
   /// Creates an instance with value 0.
   public init() {
     &self.value = Builtin.zeroinitializer_float64()

--- a/StandardLibrary/Sources/Core/Numbers/Int.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int.hylo
@@ -3,10 +3,10 @@
 public struct Int is Deinitializable {
 
   /// The raw value of this instance.
-  internal var value: Builtin.word
+  module var value: Builtin.word
 
   /// Creates an instance with its raw value.
-  internal memberwise init
+  module memberwise init
 
   /// Creates an instance with value `0`.
   public init() {

--- a/StandardLibrary/Sources/Core/Numbers/Int32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int32.hylo
@@ -3,10 +3,10 @@
 public struct Int32 is Deinitializable {
 
   /// The raw value of this instance.
-  internal var value: Builtin.i32
+  module var value: Builtin.i32
 
   /// Creates an instance with its raw value.
-  internal memberwise init
+  module memberwise init
 
   /// Creates an instance with value `0`.
   public init() {

--- a/StandardLibrary/Sources/Core/Numbers/Int64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int64.hylo
@@ -3,10 +3,10 @@
 public struct Int64 is Deinitializable {
 
   /// The raw value of this instance.
-  internal var value: Builtin.i64
+  module var value: Builtin.i64
 
   /// Creates an instance with its raw value.
-  internal memberwise init
+  module memberwise init
 
   /// Creates an instance with value `0`.
   public init() {

--- a/StandardLibrary/Sources/Core/Pointer.hylo
+++ b/StandardLibrary/Sources/Core/Pointer.hylo
@@ -2,10 +2,10 @@
 public struct Pointer<Pointee> {
 
   /// The raw value of this instance.
-  internal var value: Builtin.ptr
+  module var value: Builtin.ptr
 
   /// Creates an instance with the given raw value.
-  internal memberwise init
+  module memberwise init
 
   /// Creates an instance that does not address any usable storage.
   public static fun null() -> Self {

--- a/Tests/CompilerTests/negative/illegal-inlining.diagnostics.expected
+++ b/Tests/CompilerTests/negative/illegal-inlining.diagnostics.expected
@@ -1,0 +1,3 @@
+negative/illegal-inlining.hylo:14.5-14: error: use of non-exposed function in inlined function
+    self.m1()
+    ~~~~~~~~~

--- a/Tests/CompilerTests/negative/illegal-inlining.hylo
+++ b/Tests/CompilerTests/negative/illegal-inlining.hylo
@@ -1,0 +1,22 @@
+//! stage:lowering
+
+public fun f0() {}
+
+struct S {
+
+  @inline(always) @exposed
+  fun g0() {
+    // OK: `f0` is public to the whole module.
+    f0()
+    // OK: `m0` is explicitly exposed.
+    self.m0()
+    // Error: `m1` is not exposed because `S` is not public.
+    self.m1()
+  }
+
+  @exposed
+  public fun m0() {}
+
+  public fun m1() {}
+
+}

--- a/Tests/CompilerTests/negative/invalid-annotation.diagnostics.expected
+++ b/Tests/CompilerTests/negative/invalid-annotation.diagnostics.expected
@@ -16,3 +16,9 @@ negative/invalid-annotation.hylo:15.1-6: error: invalid annotation
 negative/invalid-annotation.hylo:17.1-6: error: invalid annotation
 @blah given Void is P {}
 ~~~~~
+negative/invalid-annotation.hylo:19.9-12: error: expected 'always' or 'never'
+@inline(foo) fun f0() {}
+        ~~~
+negative/invalid-annotation.hylo:20.16-17: error: '@inline' accepts at most 1 argument
+@inline(never, 1) fun f1() {}
+               ^

--- a/Tests/CompilerTests/negative/invalid-annotation.hylo
+++ b/Tests/CompilerTests/negative/invalid-annotation.hylo
@@ -15,3 +15,6 @@ trait P {
 @blah extension Void {}
 
 @blah given Void is P {}
+
+@inline(foo) fun f0() {}
+@inline(never, 1) fun f1() {}

--- a/Tests/FrontEndTests/Parser/LexerTests.swift
+++ b/Tests/FrontEndTests/Parser/LexerTests.swift
@@ -139,9 +139,8 @@ final class LexerTests: XCTestCase {
 
   func testKeywords() throws {
     let input: SourceFile = """
-      auto case else enum extension false fun given if import infix init inout internal let match
-      postfix prefix private public return set sink static struct subscript trait true type var
-      where yield
+      auto case else enum extension false fun given if import infix init inout let match module
+      postfix prefix public return set sink static struct subscript trait true type var where yield
       """
     var scanner = Lexer(tokenizing: input)
     try assertNext(from: &scanner, is: .auto)
@@ -157,12 +156,11 @@ final class LexerTests: XCTestCase {
     try assertNext(from: &scanner, is: .infix)
     try assertNext(from: &scanner, is: .`init`)
     try assertNext(from: &scanner, is: .inout)
-    try assertNext(from: &scanner, is: .internal)
     try assertNext(from: &scanner, is: .let)
     try assertNext(from: &scanner, is: .match)
+    try assertNext(from: &scanner, is: .module)
     try assertNext(from: &scanner, is: .postfix)
     try assertNext(from: &scanner, is: .prefix)
-    try assertNext(from: &scanner, is: .private)
     try assertNext(from: &scanner, is: .public)
     try assertNext(from: &scanner, is: .return)
     try assertNext(from: &scanner, is: .set)


### PR DESCRIPTION
This patch implements a pass checking that declarations annotated with `@inline(always)` are indeed inlineable.

The pass implements only a basic test that looks at all function applications and verify if they have sufficient exposure. A complete implementation should consider more complicated call patterns and also verify that inlined functions are not recursive.

See [this discussion](https://github.com/orgs/hylo-lang/discussions/1895#discussion-10149255) for more details about the design goals.