### PR TITLE
Partial artifact matching based test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Tests/CompilerTests/CompilerTests+GeneratedTests.swift
 
 # Observations during testing
 Tests/CompilerTests/**/*.observed
+Tests/CompilerTests/**/*.observed.exe
 StandardLibrary/**/*.observed
 
 # Local development

--- a/Sources/Utilities/Sequence+Extensions.swift
+++ b/Sources/Utilities/Sequence+Extensions.swift
@@ -65,4 +65,9 @@ extension Sequence {
     joinedString(separator: separator) { String(describing: $0) }
   }
 
+  /// Returns the element of `self` that minimizes `f`, or `nil` if `self` is empty.
+  public func min<R: Comparable>(by keyPath: (Element) -> R) -> Element? {
+    self.min(by: { (a, b) in keyPath(a) < keyPath(b) })
+  }
+
 }

--- a/Sources/Utilities/Sequence+Extensions.swift
+++ b/Sources/Utilities/Sequence+Extensions.swift
@@ -65,9 +65,13 @@ extension Sequence {
     joinedString(separator: separator) { String(describing: $0) }
   }
 
-  /// Returns the element of `self` that minimizes `f`, or `nil` if `self` is empty.
-  public func min<R: Comparable>(by keyPath: (Element) -> R) -> Element? {
-    self.min(by: { (a, b) in keyPath(a) < keyPath(b) })
+  /// Returns the element in `self` with the smallest value measured by `p`, if any.
+  /// 
+  /// If there is more than one smallest element, it is unspecified which one is returned.
+  ///
+  /// - Complexity: O(n)
+  public func min<R: Comparable>(measuredBy p: (Element) -> R) -> Element? {
+    self.min(by: { (a, b) in p(a) < p(b) })
   }
 
 }

--- a/Sources/Utilities/StringProtocol+Extensions.swift
+++ b/Sources/Utilities/StringProtocol+Extensions.swift
@@ -29,6 +29,11 @@ extension StringProtocol {
     .init(filter({ (a) in a != c }))
   }
 
