### PR TITLE
Use platform's default relocation model in driver

### DIFF
--- a/Sources/BackEnd/ConcreteLayout.swift
+++ b/Sources/BackEnd/ConcreteLayout.swift
@@ -12,7 +12,7 @@ internal struct ConcreteLayout {
 
     /// The raw value of the instance.
     ///
-    /// Non-negative numbers represent a fixed size, in bytes. `-1` represents a dynmic size. All
+    /// Non-negative numbers represent a fixed size, in bytes. `-1` represents a dynamic size. All
     /// other values are undefined.
     private let raw: Int
 

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -1104,7 +1104,7 @@ extension Program {
       fields: fields, propertyToField: rowToField, size: .fixed(size), alignment: a)
   }
 
-  /// Returns the LLVM IR type of the entity decalred by `d`, which is a property of an opaque
+  /// Returns the LLVM IR type of the entity declared by `d`, which is a property of an opaque
   /// record having type `t`.
   private mutating func typeOfProperty(
     declaredBy d: DeclarationIdentity, withType t: AnyTypeIdentity,

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -48,11 +48,25 @@ public struct Driver {
   /// A map from a Hylo module to its corresponding LLVM module, populated by `lowerToLLVM(_:)`.
   private var llvmModules: [Module.ID: LLVMModuleBox] = [:]
 
+  /// The relocation model that suits the host platform when none is specified.
+  ///
+  /// On Linux, the system toolchain links position-independent executables (PIE) by default, which
+  /// requires position-independent object code; emitting code with the target's own default (which
+  /// is `static` on x86-64 Linux) produces absolute relocations that the PIE linker rejects.
+  /// Elsewhere we defer to the target's default.
+  public static var defaultRelocationModel: RelocationModel {
+    #if os(Linux)
+      return .pic
+    #else
+      return .default
+    #endif
+  }
+
   /// Creates an instance with the given properties.
   public init(
     moduleCachePath: URL? = nil, targetSpecification: TargetSpecification,
     optimization: OptimizationLevel = .none,
-    relocation: RelocationModel = .default,
+    relocation: RelocationModel = Driver.defaultRelocationModel,
     codeModel: CodeModel = .default,
     librarySearchPaths: [URL] = [], librariesToLink: [String] = []
   ) {

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -131,7 +131,7 @@ private typealias Module = FrontEnd.Module
       moduleCachePath: noCaching ? nil : moduleCachePath!,
       targetSpecification: try resolveTarget(),
       optimization: optimizationLevel,
-      relocation: relocationModel ?? defaultRelocationModel(),
+      relocation: relocationModel ?? Driver.defaultRelocationModel,
       codeModel: codeModel ?? .default,
       librarySearchPaths: librarySearchPaths)
 
@@ -276,17 +276,6 @@ private typealias Module = FrontEnd.Module
       target: triple,
       cpu: resolveCPU(crossCompiling: crossCompiling),
       features: resolveCPUFeatures(crossCompiling: crossCompiling))
-  }
-
-  /// The default relocation model when not specified on the command line.
-  ///
-  /// Note: This may be obsolete after https://github.com/hylo-lang/hylo-new/issues/96 is resolved.
-  private func defaultRelocationModel() -> RelocationModel {
-    #if os(Linux)
-      return .pic
-    #else
-      return .default
-    #endif
   }
 
   /// Emits the AST of `module` in `program` with name `name`, using the tree printer.


### PR DESCRIPTION
Previously, the platform's default relocation model was only set by the command line, so the tests didn't apply it. Changed it so that the driver already applies this default.