### PR TITLE
refactor: cache standard library type classification in Typer

### DIFF
--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4639,7 +4639,7 @@ public struct Typer {
     guard program.containsStandardLibrary else { return false }
 
     let u = program.types.dealiased(t)
-    return ts.contains { u == standardLibraryType($0) }
+    return ts.contains(where: { (v) in standardLibraryType(v) == u })
   }
 
   /// Returns the type of the given standard library entity.

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -102,6 +102,9 @@ public struct Typer {
     /// The cache of `Typer.declaredType(of:)` for predefined givens.
     fileprivate var predefinedGivens: [Given: AnyTypeIdentity]
 
+    /// The cache of `Typer.standardLibraryType(_:)`.
+    fileprivate var standardLibraryEntityToType: [Program.StandardLibraryEntity: AnyTypeIdentity]
+
     /// The cache of `Typer.canDeriveCoercion(_:_:applying:)`.
     fileprivate var canDeriveCoercion: [Given: [TypePair: (Bool, Bool)]]
 
@@ -121,6 +124,7 @@ public struct Typer {
       self.witnessToAliases = [:]
       self.declarationToTentativeType = [:]
       self.predefinedGivens = [:]
+      self.standardLibraryEntityToType = [:]
       self.canDeriveCoercion = [:]
     }
 
@@ -4616,15 +4620,7 @@ public struct Typer {
   /// The module containing the standard library must have been loaded in the `self.program`, or
   /// `self.module` is the standard library.
   private mutating func isStandardLibraryIntegerType(_ t: AnyTypeIdentity) -> Bool {
-    guard program.containsStandardLibrary else { return false }
-    switch program.types.dealiased(t) {
-    case standardLibraryType(.int),
-        standardLibraryType(.int32),
-        standardLibraryType(.int64):
-      return true
-    default:
-      return false
-    }
+    isStandardLibraryType(t, in: [.int, .int32, .int64])
   }
 
   /// Returns `true` iff `t` is a standard library floating point type (e.g., `Hylo.Float32`).
@@ -4632,14 +4628,21 @@ public struct Typer {
   /// The module containing the standard library must have been loaded in the `self.program`, or
   /// `self.module` is the standard library.
   private mutating func isStandardLibraryFloatingPointType(_ t: AnyTypeIdentity) -> Bool {
+    isStandardLibraryType(t, in: [.float32, .float64])
+  }
+
+  /// Returns `true` iff `t` is one of the given standard library types.
+  private mutating func isStandardLibraryType(
+    _ t: AnyTypeIdentity,
+    in ts: [Program.StandardLibraryEntity]
+  ) -> Bool {
     guard program.containsStandardLibrary else { return false }
-    switch program.types.dealiased(t) {
-    case standardLibraryType(.float32),
-        standardLibraryType(.float64):
-      return true
-    default:
-      return false
+
+    let u = program.types.dealiased(t)
+    for e in ts {
+      if u == standardLibraryType(e) { return true }
     }
+    return false
   }
 
   /// Returns the type of the given standard library entity.
@@ -4652,6 +4655,8 @@ public struct Typer {
   private mutating func standardLibraryType(
     _ n: Program.StandardLibraryEntity
   ) -> AnyTypeIdentity {
+    if let t = cache.standardLibraryEntityToType[n] { return t }
+
     let d = program.standardLibraryDeclaration(n)
 
     let t: AnyTypeIdentity
@@ -4664,7 +4669,9 @@ public struct Typer {
     }
 
     let m = (program.types[t] as? Metatype) ?? fatalError("missing or corrupt standard library")
-    return m.inhabitant
+    let result = m.inhabitant
+    cache.standardLibraryEntityToType[n] = result
+    return result
   }
 
   // MARK: Helpers

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4631,7 +4631,7 @@ public struct Typer {
     isStandardLibraryType(t, in: [.float32, .float64])
   }
 
-  /// Returns `true` iff `t` is one of the given standard library types.
+  /// Returns `true` iff `t` is one of the standard library types `ts`.
   private mutating func isStandardLibraryType(
     _ t: AnyTypeIdentity,
     in ts: [Program.StandardLibraryEntity]

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4639,10 +4639,7 @@ public struct Typer {
     guard program.containsStandardLibrary else { return false }
 
     let u = program.types.dealiased(t)
-    for e in ts {
-      if u == standardLibraryType(e) { return true }
-    }
-    return false
+    return ts.contains { u == standardLibraryType($0) }
   }
 
   /// Returns the type of the given standard library entity.


### PR DESCRIPTION
## Summary

Unifies the standard library type classification checks in `Typer` behind a single memoized helper, as proposed in #118.

- Adds a `standardLibraryEntityToType` cache to `Typer.Memos`, keyed by `Program.StandardLibraryEntity`, alongside the existing lazy caches.
- Memoizes `standardLibraryType(_:)` against that cache so repeated resolutions of the same entity are O(1) instead of re-resolving the declaration to a type on every call.
- Introduces a private `isStandardLibraryType(_:in:)` helper that guards on `program.containsStandardLibrary`, dealiases the type once, and checks membership using the now-cached lookups.
- Reimplements `isStandardLibraryIntegerType` and `isStandardLibraryFloatingPointType` as thin wrappers over the new helper.

## Why this matters

As noted in #118, classifying a type as a standard library integer or floating point type re-ran a per-call membership scan, with each `standardLibraryType(_:)` call resolving the entity to a type from scratch (roughly ten hashmap lookups per check). The maintainer's proposed approach was to unify these into a single helper backed by a memoized cache that works like the other cached methods on `Typer.Memos`, mirroring the lazy-cache pattern already used throughout the typer. This change follows that approach: the cache turns repeated entity resolutions into O(1) lookups while keeping the classification logic identical.

## Testing

The change is behavior-preserving: the same entities (`[.int, .int32, .int64]` for integers, `[.float32, .float64]` for floats) are checked against the same dealiased type, and the `program.containsStandardLibrary` guard is preserved so partial-standard-library programs still return `false` without crashing. `swiftc -parse` on the modified file passes; a full `swift build` requires the LLVM toolchain headers, which are not available in this environment.

Fixes #118
