### PR TITLE
Fix typer crash on bodyless local functions

### DIFF
--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -274,8 +274,11 @@ public struct Typer {
       }
     }
 
+    /// Nothing to do if the function has no body; missing definitions are diagnosed elsewhere.
+    guard let body = program[d].body else { return captures }
+
     // Visit the syntax tree to collect all captures.
-    var work = program[d].body!.reversed().map({ (s) in (s.erased, false) })
+    var work = body.reversed().map({ (s) in (s.erased, false) })
     while let (n, isMarkedForMutation) = work.popLast() {
       switch program.tag(of: n) {
       case InoutExpression.self:

--- a/Tests/CompilerTests/negative/bodyless-local-function.diagnostics.expected
+++ b/Tests/CompilerTests/negative/bodyless-local-function.diagnostics.expected
@@ -1,0 +1,3 @@
+negative/bodyless-local-function.hylo:4.7-12: error: declaration requires a body
+  fun inner()
+      ~~~~~

--- a/Tests/CompilerTests/negative/bodyless-local-function.hylo
+++ b/Tests/CompilerTests/negative/bodyless-local-function.hylo
@@ -1,0 +1,5 @@
+//! no-std stage:typing
+
+fun outer() -> Void {
+  fun inner()
+}


### PR DESCRIPTION
`Typer.implicitCaptures(of:)` force-unwraps `program[d].body`, assuming every local function has a body.

A local function written without a body is a already diagnosed, but without an early exit. This PR updates `impicitCaptures` to be lenient about a missing `body`, returning a sensible default (0 captures) when body is not present.

### Reproducer
```hylo
//! no-std stage:typing

fun outer() -> Void {
  fun inner()
}
```