### PR TITLE
Fix compiler crash on incomplete type declaration

### DIFF
--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -28,6 +28,11 @@ public struct Parser {
       if case .typeBody = self { return true } else { return false }
     }
 
+    /// Returns `true` iff `self` denotes the body of a trait declaration.
+    var isTraitBody: Bool {
+      self == .typeBody(.init(TraitDeclaration.self))
+    }
+
   }
 
   /// The tokens in the input.
@@ -1185,8 +1190,23 @@ public struct Parser {
     let introducer = try take(.type) ?? expected("'type'")
     let identifier = parseSimpleIdentifier()
 
-    // If the next token is `<` or `=`, commit to a type alias declaration.
-    if next(is: .leftAngle) || next(is: .assign) {
+    // In a trait body, a 'type' declaration that is not followed by `<` or `=` introduces an
+    // associated type. Everywhere else, 'type' always introduces a type alias.
+    if !next(is: .assign) && !next(is: .leftAngle) && context.isTraitBody {
+      // No modifiers or annotations allowed on associated types.
+      _ = sanitize(prologue.annotations, accepting: { _ in false })
+      _ = sanitize(prologue.modifiers, accepting: { _ in false })
+
+      let d = file.insert(
+        AssociatedTypeDeclaration(
+          introducer: introducer,
+          identifier: identifier,
+          site: span(from: introducer)))
+      return .init(d)
+    }
+
+    // Otherwise, commit to a type alias declaration.
+    else {
       let parameters = try parseOptionalTypeParameterClause(in: &file)
       _ = try take(.assign) ?? expected("'='")
       let aliasee = try parseExpression(in: &file)
@@ -1202,25 +1222,6 @@ public struct Parser {
           parameters: parameters,
           aliasee: aliasee,
           site: introducer.site.extended(upTo: position.index)))
-      return .init(d)
-    }
-
-    // Otherwise, commit to an associated type declaration.
-    else {
-      // No modifiers or annotations allowed on associated types.
-      _ = sanitize(prologue.annotations, accepting: { _ in false })
-      _ = sanitize(prologue.modifiers, accepting: { _ in false })
-
-      // An error has already been reported if the identifier is `$!`.
-      if !context.isTypeBody && (identifier.value != "$!") {
-        report(.init("declaration is not allowed here", at: introducer.site))
-      }
-
-      let d = file.insert(
-        AssociatedTypeDeclaration(
-          introducer: introducer,
-          identifier: identifier,
-          site: span(from: introducer)))
       return .init(d)
     }
   }

--- a/Tests/CompilerTests/negative/illegal-associated-type-declaration.diagnostics.expected
+++ b/Tests/CompilerTests/negative/illegal-associated-type-declaration.diagnostics.expected
@@ -1,6 +1,0 @@
-negative/illegal-associated-type-declaration.hylo:5.1-5: error: declaration is not allowed here
-type X
-~~~~
-negative/illegal-associated-type-declaration.hylo:8.5: error: expected identifier
-type
-    ^

--- a/Tests/CompilerTests/negative/illegal-associated-type-declaration.hylo
+++ b/Tests/CompilerTests/negative/illegal-associated-type-declaration.hylo
@@ -1,8 +1,0 @@
-// Alias declaration
-type X = Int
-
-// Associated type declaration
-type X
-
-// Incomplete type declaration
-type

--- a/Tests/CompilerTests/negative/incomplete-type-declaration.diagnostics.expected
+++ b/Tests/CompilerTests/negative/incomplete-type-declaration.diagnostics.expected
@@ -1,0 +1,12 @@
+negative/incomplete-type-declaration.hylo:5.7: error: expected '='
+type Y
+      ^
+negative/incomplete-type-declaration.hylo:8.5: error: expected '='
+type
+    ^
+negative/incomplete-type-declaration.hylo:8.5: error: expected identifier
+type
+    ^
+negative/incomplete-type-declaration.hylo:12.7: error: expected identifier
+  type
+      ^

--- a/Tests/CompilerTests/negative/incomplete-type-declaration.hylo
+++ b/Tests/CompilerTests/negative/incomplete-type-declaration.hylo
@@ -1,0 +1,13 @@
+// Type alias declaration
+type X = Int
+
+// Incomplete type alias declaration
+type Y
+
+// Incomplete type declaration
+type
+
+trait P {
+  // Incomplete associated type declaration
+  type
+}


### PR DESCRIPTION
See https://github.com/hylo-lang/hylo-new/issues/24

A type declaration is an associated type only inside a trait body; everywhere else it's expected to be a type alias, and thus a `=` or `<` is required after the identifier. After this fix, all the following cases get reported without a crash:

```
// Incomplete type alias declaration
type Y

// Incomplete type declaration
type

trait P {
  // Incomplete associated type declaration
  type
}
```