+  /// Returns `self` with unix-style line endings.
+  public func normalizedLineEndings() -> String {
+    replacingOccurrences(of: "\r\n", with: "\n")  // Windows
+  }
+
 }
 
 extension StringProtocol where SubSequence == Substring {

--- a/Tests/CompilerTests/CompilerTests.swift
+++ b/Tests/CompilerTests/CompilerTests.swift
@@ -3,9 +3,10 @@ import Foundation
 import FrontEnd
 import StandardLibrary
 import Utilities
+import StableCollections
 import XCTest
 
-/// `true` iff intermediate compilation artifacts must be saved for successful tests.
+/// `true` iff intermediate compilation artifacts shall be saved for successful tests.
 private let alwaysSaveArtifacts: Bool = false
 
 /// The driver for generated compiler tests.
@@ -63,10 +64,11 @@ final class CompilerTests: XCTestCase {
     /// Returns where to save the generated executable upon failure.
     func executableDestination() -> URL {
       let suffix = Host.nativeExecutableSuffix
+      let tag = ArtifactTag.executable
       if isPackage {
-        return root.appending(component: ".executable\(suffix)")
+        return root.appending(component: ".\(tag).observed\(suffix)")
       } else {
-        return root.deletingPathExtension().appendingPathExtension("executable\(suffix)")
+        return root.deletingPathExtension().appendingPathExtension("\(tag).observed\(suffix)")
       }
     }
 
@@ -80,19 +82,63 @@ final class CompilerTests: XCTestCase {
 
   }
 
-  /// The intermediate artifacts of a module's compilation.
+  /// The type of a compilation artifact.
+  enum ArtifactTag: String, CustomStringConvertible, Comparable {
+
+    /// Hylo IR immediately after lowering, without any processing.
+    case rawIR = "raw-ir"
+
+    /// Hylo IR after mandatory transformation passes.
+    case refinedIR = "refined-ir"
+
+    /// LLVM IR.
+    case llvmIR = "llvm-ir"
+
+    /// The executable generated from the compiled program.
+    case executable = "executable"
+
+    /// All textual artifacts of the compilation and testing pipeline.
+    static var allTextual: [ArtifactTag] {
+      [.rawIR, .refinedIR, .llvmIR]
+    }
+
+    /// The minimum stage of compilation to produce this artifact.
+    var minimumStage: Manifest.Stage {
+      switch self {
+      case .rawIR: .lowering
+      case .refinedIR: .lowering
+      case .llvmIR: .llvm
+      case .executable: .execution
+      }
+    }
+
+    /// The textual description of `self`.
+    var description: String { rawValue }
+
+    /// The order of `self` among all artifact tags, which is used to sort them.
+    var order: Int {
+      switch self {
+      case .rawIR: 0
+      case .refinedIR: 1
+      case .llvmIR: 2
+      case .executable: 3
+      }
+    }
+
+    /// Returns true iff `l` is ordered before `r`.
+    static func < (l: CompilerTests.ArtifactTag, r: CompilerTests.ArtifactTag) -> Bool {
+      l.order < r.order
+    }
+
+  }
+
+  /// The intermediate artifacts of a module's compilation and testing.
   ///
   /// Members shall be set after the corresponding stage is completed.
   private struct Artifacts {
 
-    /// The lowered IR of the compiled module, if any.
-    var rawIR: String?
-
-    /// The transformed IR of the compiled module, if any.
-    var transformedIR: String?
-
-    /// The compiled IR artifact of the tested module, if any.
-    var llvmIR: String?
+    /// The textual artifacts of the compilation and testing pipeline, keyed by their tag.
+    private(set) var textual = SortedDictionary<ArtifactTag, String>()
 
     /// The URL of the generated executable residing in a temporary directory, if any.
     ///
@@ -102,18 +148,19 @@ final class CompilerTests: XCTestCase {
 
     /// Saves the artifacts into test-case-level observation files of `test`.
     func save(into test: TestDescription) throws {
-      if let a = rawIR {
-        try test.saveTestCaseLevelObservation(a, tag: "raw-ir")
+      for (tag, artifact) in textual {
+        try test.saveTestCaseLevelObservation(artifact, tag: tag.rawValue)
       }
-      if let a = transformedIR {
-        try test.saveTestCaseLevelObservation(a, tag: "transformed-ir")
-      }
-      if let a = llvmIR {
-        try test.saveTestCaseLevelObservation(a, tag: "ll")
-      }
-      if let a = executable {
+
+      if let a: URL = executable {
+        try? FileManager.default.removeItem(at: test.executableDestination())
         try FileManager.default.copyItem(at: a, to: test.executableDestination())
       }
+    }
+
+    /// Records the textual `artifact` as the artifact tagged `tag`.
+    mutating func record(_ artifact: String, for tag: ArtifactTag) {
+      textual[tag] = artifact
     }
 
   }
@@ -182,29 +229,47 @@ final class CompilerTests: XCTestCase {
 
   /// Compiles and runs `input` expecting no compilation error.
   func positive(_ input: TestDescription) async throws {
-    // Compile the input up until the specified stage.
-    let o = input.manifest.optimizations != .none
-    let r = try await compile(input, withOptimizations: o)
-    try assertSansError(r.driver.program)
+    await loggingSourceOnFailure(root: input.root) {
+      // Compile the input up until the specified stage.
+      let o = input.manifest.optimizations != .none
+      let r = try await compile(input, withOptimizations: o)
+      try assertSansError(r.driver.program)
 
-    // Should an executable be tested?
-    if input.manifest.stage == .execution {
-      let e = try XCTUnwrap(r.artifacts.executable)
-      let x = try Process.execute(e)
-      assertExitStatus(x, describedBy: input)
+      // Should an executable be tested?
+      if input.manifest.stage == .execution {
+        let e = try XCTUnwrap(r.artifacts.executable)
+        let x = try Process.execute(e)
+        assertExitStatus(x, describedBy: input)
+      }
+
+      if testFailed || alwaysSaveArtifacts { try r.artifacts.save(into: input) }
     }
-
-    if testFailed || alwaysSaveArtifacts { try r.artifacts.save(into: input) }
   }
 
   /// Compiles `input` expecting at least one compilation error.
   func negative(_ input: TestDescription) async throws {
-    let r = try await compile(input, withOptimizations: false)
-    let m = "program compiled but an error was expected.\nSource: \(input.root.path)\n"
-    XCTAssert(r.driver.program.containsError, m)
-    assertExpectations(r.expectedDiagnostics, r.driver.program.diagnostics)
+    await loggingSourceOnFailure(root: input.root) {
+      let r = try await compile(input, withOptimizations: false)
+      let m = "program compiled but an error was expected.\nSource: \(input.root.path)\n"
+      XCTAssert(r.driver.program.containsError, m)
+      assertExpectations(r.expectedDiagnostics, r.driver.program.diagnostics)
 
-    if testFailed || alwaysSaveArtifacts { try r.artifacts.save(into: input) }
+      if testFailed || alwaysSaveArtifacts { try r.artifacts.save(into: input) }
+    }
+  }
+
+  /// Executes `action`, and logs the test case's `root` on test failure for easier diagnostics.
+  ///
+  /// Also logs and catches any error thrown by `action`, failing the test case.
+  private func loggingSourceOnFailure<T>(root: URL, _ action: () async throws -> T) async {
+    do {
+      _ = try await action()
+      if testFailed {
+        XCTFail("\nSource: \(root.path)\n")
+      }
+    } catch let e {
+      XCTFail("\(e)\nSource: \(root.path)\n")
+    }
   }
 
   /// Compiles `input` and returns the resulting artifacts.
@@ -236,8 +301,8 @@ final class CompilerTests: XCTestCase {
     var artifacts = Artifacts()
     do {
       try await compile(
-        m, until: input.manifest.stage, using: &driver,
-        accumulatingArtifactsInto: &artifacts)
+        m, until: input.manifest.stage, using: &driver, accumulatingArtifactsInto: &artifacts,
+        expectedArtifacts: input.manifest.artifactExpectations)
     } catch let e {
       try artifacts.save(into: input)
       throw e
@@ -255,7 +320,8 @@ final class CompilerTests: XCTestCase {
   /// adding compilation artifacts to `artifacts`.
   private func compile(
     _ m: Module.ID, until stage: Manifest.Stage, using driver: inout Driver,
-    accumulatingArtifactsInto artifacts: inout Artifacts
+    accumulatingArtifactsInto artifacts: inout Artifacts,
+    expectedArtifacts: SortedDictionary<ArtifactTag, String>
   ) async throws {
     // Exit if there are parsing errors or if the stage is set to `parsing`.
     if driver.program[m].containsError || (stage == .parsing) { return }
@@ -268,17 +334,24 @@ final class CompilerTests: XCTestCase {
     // IR Lowering.
     let l = await driver.lower(m)
     if l.containsError { return }
-    artifacts.rawIR = driver.program.show(driver.program[m].ir)
+    let rawIR = driver.program.show(driver.program[m].ir)
+    artifacts.record(rawIR, for: .rawIR)
+    assertArtifact(.rawIR, expected: expectedArtifacts[.rawIR], observed: rawIR)
 
     // IR Transformation passes.
     let t = await driver.applyTransformationPasses(m)
     if t.containsError { return }
-    artifacts.transformedIR = driver.program.show(driver.program[m].ir)
+    let refinedIR = driver.program.show(driver.program[m].ir)
+    artifacts.record(refinedIR, for: .refinedIR)
+    assertArtifact(.refinedIR, expected: expectedArtifacts[.refinedIR],
+      observed: refinedIR)
     if stage == .lowering { return }
 
     // LLVM Lowering.
     if (try driver.compileToLLVM(m)).containsError { return }
-    artifacts.llvmIR = driver.llvmIR(of: m)!
+    let llvmIR = driver.llvmIR(of: m)!
+    artifacts.record(llvmIR, for: .llvmIR)
+    assertArtifact(.llvmIR, expected: expectedArtifacts[.llvmIR], observed: llvmIR)
     if stage == .llvm { return }
 
     // When the stdlib can be compiled, lower it to LLVM so generateExecutable can link it.
@@ -292,6 +365,20 @@ final class CompilerTests: XCTestCase {
       let executable = outputDirectory.appendingPathComponent(driver.program[m].name)
       _ = try driver.generateExecutable(from: m, writingTo: executable)
       artifacts.executable = executable
+    }
+  }
+
+  /// Asserts that the `observed` artifact tagged `tag` matches `expected`, if present.
+  private func assertArtifact(_ tag: ArtifactTag, expected: String?, observed: String) {
+    guard let e = expected else { return }
+
+    for c in IRMatching.comparisons(expected: e, observed: observed) {
+      guard let o = c.observed else {
+        XCTFail("No section in observed \(tag) matches:\n```\(c.expected)```\n")
+        continue
+      }
+
+      XCTAssertEqual(o, c.expected, "\(tag) did not meet expectations.")
     }
   }
 

--- a/Tests/CompilerTests/IRMatching.swift
+++ b/Tests/CompilerTests/IRMatching.swift
@@ -10,16 +10,13 @@ enum IRMatching {
   struct Comparison: Equatable {
 
     /// A fragment of the expected artifact.
-    let expected: String
+    let expected: Substring
 
     /// The fragment of the observed artifact that should equal `expected`, or `nil` if there were
     /// no fragments observed.
-    let observed: String?
+    let observed: Substring?
 
   }
-
-  /// A list of consecutive non-blank lines.
-  typealias Section = [Substring]
 
   /// Returns the comparisons to perform to check that `observed` satisfies `expected`.
   ///
@@ -30,29 +27,60 @@ enum IRMatching {
   /// A section is a maximal run of consecutive non-blank lines. An expected section is matched
   /// against the observed section having the most similar first line.
   static func comparisons(expected: String, observed: String) -> [Comparison] {
-    let expected = sections(of: expected.normalizedLineEndings())
-    let observed = sections(of: observed.normalizedLineEndings())
+    let observed = Array(sections(of: observed.normalizedLineEndings()))
 
-    return expected.map { (e) in
-      let head = e[0]
+    // Index the observed sections by their first line so the common case (an exact match) is just a lookup.
+    var byFirstLine: [Substring: Substring] = [:]
+    for s in observed {
+      byFirstLine[s.firstLine] = byFirstLine[s.firstLine] ?? s
+    }
 
-      // Pair with the observed section having the most similar first line.
-      let matched = observed.min(by: { (s) in distance(head, s[0]) })
+    return sections(of: expected.normalizedLineEndings()).map { (e) in
+      let head = e.firstLine
 
-      return Comparison(
-        expected: e.joined(separator: "\n"),
-        observed: matched.map({ (m) in m.joined(separator: "\n") }))
+      // Happy path: an observed section with the same first line. Otherwise, fall back to the one
+      // whose first line is the most similar.
+      let matched =
+        byFirstLine[head] ?? observed.min(measuredBy: { (s) in distance(head, s.firstLine) })
+
+      return Comparison(expected: e, observed: matched)
     }
   }
 
-  /// Returns the sections of `s`, in order of appearance.
+  /// Returns an iterator over the sections of `s`, in order of appearance.
   ///
   /// A section is a maximal run of consecutive non-blank lines, where a line is blank if it's empty
-  /// or contains only whitespace.
-  static func sections(of s: String) -> [Section] {
-    s.split(separator: "\n", omittingEmptySubsequences: false)
-      .split(whereSeparator: { $0.allSatisfy(\.isWhitespace) })
-      .map(Array.init)
+  /// or contains only whitespace. Sections are yielded as slices of `s` in a single forward pass.
+  static func sections(of s: String) -> AnyIterator<Substring> {
+    var i = s.startIndex
+    var done = false
+
+    // Returns the next line of `s`—excluding its terminating newline—or `nil` once every line has
+    // been consumed. As in `split(omittingEmptySubsequences: false)`, a trailing newline yields a
+    // final empty line.
+    func nextLine() -> Substring? {
+      if done { return nil }
+      let start = i
+      while (i != s.endIndex) && !s[i].isNewline { i = s.index(after: i) }
+      let line = s[start ..< i]
+      if i == s.endIndex { done = true } else { i = s.index(after: i) }
+      return line
+    }
+
+    return AnyIterator { () -> Substring? in
+      // Skip blank lines until the start of the next section, if any.
+      var line = nextLine()
+      while let l = line, l.allSatisfy(\.isWhitespace) { line = nextLine() }
+      guard let head = line else { return nil }
+
+      // Extend the section across consecutive non-blank lines.
+      var end = head.endIndex
+      while let l = nextLine() {
+        if l.allSatisfy(\.isWhitespace) { break }
+        end = l.endIndex
+      }
+      return s[head.startIndex ..< end]
+    }
   }
 
 }

--- a/Tests/CompilerTests/IRMatching.swift
+++ b/Tests/CompilerTests/IRMatching.swift
@@ -24,12 +24,14 @@ enum IRMatching {
   /// result has one comparison per expected section. Sections of `observed` with no counterpart in
   /// `expected` are ignored, making `expected` a partial specification of `observed`.
   ///
-  /// A section is a maximal run of consecutive non-blank lines. An expected section is matched
-  /// against the observed section having the most similar first line.
+  /// A section is a maximal run of consecutive non-blank lines, where a line is blank if it's
+  /// empty or contains only whitespace. Sections are yielded as slices of `s` computed with a
+  /// single forward pass over `s`.
   static func comparisons(expected: String, observed: String) -> [Comparison] {
     let observed = Array(sections(of: observed.normalizedLineEndings()))
 
-    // Index the observed sections by their first line so the common case (an exact match) is just a lookup.
+    // Index the observed sections by their first line so the common case (an exact match) is just
+    // a lookup.
     var byFirstLine: [Substring: Substring] = [:]
     for s in observed {
       byFirstLine[s.firstLine] = byFirstLine[s.firstLine] ?? s
@@ -55,19 +57,19 @@ enum IRMatching {
     var i = s.startIndex
     var done = false
 
-    // Returns the next line of `s`—excluding its terminating newline—or `nil` once every line has
-    // been consumed. As in `split(omittingEmptySubsequences: false)`, a trailing newline yields a
-    // final empty line.
-    func nextLine() -> Substring? {
-      if done { return nil }
-      let start = i
-      while (i != s.endIndex) && !s[i].isNewline { i = s.index(after: i) }
-      let line = s[start ..< i]
-      if i == s.endIndex { done = true } else { i = s.index(after: i) }
-      return line
-    }
-
     return AnyIterator { () -> Substring? in
+      /// Returns the next line of `s` (excluding its terminating newline) or `nil` once every line
+      /// has been consumed. As in `split(omittingEmptySubsequences: false)`, a trailing newline
+      /// yields a final empty line.
+      func nextLine() -> Substring? {
+        if done { return nil }
+        let start = i
+        while (i != s.endIndex) && !s[i].isNewline { i = s.index(after: i) }
+        let line = s[start ..< i]
+        if i == s.endIndex { done = true } else { i = s.index(after: i) }
+        return line
+      }
+
       // Skip blank lines until the start of the next section, if any.
       var line = nextLine()
       while let l = line, l.allSatisfy(\.isWhitespace) { line = nextLine() }

--- a/Tests/CompilerTests/IRMatching.swift
+++ b/Tests/CompilerTests/IRMatching.swift
@@ -1,0 +1,63 @@
+import Utilities
+
+/// Matching of an observed compiler artifact against an expected one.
+///
+/// This type contains XCTest-independent logic used by the compiler tests to decide what
+/// must be compared. It supports any line-oriented, section-structured artifact.
+enum IRMatching {
+
+  /// An equality that must hold for an observed artifact to satisfy an expectation.
+  struct Comparison: Equatable {
+
+    /// A fragment of the expected artifact.
+    let expected: String
+
+    /// The fragment of the observed artifact that should equal `expected`, or `nil` if there were
+    /// no fragments observed.
+    let observed: String?
+
+  }
+
+  /// A list of consecutive non-blank lines.
+  typealias Section = [Substring]
+
+  /// Returns the comparisons to perform to check that `observed` satisfies `expected`.
+  ///
+  /// Each *section* of `expected` is matched independently against a section of `observed`, so the
+  /// result has one comparison per expected section. Sections of `observed` with no counterpart in
+  /// `expected` are ignored, making `expected` a partial specification of `observed`.
+  ///
+  /// A section is a maximal run of consecutive non-blank lines. An expected section is matched
+  /// against the observed section having the most similar first line.
+  static func comparisons(expected: String, observed: String) -> [Comparison] {
+    let expected = sections(of: expected.normalizedLineEndings())
+    let observed = sections(of: observed.normalizedLineEndings())
+
+    return expected.map { (e) in
+      let head = e[0]
+
+      // Pair with the observed section having the most similar first line.
+      let matched = observed.min(by: { (s) in distance(head, s[0]) })
+
+      return Comparison(
+        expected: e.joined(separator: "\n"),
+        observed: matched.map({ (m) in m.joined(separator: "\n") }))
+    }
+  }
+
+  /// Returns the sections of `s`, in order of appearance.
+  ///
+  /// A section is a maximal run of consecutive non-blank lines, where a line is blank if it's empty
+  /// or contains only whitespace.
+  static func sections(of s: String) -> [Section] {
+    s.split(separator: "\n", omittingEmptySubsequences: false)
+      .split(whereSeparator: { $0.allSatisfy(\.isWhitespace) })
+      .map(Array.init)
+  }
+
+}
+
+/// Returns the smallest number of additions and deletions that transform `b` into `a`.
+private func distance(_ a: Substring, _ b: Substring) -> Int {
+  a.difference(from: b).count
+}

--- a/Tests/CompilerTests/IRMatching.swift
+++ b/Tests/CompilerTests/IRMatching.swift
@@ -51,8 +51,9 @@ enum IRMatching {
 
   /// Returns an iterator over the sections of `s`, in order of appearance.
   ///
-  /// A section is a maximal run of consecutive non-blank lines, where a line is blank if it's empty
-  /// or contains only whitespace. Sections are yielded as slices of `s` in a single forward pass.
+  /// A section is a maximal run of consecutive non-blank lines, where a line is blank if it is
+  /// empty or contains only whitespace. Sections are yielded as slices of `s` computed with a
+  // single forward pass over `s`.
   static func sections(of s: String) -> AnyIterator<Substring> {
     var i = s.startIndex
     var done = false

--- a/Tests/CompilerTests/IRMatchingTests.swift
+++ b/Tests/CompilerTests/IRMatchingTests.swift
@@ -145,7 +145,7 @@ final class IRMatchingTests: XCTestCase {
         %r0 = return
       }
       """
-    // No exact first-line match: the body changes the signature slightly. The closest section wins.
+    // No exact first-line match: the body changes the signature slightly. Closest section wins.
     let observed = """
       fun helper(let %p0: Void) {
         %r0 = return

--- a/Tests/CompilerTests/IRMatchingTests.swift
+++ b/Tests/CompilerTests/IRMatchingTests.swift
@@ -164,12 +164,46 @@ final class IRMatchingTests: XCTestCase {
 
   func testSectionsSplitsOnBlankAndWhitespaceOnlyLines() {
     let s = "a\nb\n\nc\n   \nd\n"
-    XCTAssertEqual(IRMatching.sections(of: s), [["a", "b"], ["c"], ["d"]])
+    XCTAssertEqual(Array(IRMatching.sections(of: s)), ["a\nb", "c", "d"])
   }
 
   func testSectionsOfEmptyInputIsEmpty() {
-    XCTAssertEqual(IRMatching.sections(of: "").count, 0)
-    XCTAssertEqual(IRMatching.sections(of: "\n  \n").count, 0)
+    XCTAssertEqual(Array(IRMatching.sections(of: "")).count, 0)
+    XCTAssertEqual(Array(IRMatching.sections(of: "\n  \n")).count, 0)
+  }
+
+  func testSectionsSkipsLeadingBlankLines() {
+    let s = "\n  \n\t\na\nb"
+    XCTAssertEqual(Array(IRMatching.sections(of: s)), ["a\nb"])
+  }
+
+  func testSectionsIgnoresTrailingBlankLines() {
+    let s = "a\nb\n\n  \n"
+    XCTAssertEqual(Array(IRMatching.sections(of: s)), ["a\nb"])
+  }
+
+  func testSectionsCollapsesConsecutiveBlankLinesBetweenSections() {
+    let s = "a\n\n\n\nb"
+    XCTAssertEqual(Array(IRMatching.sections(of: s)), ["a", "b"])
+  }
+
+  func testSectionsTreatsTabsAndSpacesAsBlankSeparators() {
+    let s = "a\n\t \t\nb"
+    XCTAssertEqual(Array(IRMatching.sections(of: s)), ["a", "b"])
+  }
+
+  func testSectionsSingleSectionWithoutTrailingNewline() {
+    let s = "only\nsection"
+    XCTAssertEqual(Array(IRMatching.sections(of: s)), ["only\nsection"])
+  }
+
+  func testSectionsPreservesLeadingAndInteriorWhitespaceWithinALine() {
+    let s = "  indented\n    body  \n\nnext"
+    XCTAssertEqual(Array(IRMatching.sections(of: s)), ["  indented\n    body  ", "next"])
+  }
+
+  func testSectionsOfSingleNonBlankLine() {
+    XCTAssertEqual(Array(IRMatching.sections(of: "a")), ["a"])
   }
 
 }

--- a/Tests/CompilerTests/IRMatchingTests.swift
+++ b/Tests/CompilerTests/IRMatchingTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+
+final class IRMatchingTests: XCTestCase {
+
+  // MARK: comparisons
+
+  func testMarkerlessInputIsMatchedAsSections() {
+    let cs = IRMatching.comparisons(expected: "a\nb", observed: "a\nc")
+    XCTAssertEqual(cs, [.init(expected: "a\nb", observed: "a\nc")])
+  }
+
+  func testNormalizesLineEndings() {
+    let cs = IRMatching.comparisons(expected: "a\r\nb", observed: "a\r\nb")
+    XCTAssertEqual(cs, [.init(expected: "a\nb", observed: "a\nb")])
+  }
+
+  func testPartialMatchesByGlobalSymbol() {
+    let expected = """
+      define i32 @"foo"() {
+        ret i32 0
+      }
+      """
+    let observed = """
+      define void @"bar"() {
+        ret void
+      }
+
+      define i32 @"foo"() {
+        ret i32 0
+      }
+      """
+    let cs = IRMatching.comparisons(expected: expected, observed: observed)
+    XCTAssertEqual(cs.count, 1)
+    XCTAssertEqual(cs[0].expected, "define i32 @\"foo\"() {\n  ret i32 0\n}")
+    XCTAssertEqual(cs[0].observed, cs[0].expected)
+  }
+
+  func testPartialReportsMismatchInMatchedSection() {
+    let expected = """
+      define i32 @"foo"() {
+        ret i32 0
+      }
+      """
+    let observed = """
+      define i32 @"foo"() {
+        ret i32 1
+      }
+      """
+    let cs = IRMatching.comparisons(expected: expected, observed: observed)
+    XCTAssertEqual(cs.count, 1)
+    XCTAssertNotNil(cs[0].observed)
+    XCTAssertNotEqual(cs[0].expected, cs[0].observed)
+  }
+
+  func testPartialMatchesEachSectionIndependentlyAndIgnoresOrder() {
+    let expected = """
+      define i32 @"a"() {
+        ret i32 0
+      }
+
+      define i32 @"b"() {
+        ret i32 1
+      }
+      """
+    let observed = """
+      define i32 @"b"() {
+        ret i32 1
+      }
+
+      define i32 @"a"() {
+        ret i32 0
+      }
+      """
+    let cs = IRMatching.comparisons(expected: expected, observed: observed)
+    XCTAssertEqual(cs.count, 2)
+    for c in cs { XCTAssertEqual(c.expected, c.observed) }
+  }
+
+  func testPartialFallsBackToClosestFirstLineWhenNoSymbol() {
+    let expected = """
+      %T = type { i32 }
+      """
+    let observed = """
+      %U = type { i64 }
+
+      %T = type { i32. }
+      """
+    let cs = IRMatching.comparisons(expected: expected, observed: observed)
+    XCTAssertEqual(cs.count, 1)
+    // The closest observed section is chosen even though it isn't identical to the expected one.
+    XCTAssertEqual(cs[0].observed, "%T = type { i32. }")
+  }
+
+  func testPartialUnmatchedWhenObservedHasNoSection() {
+    let cs = IRMatching.comparisons(
+      expected: "define void @\"f\"() {\n}", observed: "\n  \n")
+    XCTAssertEqual(cs.count, 1)
+    XCTAssertNil(cs[0].observed)
+  }
+
+  // MARK: comparisons (Hylo IR)
+
+  func testHyloPartialMatchesByFirstLineIgnoringOrder() {
+    let expected = """
+      fun main(set %p0: Int32) {
+        %r0 = return
+      }
+      """
+    let observed = """
+      fun use(_:)<T>(let %p0: T) {
+        %r0 = return
+      }
+
+      fun main(set %p0: Int32) {
+        %r0 = return
+      }
+      """
+    let cs = IRMatching.comparisons(expected: expected, observed: observed)
+    XCTAssertEqual(cs.count, 1)
+    XCTAssertEqual(cs[0].expected, "fun main(set %p0: Int32) {\n  %r0 = return\n}")
+    XCTAssertEqual(cs[0].observed, cs[0].expected)
+  }
+
+  func testHyloPartialReportsMismatchInMatchedSection() {
+    let expected = """
+      fun main(set %p0: Int32) {
+        %r0 = return
+      }
+      """
+    let observed = """
+      fun main(set %p0: Int32) {
+        %r0 = alloca Void
+        %r1 = return
+      }
+      """
+    let cs = IRMatching.comparisons(expected: expected, observed: observed)
+    XCTAssertEqual(cs.count, 1)
+    XCTAssertNotNil(cs[0].observed)
+    XCTAssertNotEqual(cs[0].expected, cs[0].observed)
+  }
+
+  func testHyloPartialFallsBackToClosestFirstLine() {
+    let expected = """
+      fun main(set %p0: Int32) {
+        %r0 = return
+      }
+      """
+    // No exact first-line match: the body changes the signature slightly. The closest section wins.
+    let observed = """
+      fun helper(let %p0: Void) {
+        %r0 = return
+      }
+
+      fun main(set %p0: Int64) {
+        %r0 = return
+      }
+      """
+    let cs = IRMatching.comparisons(expected: expected, observed: observed)
+    XCTAssertEqual(cs.count, 1)
+    XCTAssertEqual(cs[0].observed, "fun main(set %p0: Int64) {\n  %r0 = return\n}")
+  }
+
+  // MARK: sections
+
+  func testSectionsSplitsOnBlankAndWhitespaceOnlyLines() {
+    let s = "a\nb\n\nc\n   \nd\n"
+    XCTAssertEqual(IRMatching.sections(of: s), [["a", "b"], ["c"], ["d"]])
+  }
+
+  func testSectionsOfEmptyInputIsEmpty() {
+    XCTAssertEqual(IRMatching.sections(of: "").count, 0)
+    XCTAssertEqual(IRMatching.sections(of: "\n  \n").count, 0)
+  }
+
+}

--- a/Tests/CompilerTests/Manifest.swift
+++ b/Tests/CompilerTests/Manifest.swift
@@ -4,8 +4,8 @@ import Utilities
 /// A test manifest.
 struct Manifest {
 
-  /// A stage of the compilation pipeline.
-  enum Stage: String {
+  /// A stage of the compilation and testing pipeline.
+  enum Stage: String, Comparable {
 
     /// After the abstract syntax tree has been parsed.
     case parsing
@@ -21,6 +21,22 @@ struct Manifest {
 
     /// After the program has been compiled and ran.
     case execution
+
+    /// The position of `self` in the pipeline.
+    var order: Int {
+      switch self {
+      case .parsing: 0
+      case .typing: 1
+      case .lowering: 2
+      case .llvm: 3
+      case .execution: 4
+      }
+    }
+
+    /// True iff `l` is earlier in the pipeline than `r`.
+    static func < (l: Stage, r: Stage) -> Bool {
+      l.order < r.order
+    }
 
   }
 
@@ -46,6 +62,9 @@ struct Manifest {
 
   /// The expected exit status of the input, if executed.
   private(set) var exitStatus: Int32 = 0
+
+  /// The expected textual artifacts of the test run, asserted when present.
+  private(set) var artifactExpectations = SortedDictionary<CompilerTests.ArtifactTag, String>()
 
   /// Creates an instance with a default configuration.
   init() {}
@@ -82,6 +101,33 @@ struct Manifest {
     else {
       self.init()
     }
+
+    try self.readArtifactExpectations(forTestAt: root, stage: stage)
+  }
+
+  /// Reads and sets expectations for the test case at `root`.
+  mutating func readArtifactExpectations(forTestAt root: URL, stage: Stage) throws {
+    for tag in CompilerTests.ArtifactTag.allTextual {
+      self.artifactExpectations[tag] = try Self.readFromDisk(
+        forTestAt: root, tag: tag, minimumStage: tag.minimumStage, stage: stage)
+    }
+  }
+
+  /// Reads the `tag`-specific expectation for a test case at `root`.
+  static func readFromDisk(
+    forTestAt root: URL, tag: CompilerTests.ArtifactTag, minimumStage: Manifest.Stage,
+    stage: Manifest.Stage
+  ) throws -> String? {
+    let r = try? String(
+      contentsOf: root.deletingPathExtension().appendingPathExtension("\(tag).expected"),
+      encoding: .utf8)
+
+    if stage < minimumStage && r != nil {
+      throw TestFailure.invalidTestDescription(
+        "\(tag) assertion requires stage:\(minimumStage) or higher but was \(stage).")
+    }
+
+    return r
   }
 
   /// Updates the configuration of `self` with the option parsed from `s`.
@@ -111,10 +157,25 @@ struct Manifest {
     try parse(v).unwrapOrThrow(ManifestError.invalidArgument(option: String(k), argument: v))
   }
 
-  /// Returns the first line of the file at `url`, which is encoded in UTF-8, or `nil`if that
-  /// this file could not be read.
+  /// Returns the first line of the file at `url`, which is encoded in UTF-8, or `nil` if this file
+  /// could not be read.
   private static func firstLine(of url: URL) -> Substring? {
     (try? String(contentsOf: url, encoding: .utf8))?.firstLine
+  }
+
+  /// A failure reported when parsing a test manifest.
+  private enum TestFailure: Error {
+
+    /// The test failed because its description was invalid.
+    case invalidTestDescription(String)
+
+    var localizedDescription: String {
+      switch self {
+      case .invalidTestDescription(let d):
+        return "Invalid test description (\(d))"
+      }
+    }
+
   }
 
 }

--- a/Tests/CompilerTests/README.md
+++ b/Tests/CompilerTests/README.md
@@ -7,12 +7,44 @@ A use case is either a single Hylo source file or a directory representing a pac
 A single-file test is compiled to a binary executable, just as if it was passed as an argument to `hc`.
 A package test is built according to the configuration specified by its manifest.
 
+
+## Testing without the standard library
+
+You can add `//! no-std` on the first line of a single-file test to disable the loading of the standard library. We encourage using `no-std` when possible, as it makes the test significantly faster.
+
+## Stopping after a compilation stage
+
+Add `//! stage:stage_name` to stop the driver after a specific compilation stage. Valid stages are:
+- `stage:parsing`
+- `stage:typing`
+- `stage:lowering`
+- `stage:llvm`
+- `stage:execution` (default); applicable only in positive tests.
+
+## Expectation types
+
+### Exit status
+
+Specify an expected exit code by `exit-status:42` manifest attribute. `0` is expected by default.
+Asserted when `stage` is set to `execution` (default). 
+
+### Textual Artifact Expectations
+
+Add a `test-case.<artifact-tag>.expected` file besides your `test-case.hylo` to assert the contents of a compilation artifact. Valid artifacts are:
+- `*.raw-ir.expected`
+- `*.refined-ir.expected`
+- `*.llvm-ir.expected`
+
+An artifact is composed of a set of contiguous sections, delimited by empty lines. E.g. each function in Hylo IR and LLVM IR are their own sections.
+
+It is sufficient to specify a subset of sections of the actual artifact. The expected section is matched with the observed section having the closest first line. Then they are compared for equality.
+
+## Inspecting Intermediate Artifacts
+
+Intermediate compilation artifacts are saved on test failure as `*.observed` files besides the corresponding test case. You can temporarily set `alwaysSaveArtifacts` to `true` in `CompilerTests.swift` to save these even when a test passes.
+
 ## Generating Swift tests manually
 
 Test cases are generated automatically as part of SPM's build sequence.
 You can also use `hc-tests` to generate test cases manually.
 The tool goes over each file or sub-directory under `negative` and `positive` and create a corresponding method to invoke `CompilerTests.compile(_:)`.
-
-## Testing without the standard library
-
-You can add `//! no-std` on the first line of a single-file test to disable the loading of the standard library.

--- a/Tests/CompilerTests/positive/generic-call.llvm-ir.expected
+++ b/Tests/CompilerTests/positive/generic-call.llvm-ir.expected
@@ -1,0 +1,20 @@
+define private %sTR0U7Int32S10 @"mFM6TestUegenericcallC3PF03flT01tR516selfgcTK20sTR0U7Int32S15cDpTcTK21L3tR501L3tR5$hJ"(ptr %0) {
+  %2 = alloca %sTR0U7Int32S10, align 4
+  %3 = alloca {}, align 8
+  %4 = call %sTR0U7Int32S10 @"M6TestUegenericcallcDpTcTK1C3P1gcTK20tR50F03flT01tR516selftR5sTR0U7Int32S15$fJ"()
+  store %sTR0U7Int32S10 %4, ptr %2, align 8
+  %5 = load %sTR0U7Int32S10, ptr %2, align 1
+  ret %sTR0U7Int32S10 %5
+}
+
+define private i32 @"lPM6TestUegenericcallF06mainlT01tR50sTR0U7Int32S134$hJ"(ptr %0, ptr %1, ptr %2, ptr %3) {
+  %5 = load [2 x ptr], ptr %1, align 8
+  %6 = extractvalue [2 x ptr] %5, 0
+  %7 = extractvalue [2 x ptr] %5, 1
+  %8 = getelementptr inbounds %"pTcTM6TestUegenericcallC3P1gcTK20tR5$jJ", ptr %0, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = call %sTR0U7Int32S10 %9()
+  store %sTR0U7Int32S10 %10, ptr %6, align 8
+  call void %2(ptr %3)
+  ret i32 0
+}

--- a/Tests/CompilerTests/positive/generic-call.raw-ir.expected
+++ b/Tests/CompilerTests/positive/generic-call.raw-ir.expected
@@ -1,0 +1,7 @@
+fun P.f<Self: Void>(let %p0: P<Void>, let %p1: Void, set %p2: Int32) {
+%b0:
+  %r0 = access [let] %p1
+  %r1 = access [set] %p2
+  %r2 = apply $<ConformanceDeclaration at generic-call:7.1>.f(%r0) => %r1
+  %r3 = return
+}

--- a/Tests/CompilerTests/positive/generic-call.refined-ir.expected
+++ b/Tests/CompilerTests/positive/generic-call.refined-ir.expected
@@ -1,0 +1,9 @@
+fun P.f<Self: Void>(let %p0: P<Void>, let %p1: Void, set %p2: Int32) {
+%b0:
+  %r0 = access [let] %p1
+  %r1 = access [set] %p2
+  %r2 = apply $<ConformanceDeclaration at generic-call:7.1>.f(%r0) => %r1
+  %r5 = end %r1
+  %r4 = end %r0
+  %r3 = return
+}

--- a/Tests/UtilitiesTests/SequenceTests.swift
+++ b/Tests/UtilitiesTests/SequenceTests.swift
@@ -17,6 +17,12 @@ final class SequenceTests: XCTestCase {
     XCTAssertEqual(x2.least(by: E.areInIncreasingOrder(_:_:)), .f)
   }
 
+  func testMin() {
+    let xs = [1, 2, 3, 4]
+    XCTAssertEqual(xs.min(by: { (x) in x }), 1)
+    XCTAssertEqual(xs.min(by: { (x) in -x }), 4)
+  }
+
 }
 
 private enum E: Equatable {

--- a/Tests/UtilitiesTests/SequenceTests.swift
+++ b/Tests/UtilitiesTests/SequenceTests.swift
@@ -19,8 +19,8 @@ final class SequenceTests: XCTestCase {
 
   func testMin() {
     let xs = [1, 2, 3, 4]
-    XCTAssertEqual(xs.min(by: { (x) in x }), 1)
-    XCTAssertEqual(xs.min(by: { (x) in -x }), 4)
+    XCTAssertEqual(xs.min(measuredBy: { (x) in x }), 1)
+    XCTAssertEqual(xs.min(measuredBy: { (x) in -x }), 4)
   }
 
 }


### PR DESCRIPTION
You can add a `test-case.<artifact-tag>.expected` file besides your `test-case.hylo` to assert the contents of a compilation artifact. Valid artifacts are:
- `*.raw-ir.expected`
- `*.transformed-ir.expected`
- `*.llvm-ir.expected`

An artifact is composed of a set of contiguous sections, delimited by empty lines. E.g. each function in Hylo IR and LLVM IR are their own sections.

It is sufficient to specify a subset of sections of the actual artifact. The expected section is matched with the observed section having the closest first line. Then they are compared for equality.