### PR TITLE
Fix parser crash on unterminated calls

### DIFF
--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -2474,7 +2474,7 @@ public struct Parser {
     if let n = peek() {
       return tokens.source[position.index ..< n.site.start.index].contains(where: \.isNewline)
     } else {
-      return tokens.source.index(after: position.index) == tokens.source.endIndex
+      return position.index == tokens.source.endIndex
     }
   }
 

--- a/Tests/CompilerTests/negative/unterminated-call-at-eof.diagnostics.expected
+++ b/Tests/CompilerTests/negative/unterminated-call-at-eof.diagnostics.expected
@@ -1,0 +1,21 @@
+negative/unterminated-call-at-eof.hylo:4.9: error: expected expression
+  _ = f(
+        ^
+negative/unterminated-call-at-eof.hylo:5.2: error: expected expression
+}
+ ^
+negative/unterminated-call-at-eof.hylo:7.14: error: consecutive statements on the same line must be separated by ';'
+subscript x(){
+             ^
+negative/unterminated-call-at-eof.hylo:8.4: error: expected ','
+  _ = x[
+   ^
+negative/unterminated-call-at-eof.hylo:8.4: error: expected expression
+  _ = x[
+   ^
+negative/unterminated-call-at-eof.hylo:9.2: error: consecutive statements on the same line must be separated by ';'
+}
+ ^
+negative/unterminated-call-at-eof.hylo:9.2: error: expected '}'
+}
+ ^

--- a/Tests/CompilerTests/negative/unterminated-call-at-eof.hylo
+++ b/Tests/CompilerTests/negative/unterminated-call-at-eof.hylo
@@ -1,0 +1,9 @@
+//! stage:parsing no-std
+
+fun f() {
+  _ = f(
+}
+
+subscript x(){
+  _ = x[
+}


### PR DESCRIPTION
`position` refers to the next unconsumed token's position. If that's endIndex, it is illegal to get the subsequent index. This caused #149. The crash happened both on incomplete subscript and function calls.