### PR TITLE
List members for LSP support

### DIFF
--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -1229,7 +1229,7 @@ public struct Parser {
     in file: inout Module.SourceContainer
   ) throws -> VariableDeclaration.ID {
     let n = try take(.name) ?? expected("identifier")
-    return file.insert(VariableDeclaration(identifier: .init(n)))
+    return file.insert(VariableDeclaration(identifier: .init(n), synthesized: false))
   }
 
   /// Parses a type alias or associated type declaration.
@@ -3058,7 +3058,7 @@ extension Module.SourceContainer {
     let s = SourceSpan.empty(at: site.start)
 
     let p: PatternIdentity = if let i = identifier {
-      .init(insert(VariableDeclaration(identifier: .init(i))))
+      .init(insert(VariableDeclaration(identifier: .init(i), synthesized: false)))
     } else {
       .init(synthesizeVariableDeclaration(at: s))
     }
@@ -3084,7 +3084,7 @@ extension Module.SourceContainer {
     at site: SourceSpan
   ) -> VariableDeclaration.ID {
     let n = String(syntax.count, radix: 36)
-    return insert(VariableDeclaration(identifier: .init("$\(n)", at: site)))
+    return insert(VariableDeclaration(identifier: .init("$\(n)", at: site), synthesized: true))
   }
 
 }

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -1229,7 +1229,7 @@ public struct Parser {
     in file: inout Module.SourceContainer
   ) throws -> VariableDeclaration.ID {
     let n = try take(.name) ?? expected("identifier")
-    return file.insert(VariableDeclaration(identifier: .init(n), synthesized: false))
+    return file.insert(VariableDeclaration(identifier: .init(n), isSynthesized: false))
   }
 
   /// Parses a type alias or associated type declaration.
@@ -3058,7 +3058,7 @@ extension Module.SourceContainer {
     let s = SourceSpan.empty(at: site.start)
 
     let p: PatternIdentity = if let i = identifier {
-      .init(insert(VariableDeclaration(identifier: .init(i), synthesized: false)))
+      .init(insert(VariableDeclaration(identifier: .init(i), isSynthesized: false)))
     } else {
       .init(synthesizeVariableDeclaration(at: s))
     }
@@ -3084,7 +3084,7 @@ extension Module.SourceContainer {
     at site: SourceSpan
   ) -> VariableDeclaration.ID {
     let n = String(syntax.count, radix: 36)
-    return insert(VariableDeclaration(identifier: .init("$\(n)", at: site), synthesized: true))
+    return insert(VariableDeclaration(identifier: .init("$\(n)", at: site), isSynthesized: true))
   }
 
 }

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1946,4 +1946,49 @@ extension Program {
     })
   }
 
+  /// Returns every member reachable on a value of type `t` from `scopeOfUse`.
+  ///
+  /// The result is the union of `t`'s native members, the members of the extensions of `t` visible
+  /// from `scopeOfUse`, and the requirements of every visible trait to which `t` conforms in the
+  /// implicit context at `scopeOfUse`.
+  ///
+  /// Pass `selectionIsStatic` to choose which members are returned: static members and initializers
+  /// reached through a type or instance members reached through a value.
+  ///
+  /// - Requires: `m` has been type checked.
+  public mutating func members(
+    of t: AnyTypeIdentity, in m: Module.ID, visibleFrom scopeOfUse: ScopeIdentity,
+    static selectionIsStatic: Bool
+  ) -> [MemberCandidate] {
+    withTyper(typing: m) { (typer) in
+      typer.members(of: t, visibleFrom: scopeOfUse, static: selectionIsStatic)
+        .compactMap { (c) in
+          c.reference.target.map { (d) in
+            MemberCandidate(declaration: d, reference: c.reference, type: c.type)
+          }
+        }
+    }
+  }
+
+}
+
+/// A member reachable on a receiver, together with its type and how it is referred to.
+public struct MemberCandidate: Sendable {
+
+  /// The declaration of the member.
+  public let declaration: DeclarationIdentity
+
+  /// How the member is referred to (direct, bound member, or inherited via extension/conformance).
+  public let reference: DeclarationReference
+
+  /// The type of the member as selected on the receiver, with conformance substitutions applied.
+  public let type: AnyTypeIdentity
+
+  /// Creates an instance with the given properties.
+  public init(declaration: DeclarationIdentity, reference: DeclarationReference, type: AnyTypeIdentity) {
+    self.declaration = declaration
+    self.reference = reference
+    self.type = type
+  }
+
 }

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1968,36 +1968,28 @@ extension Program {
   /// - Requires: `m` has been type checked.
   public mutating func members(
     of t: AnyTypeIdentity, in m: Module.ID, visibleFrom scopeOfUse: ScopeIdentity,
-    static selectionIsStatic: Bool
+    resolvedStatically selectionIsStatic: Bool
   ) -> [MemberCandidate] {
     withTyper(typing: m) { (typer) in
-      typer.members(of: t, visibleFrom: scopeOfUse, static: selectionIsStatic)
-        .compactMap { (c) in
-          c.reference.target.map { (d) in
-            MemberCandidate(declaration: d, reference: c.reference, type: c.type)
-          }
-        }
+      typer.members(of: t, visibleFrom: scopeOfUse, resolvedStatically: selectionIsStatic)
+        .map { (c) in MemberCandidate(declaration: c.reference, type: c.type) }
     }
   }
 
 }
 
-/// A member reachable on a receiver, together with its type and how it is referred to.
+/// A member declaration and its type.
 public struct MemberCandidate: Sendable {
 
-  /// The declaration of the member.
-  public let declaration: DeclarationIdentity
-
   /// How the member is referred to (direct, bound member, or inherited via extension/conformance).
-  public let reference: DeclarationReference
+  public let declaration: DeclarationReference
 
   /// The type of the member as selected on the receiver, with conformance substitutions applied.
   public let type: AnyTypeIdentity
 
   /// Creates an instance with the given properties.
-  public init(declaration: DeclarationIdentity, reference: DeclarationReference, type: AnyTypeIdentity) {
+  public init(declaration: DeclarationReference, type: AnyTypeIdentity) {
     self.declaration = declaration
-    self.reference = reference
     self.type = type
   }
 

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1946,6 +1946,16 @@ extension Program {
     })
   }
 
+  /// Returns the type denoted by "Self" in `scopeOfUse`, or `nil` if "Self"
+  /// is not legal there.
+  ///
+  /// - Requires: The module containing `scopeOfUse` has been type checked.
+  public mutating func typeOfSelf(in scopeOfUse: ScopeIdentity) -> AnyTypeIdentity? {
+    withTyper(typing: scopeOfUse.file.module) { (typer) in
+      typer.typeOfSelf(in: scopeOfUse)
+    }
+  }
+
   /// Returns every member reachable on a value of type `t` from `scopeOfUse`.
   ///
   /// The result is the union of `t`'s native members, the members of the extensions of `t` visible

--- a/Sources/FrontEnd/Syntax/Declarations/VariableDeclaration.swift
+++ b/Sources/FrontEnd/Syntax/Declarations/VariableDeclaration.swift
@@ -14,6 +14,9 @@ public struct VariableDeclaration: Declaration, Pattern {
   /// The site from which `self` was parsed.
   public var site: SourceSpan { identifier.site }
 
+  /// `true` iff `identifier` was synthesized rather than user-written.
+  public var synthesized: Bool
+
 }
 
 extension VariableDeclaration: Showable {
@@ -29,10 +32,12 @@ extension VariableDeclaration: Archivable {
 
   public init<T>(from archive: inout ReadableArchive<T>, in context: inout Any) throws {
     self.identifier = try archive.read(Parsed<String>.self, in: &context)
+    self.synthesized = try archive.read(Bool.self, in: &context)
   }
 
   public func write<T>(to archive: inout WriteableArchive<T>, in context: inout Any) throws {
     try archive.write(identifier, in: &context)
+    try archive.write(synthesized, in: &context)
   }
 
 }

--- a/Sources/FrontEnd/Syntax/Declarations/VariableDeclaration.swift
+++ b/Sources/FrontEnd/Syntax/Declarations/VariableDeclaration.swift
@@ -15,7 +15,7 @@ public struct VariableDeclaration: Declaration, Pattern {
   public var site: SourceSpan { identifier.site }
 
   /// `true` iff `identifier` was synthesized rather than user-written.
-  public var synthesized: Bool
+  public var isSynthesized: Bool
 
 }
 
@@ -32,12 +32,12 @@ extension VariableDeclaration: Archivable {
 
   public init<T>(from archive: inout ReadableArchive<T>, in context: inout Any) throws {
     self.identifier = try archive.read(Parsed<String>.self, in: &context)
-    self.synthesized = try archive.read(Bool.self, in: &context)
+    self.isSynthesized = try archive.read(Bool.self, in: &context)
   }
 
   public func write<T>(to archive: inout WriteableArchive<T>, in context: inout Any) throws {
     try archive.write(identifier, in: &context)
-    try archive.write(synthesized, in: &context)
+    try archive.write(isSynthesized, in: &context)
   }
 
 }

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4601,9 +4601,9 @@ public struct Typer {
 
   /// Returns `true` iff `m` is part of the declaration shown when enumerating the members of a type.
   ///
-  /// In addition to `resolvableWithQualification`, this excludes the variable introduced by an
-  /// implicit (`using`/`given`) binding. Such a value is should be reached through implicit
-  /// resolution, not member selection.
+  /// In addition to `resolvableWithQualification`, this excludes the synthesized variable 
+  /// introduced by a given. Such a value should be reached through implicit resolution, not
+  /// member selection.
   private func isEnumerableMember(_ m: DeclarationIdentity) -> Bool {
     guard resolvableWithQualification(m) else { return false }
     if let v = program.cast(m, to: VariableDeclaration.self) {

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -3099,7 +3099,7 @@ public struct Typer {
 
   /// Returns the type of an instance of `Self` in `s`, or `nil` if `s` isn't notionally in the
   /// scope of a type declaration.
-  private mutating func typeOfSelf(in s: ScopeIdentity) -> AnyTypeIdentity? {
+  internal mutating func typeOfSelf(in s: ScopeIdentity) -> AnyTypeIdentity? {
     if let memoized = cache.scopeToTypeOfSelf[s] { return memoized }
 
     guard let n = s.node else { return nil }

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4243,15 +4243,15 @@ public struct Typer {
   ) -> [NameResolutionCandidate] {
     if q.isVariable { return [] }
 
-    // `qualificationForSelection` normalizes the receiver type (a `let`/`inout` projection unwraps
-    // to its projectee, a metatype to its inhabitant). The static/instance choice is the caller's,
-    // not derived from `q`, so the two cannot silently disagree.
     let r = qualificationForSelection(on: q).type
 
     var candidates: [NameResolutionCandidate] = []
-    candidates.append(contentsOf: nativeMembers(of: r, resolvedStatically: s))
-    candidates.append(contentsOf: extensionMembers(of: r, visibleFrom: scopeOfUse, resolvedStatically: s))
-    candidates.append(contentsOf: inheritedMembers(of: r, visibleFrom: scopeOfUse, resolvedStatically: s))
+    candidates.append(contentsOf:
+      nativeMembers(of: r, resolvedStatically: s))
+    candidates.append(contentsOf:
+      extensionMembers(of: r, visibleFrom: scopeOfUse, resolvedStatically: s))
+    candidates.append(contentsOf:
+      inheritedMembers(of: r, visibleFrom: scopeOfUse, resolvedStatically: s))
 
     return Self.uniqueCandidates(candidates)
   }
@@ -4271,7 +4271,7 @@ public struct Typer {
 
   /// Returns the natives members of `q`.
   /// 
-  /// Static members are returned iff `selectionIsStatic` is true.
+  /// Static members are included iff `selectionIsStatic` is true.
   private mutating func nativeMembers(
     of q: AnyTypeIdentity, resolvedStatically selectionIsStatic: Bool
   ) -> [NameResolutionCandidate] {
@@ -4294,7 +4294,7 @@ public struct Typer {
 
   /// Returns the members of `q` that are inherited by extension and visible from `scopeOfUse`.
   /// 
-  /// Static members are returned iff `selectionIsStatic` is true.
+  /// Static members are included iff `selectionIsStatic` is true.
   private mutating func extensionMembers(
     of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, 
     resolvedStatically selectionIsStatic: Bool
@@ -4322,8 +4322,8 @@ public struct Typer {
 
   /// Returns a candidate for every trait requirement reachable on `q` through conformances visible
   /// from `scopeOfUse`.
-  /// 
-  /// Static members are returned iff `selectionIsStatic` is true.
+  ///
+  /// Static members are included iff `selectionIsStatic` is true.
   private mutating func inheritedMembers(
     of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, resolvedStatically selectionIsStatic: Bool
   ) -> [NameResolutionCandidate] {

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4230,17 +4230,16 @@ public struct Typer {
     return candidates
   }
 
-  /// Returns a candidate for every member of `q` reachable in `scopeOfUse`.
+  /// This method is similar to `resolve(_:memberOf:visibleFrom:)`, except that it collects all
+  /// members (declared together with the type or inherited by extension/conformance) that are
+  /// visible from `scopeOfUse`, rather than resolving a single name.
   ///
-  /// This is the enumerating counterpart of `resolve(_:memberOf:visibleFrom:)`: rather than
-  /// resolving a single name, it collects all native members, all members of the applicable
-  /// extensions visible from `scopeOfUse`, and all requirements of every visible trait to which `q`
-  /// conforms (decided by `summon`, exactly as name resolution would). It is the building block for
-  /// IDE features such as member completion.
+  /// This method is intended for tooling and should not be used to perform name resolution. Its
+  /// implementation does not uphold coherence.
   ///
   /// - Requires: `q` is not a unification variable and the enclosing module has been type checked.
   internal mutating func members(
-    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, static s: Bool
+    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, resolvedStatically s: Bool
   ) -> [NameResolutionCandidate] {
     if q.isVariable { return [] }
 
@@ -4250,32 +4249,37 @@ public struct Typer {
     let r = qualificationForSelection(on: q).type
 
     var candidates: [NameResolutionCandidate] = []
-    candidates.append(contentsOf: nativeMembers(of: r, statically: s))
-    candidates.append(contentsOf: extensionMembers(of: r, visibleFrom: scopeOfUse, statically: s))
-    candidates.append(contentsOf: inheritedMembers(of: r, visibleFrom: scopeOfUse, statically: s))
+    candidates.append(contentsOf: nativeMembers(of: r, resolvedStatically: s))
+    candidates.append(contentsOf: extensionMembers(of: r, visibleFrom: scopeOfUse, resolvedStatically: s))
+    candidates.append(contentsOf: inheritedMembers(of: r, visibleFrom: scopeOfUse, resolvedStatically: s))
 
-    // Dedup by declaration identity (e.g. the same trait requirement reached through several
-    // witnesses) while keeping same-named members of distinct declarations (overloads, or members
-    // offered by more than one in-scope trait).
+    return Self.uniqueCandidates(candidates)
+  }
+
+  /// Remove duplicate resolution candidates while keeping same-named members of distinct
+  /// declarations (e.g., overloads or members offered by more than one in-scope trait).
+  static func uniqueCandidates(_ cs: [NameResolutionCandidate]) -> [NameResolutionCandidate] {
     var seen: Set<DeclarationIdentity> = []
-    return candidates.filter { (c) in
-      guard let d = c.reference.target else { return true }
-      return seen.insert(d).inserted
+    return cs.filter { (c) in
+      if let d = c.reference.target {
+        seen.insert(d).inserted
+      } else {
+        true
+      }
     }
   }
 
-  /// Returns a candidate for every native member of `q`.
+  /// Returns the natives members of `q`.
   /// 
   /// Static members are returned iff `selectionIsStatic` is true.
   private mutating func nativeMembers(
-    of q: AnyTypeIdentity, statically selectionIsStatic: Bool
+    of q: AnyTypeIdentity, resolvedStatically selectionIsStatic: Bool
   ) -> [NameResolutionCandidate] {
     //  Mirrors `resolve(_:nativeMemberOf:statically:)` but without filtering by name.
     let (context, receiver) = program.types.contextAndHead(q)
     var candidates: [NameResolutionCandidate] = []
     for ds in declarations(nativeMembersOf: q).values {
-      for m in ds {
-        if !isEnumerableMember(m) { continue }
+      for m in ds where isEnumerableMember(m) {
         var member = typeOfName(referringTo: m, statically: selectionIsStatic)
         if let a = program.types[receiver] as? TypeApplication {
           member = program.types.substitute(a.arguments, in: member)
@@ -4288,12 +4292,12 @@ public struct Typer {
     return candidates
   }
 
-  /// Returns a candidate for every member declared in an extension of `q` visible from 
-  /// `scopeOfUse`.
+  /// Returns the members of `q` that are inherited by extension and visible from `scopeOfUse`.
   /// 
   /// Static members are returned iff `selectionIsStatic` is true.
   private mutating func extensionMembers(
-    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, statically selectionIsStatic: Bool
+    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, 
+    resolvedStatically selectionIsStatic: Bool
   ) -> [NameResolutionCandidate] {
     // Mirrors `resolve(_:declaredIn:applyingTo:in:statically:)` but without filtering by name.
     var candidates: [NameResolutionCandidate] = []
@@ -4303,8 +4307,7 @@ public struct Typer {
         a.witness, applying: a.substitutions, withVariables: .substitutedByError)
       let arguments = w.typeArguments(appliedTo: e)
       for ds in declarations(lexicallyIn: .init(node: e)).values {
-        for m in ds {
-          if !isEnumerableMember(m) { continue }
+        for m in ds where isEnumerableMember(m) {
           var member = typeOfName(referringTo: m, statically: selectionIsStatic)
           if let a = arguments {
             member = program.types.substitute(a, in: member)
@@ -4322,7 +4325,7 @@ public struct Typer {
   /// 
   /// Static members are returned iff `selectionIsStatic` is true.
   private mutating func inheritedMembers(
-    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, statically selectionIsStatic: Bool
+    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, resolvedStatically selectionIsStatic: Bool
   ) -> [NameResolutionCandidate] {
     // Mirrors `resolve(_:inheritedMemberOf:visibleFrom:statically:)` but enumerates every visible 
     // trait and all of its requirements instead of resolving a single name.
@@ -4384,8 +4387,7 @@ public struct Typer {
     var ds = declarations(nativeMembersOf: q)[n.identifier] ?? []
     refineLookupResults(&ds, matching: n)
 
-    for m in ds {
-      if !resolvableWithQualification(m) { continue }
+    for m in ds where resolvableWithQualification(m) {
       var member = typeOfName(referringTo: m, statically: selectionIsStatic)
       if let a = program.types[receiver] as? TypeApplication {
         member = program.types.substitute(a.arguments, in: member)
@@ -4597,7 +4599,7 @@ public struct Typer {
     }
   }
 
-  /// Returns `true` iff `m` should be offered when enumerating the members of a type.
+  /// Returns `true` iff `m` is part of the declaration shown when enumerating the members of a type.
   ///
   /// In addition to `resolvableWithQualification`, this excludes the variable introduced by an
   /// implicit (`using`/`given`) binding. Such a value is should be reached through implicit
@@ -4605,7 +4607,7 @@ public struct Typer {
   private func isEnumerableMember(_ m: DeclarationIdentity) -> Bool {
     guard resolvableWithQualification(m) else { return false }
     if let v = program.cast(m, to: VariableDeclaration.self) {
-      return !program[v].synthesized
+      return !program[v].isSynthesized
     }
     return true
   }

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4230,6 +4230,126 @@ public struct Typer {
     return candidates
   }
 
+  /// Returns a candidate for every member of `q` reachable in `scopeOfUse`.
+  ///
+  /// This is the enumerating counterpart of `resolve(_:memberOf:visibleFrom:)`: rather than
+  /// resolving a single name, it collects all native members, all members of the applicable
+  /// extensions visible from `scopeOfUse`, and all requirements of every visible trait to which `q`
+  /// conforms (decided by `summon`, exactly as name resolution would). It is the building block for
+  /// IDE features such as member completion.
+  ///
+  /// - Requires: `q` is not a unification variable and the enclosing module has been type checked.
+  internal mutating func members(
+    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, static s: Bool
+  ) -> [NameResolutionCandidate] {
+    if q.isVariable { return [] }
+
+    // `qualificationForSelection` normalizes the receiver type (a `let`/`inout` projection unwraps
+    // to its projectee, a metatype to its inhabitant). The static/instance choice is the caller's,
+    // not derived from `q`, so the two cannot silently disagree.
+    let r = qualificationForSelection(on: q).type
+
+    var candidates: [NameResolutionCandidate] = []
+    candidates.append(contentsOf: nativeMembers(of: r, statically: s))
+    candidates.append(contentsOf: extensionMembers(of: r, visibleFrom: scopeOfUse, statically: s))
+    candidates.append(contentsOf: inheritedMembers(of: r, visibleFrom: scopeOfUse, statically: s))
+
+    // Dedup by declaration identity (e.g. the same trait requirement reached through several
+    // witnesses) while keeping same-named members of distinct declarations (overloads, or members
+    // offered by more than one in-scope trait).
+    var seen: Set<DeclarationIdentity> = []
+    return candidates.filter { (c) in
+      guard let d = c.reference.target else { return true }
+      return seen.insert(d).inserted
+    }
+  }
+
+  /// Returns a candidate for every native member of `q`.
+  /// 
+  /// Static members are returned iff `selectionIsStatic` is true.
+  private mutating func nativeMembers(
+    of q: AnyTypeIdentity, statically selectionIsStatic: Bool
+  ) -> [NameResolutionCandidate] {
+    //  Mirrors `resolve(_:nativeMemberOf:statically:)` but without filtering by name.
+    let (context, receiver) = program.types.contextAndHead(q)
+    var candidates: [NameResolutionCandidate] = []
+    for ds in declarations(nativeMembersOf: q).values {
+      for m in ds {
+        if !isEnumerableMember(m) { continue }
+        var member = typeOfName(referringTo: m, statically: selectionIsStatic)
+        if let a = program.types[receiver] as? TypeApplication {
+          member = program.types.substitute(a.arguments, in: member)
+        }
+        member = program.types.introduce(context, into: member)
+        candidates.append(
+          .init(reference: selectionIsStatic ? .direct(m) : .member(m), type: member))
+      }
+    }
+    return candidates
+  }
+
+  /// Returns a candidate for every member declared in an extension of `q` visible from 
+  /// `scopeOfUse`.
+  /// 
+  /// Static members are returned iff `selectionIsStatic` is true.
+  private mutating func extensionMembers(
+    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, statically selectionIsStatic: Bool
+  ) -> [NameResolutionCandidate] {
+    // Mirrors `resolve(_:declaredIn:applyingTo:in:statically:)` but without filtering by name.
+    var candidates: [NameResolutionCandidate] = []
+    for e in extensions(visibleFrom: scopeOfUse) where !declarationsOnStack.contains(.init(e)) {
+      guard let a = applies(e, to: q, in: scopeOfUse) else { continue }
+      let w = program.types.reify(
+        a.witness, applying: a.substitutions, withVariables: .substitutedByError)
+      let arguments = w.typeArguments(appliedTo: e)
+      for ds in declarations(lexicallyIn: .init(node: e)).values {
+        for m in ds {
+          if !isEnumerableMember(m) { continue }
+          var member = typeOfName(referringTo: m, statically: selectionIsStatic)
+          if let a = arguments {
+            member = program.types.substitute(a, in: member)
+          }
+          candidates.append(
+            .init(reference: .inherited(w, m, statically: selectionIsStatic), type: member))
+        }
+      }
+    }
+    return candidates
+  }
+
+  /// Returns a candidate for every trait requirement reachable on `q` through conformances visible
+  /// from `scopeOfUse`.
+  /// 
+  /// Static members are returned iff `selectionIsStatic` is true.
+  private mutating func inheritedMembers(
+    of q: AnyTypeIdentity, visibleFrom scopeOfUse: ScopeIdentity, statically selectionIsStatic: Bool
+  ) -> [NameResolutionCandidate] {
+    // Mirrors `resolve(_:inheritedMemberOf:visibleFrom:statically:)` but enumerates every visible 
+    // trait and all of its requirements instead of resolving a single name.
+
+    var candidates: [NameResolutionCandidate] = []
+    for concept in traits(visibleFrom: scopeOfUse) {
+      let vs = program[concept].parameters.map({ _ in fresh().erased })
+      let model = typeOfModel(of: q, conformingTo: concept, with: vs)
+      for a in summon(model.erased, in: scopeOfUse) {
+        let w = program.types.reify(
+          a.witness, applying: a.substitutions, withVariables: .substitutedByError)
+        for m in program[concept].members {
+          if !isEnumerableMember(m) { continue }
+          // Ignore the member if it is static but the qualification isn't.
+          if program.isStatic(m) && !selectionIsStatic { continue }
+          var member = typeOfImplementation(satisfying: m, in: w)
+          if !selectionIsStatic {
+            member = typeOfBoundMember(referringTo: m, withUnboundType: member)
+          }
+          candidates.append(
+            .init(reference: .inherited(w, m, statically: selectionIsStatic), type: member))
+        }
+      }
+    }
+    return candidates
+  }
+
   /// Returns candidates for resolving `n` as a member of `q` in `scopeOfUse`.
   private mutating func resolve(
     _ n: Name, memberOf q: Namespace.ID, visibleFrom scopeOfUse: ScopeIdentity
@@ -4475,6 +4595,19 @@ public struct Typer {
     default:
       return true
     }
+  }
+
+  /// Returns `true` iff `m` should be offered when enumerating the members of a type.
+  ///
+  /// In addition to `resolvableWithQualification`, this excludes the variable introduced by an
+  /// implicit (`using`/`given`) binding. Such a value is should be reached through implicit
+  /// resolution, not member selection.
+  private func isEnumerableMember(_ m: DeclarationIdentity) -> Bool {
+    guard resolvableWithQualification(m) else { return false }
+    if let v = program.cast(m, to: VariableDeclaration.self) {
+      return !program[v].synthesized
+    }
+    return true
   }
 
   /// Returns the declarations lexically contained in the declaration of `t`.

--- a/Tests/FrontEndTests/MemberEnumerationTests.swift
+++ b/Tests/FrontEndTests/MemberEnumerationTests.swift
@@ -2,17 +2,14 @@ import FrontEnd
 import XCTest
 
 /// Tests for `Program.members(of:in:visibleFrom:static:)`, the member-listing query used by LSP.
-final class MemberListingTests: XCTestCase {
+final class MemberEnumerationTests: XCTestCase {
 
-  func testListsNativeConformanceAndExtensionMembers() async throws {
-    // An instance receiver should see its own members, the members of an applicable extension, and
-    // the requirements of every trait it conforms to.
+  func testEnumerateMembers() async throws {
     let names = try await instanceMembers(
       ofStruct: "A",
       in: """
       trait P { fun f() }
       struct A {
-        public memberwise init
         public fun g() {}
       }
       given A is P { fun f() {} }
@@ -23,15 +20,12 @@ final class MemberListingTests: XCTestCase {
     XCTAssert(names.contains("h"))  // extension
   }
 
-  func testListsStaticMembersFromAllSources() async throws {
-    // A type receiver should see static members from the type itself, an extension, and a
-    // conformance.
+  func testEnumerateStaticMembers() async throws {
     let names = try await staticMembers(
       ofStruct: "A",
       in: """
       trait P { static fun h() }
       struct A {
-        public memberwise init
         public static fun f() {}
       }
       given A is P { public static fun h() {} }
@@ -42,28 +36,29 @@ final class MemberListingTests: XCTestCase {
     XCTAssert(names.contains("h"))  // conformance
   }
 
-  func testStaticConformanceRequirementRequiresStaticSelection() async throws {
+  func testEnumerateStaticInheritedMembers() async throws {
     // A static trait requirement is reachable only through a static selection (`A.s`), not on an
-    // instance, so the `static` flag must be honored in the conformance branch.
-    let source: SourceFile = """
+    // instance of `A`.
+    let s: SourceFile = """
       trait P { static fun s() }
-      struct A { public memberwise init }
+      struct A { }
       given A is P { public static fun s() {} }
       """
-    let statics = try await staticMembers(ofStruct: "A", in: source)
-    let instance = try await instanceMembers(ofStruct: "A", in: source)
+
+    let statics = try await staticMembers(ofStruct: "A", in: s)
     XCTAssertTrue(statics.contains("s"))
+
+    let instance = try await instanceMembers(ofStruct: "A", in: s)
     XCTAssertFalse(instance.contains("s"))
   }
 
-  func testDoesNotListSynthesizedConformanceWitnesses() async throws {
+  func testIgnoreSynthesizedDeclarations() async throws {
     // The synthesized `$f` member should not be listed as a member.
     let names = try await instanceMembers(
       ofStruct: "A",
       in: """
       struct A {
-        public memberwise init
-        given let x: Int = 0  
+        given let x: Int = 0
       }
       trait P { fun r() }
       given A is P { fun r() {} }
@@ -93,67 +88,35 @@ final class MemberListingTests: XCTestCase {
     let v = try XCTUnwrap(p.select(.name(.init(identifier: "v"))).first)
     let receiver = try XCTUnwrap(p.type(maybeAssignedTo: v))
     let member = try XCTUnwrap(
-      p.members(of: receiver, in: m, visibleFrom: .init(file: f), static: false)
-        .first(where: { p.name(of: $0.declaration)?.identifier == "f" }))
+      p.members(of: receiver, in: m, visibleFrom: .init(file: f), resolvedStatically: false)
+        .first(where: { p.name(of: $0.declaration.target!)?.identifier == "f" }))
 
     XCTAssertEqual(p.show(member.type), "[let A<B>](let B) let -> Void")
   }
 
-  func testTypeOfSelfIsTheEnclosingTypeWithinAStructScope() async throws {
-    // "Self" inside a struct's body denotes an instance of that struct.
-    var p = Program()
-    let _ = await typeChecked(
-      &p,
-      """
-      struct A {
-        public memberwise init
-      }
-      """)
-
-    let d = try XCTUnwrap(
-      p.select(.and(.tag(StructDeclaration.self), .name(.init(identifier: "A")))).first,
-      "no struct named 'A'")
-    let selfType = try XCTUnwrap(p.typeOfSelf(in: .init(uncheckedFrom: d.erased)))
-    XCTAssertEqual(p.show(selfType), "A")
-  }
-
-  func testTypeOfSelfIsNilAtFileScope() async throws {
-    // "Self" is not legal at the top level of a file, where no type encloses the use.
-    var p = Program()
-    let (_, f) = await typeChecked(
-      &p,
-      """
-      struct A {
-        public memberwise init
-      }
-      """)
-
-    XCTAssertNil(p.typeOfSelf(in: .init(file: f)))
-  }
-
   // MARK: - Helpers
 
-  /// Returns the identifiers of the members `Program.members` reports for the struct named
-  /// `typeName` declared in `source`, selecting instance members.
+  /// Returns the identifiers of the non-static members that `Program.members` reports for the
+  /// struct named `typeName` in `source`.
   private func instanceMembers(
     ofStruct typeName: String, in source: SourceFile,
     file: StaticString = #filePath, line: UInt = #line
   ) async throws -> Set<String> {
-    try await memberNames(ofStruct: typeName, in: source, static: false, file: file, line: line)
+    try await members(ofStruct: typeName, in: source, static: false, file: file, line: line)
   }
 
-  /// Returns the identifiers of the members `Program.members` reports for the struct named `name`
-  /// declared in `source`, selecting static members.
+  /// Returns the identifiers of the static members that `Program.members` reports for the struct 
+  /// named `name` in `source`.
   private func staticMembers(
     ofStruct name: String, in source: SourceFile,
     file: StaticString = #filePath, line: UInt = #line
   ) async throws -> Set<String> {
-    try await memberNames(ofStruct: name, in: source, static: true, file: file, line: line)
+    try await members(ofStruct: name, in: source, static: true, file: file, line: line)
   }
 
   /// Type-checks `source` as a single-file module and returns the identifiers of the members
-  /// reported for the struct named `typeName`, selecting static members iff `isStatic`.
-  private func memberNames(
+  /// of the struct named `typeName`, selecting static members iff `isStatic` is `true`.
+  private func members(
     ofStruct typeName: String, in source: SourceFile, static isStatic: Bool,
     file: StaticString, line: UInt
   ) async throws -> Set<String> {
@@ -167,8 +130,8 @@ final class MemberListingTests: XCTestCase {
     // instance type and selects static or instance members per the flag.
     let receiver = p.type(assignedTo: d)
     return Set(
-      p.members(of: receiver, in: m, visibleFrom: .init(file: f), static: isStatic)
-        .compactMap({ p.name(of: $0.declaration)?.identifier }))
+      p.members(of: receiver, in: m, visibleFrom: .init(file: f), resolvedStatically: isStatic)
+        .compactMap({ p.name(of: $0.declaration.target!)?.identifier }))
   }
 
   /// Type-checks `source` as a single-file `Main` module in `p`, returning its module and file.

--- a/Tests/FrontEndTests/MemberListingTests.swift
+++ b/Tests/FrontEndTests/MemberListingTests.swift
@@ -99,6 +99,38 @@ final class MemberListingTests: XCTestCase {
     XCTAssertEqual(p.show(member.type), "[let A<B>](let B) let -> Void")
   }
 
+  func testTypeOfSelfIsTheEnclosingTypeWithinAStructScope() async throws {
+    // "Self" inside a struct's body denotes an instance of that struct.
+    var p = Program()
+    let _ = await typeChecked(
+      &p,
+      """
+      struct A {
+        public memberwise init
+      }
+      """)
+
+    let d = try XCTUnwrap(
+      p.select(.and(.tag(StructDeclaration.self), .name(.init(identifier: "A")))).first,
+      "no struct named 'A'")
+    let selfType = try XCTUnwrap(p.typeOfSelf(in: .init(uncheckedFrom: d.erased)))
+    XCTAssertEqual(p.show(selfType), "A")
+  }
+
+  func testTypeOfSelfIsNilAtFileScope() async throws {
+    // "Self" is not legal at the top level of a file, where no type encloses the use.
+    var p = Program()
+    let (_, f) = await typeChecked(
+      &p,
+      """
+      struct A {
+        public memberwise init
+      }
+      """)
+
+    XCTAssertNil(p.typeOfSelf(in: .init(file: f)))
+  }
+
   // MARK: - Helpers
 
   /// Returns the identifiers of the members `Program.members` reports for the struct named

--- a/Tests/FrontEndTests/MemberListingTests.swift
+++ b/Tests/FrontEndTests/MemberListingTests.swift
@@ -1,0 +1,153 @@
+import FrontEnd
+import XCTest
+
+/// Tests for `Program.members(of:in:visibleFrom:static:)`, the member-listing query used by LSP.
+final class MemberListingTests: XCTestCase {
+
+  func testListsNativeConformanceAndExtensionMembers() async throws {
+    // An instance receiver should see its own members, the members of an applicable extension, and
+    // the requirements of every trait it conforms to.
+    let names = try await instanceMembers(
+      ofStruct: "A",
+      in: """
+      trait P { fun f() }
+      struct A {
+        public memberwise init
+        public fun g() {}
+      }
+      given A is P { fun f() {} }
+      extension A { fun h() {} }
+      """)
+    XCTAssert(names.contains("g"))  // native
+    XCTAssert(names.contains("f"))  // conformance
+    XCTAssert(names.contains("h"))  // extension
+  }
+
+  func testListsStaticMembersFromAllSources() async throws {
+    // A type receiver should see static members from the type itself, an extension, and a
+    // conformance.
+    let names = try await staticMembers(
+      ofStruct: "A",
+      in: """
+      trait P { static fun h() }
+      struct A {
+        public memberwise init
+        public static fun f() {}
+      }
+      given A is P { public static fun h() {} }
+      extension A { public static fun g() {} }
+      """)
+    XCTAssert(names.contains("f"))  // native
+    XCTAssert(names.contains("g"))  // extension
+    XCTAssert(names.contains("h"))  // conformance
+  }
+
+  func testStaticConformanceRequirementRequiresStaticSelection() async throws {
+    // A static trait requirement is reachable only through a static selection (`A.s`), not on an
+    // instance, so the `static` flag must be honored in the conformance branch.
+    let source: SourceFile = """
+      trait P { static fun s() }
+      struct A { public memberwise init }
+      given A is P { public static fun s() {} }
+      """
+    let statics = try await staticMembers(ofStruct: "A", in: source)
+    let instance = try await instanceMembers(ofStruct: "A", in: source)
+    XCTAssertTrue(statics.contains("s"))
+    XCTAssertFalse(instance.contains("s"))
+  }
+
+  func testDoesNotListSynthesizedConformanceWitnesses() async throws {
+    // The synthesized `$f` member should not be listed as a member.
+    let names = try await instanceMembers(
+      ofStruct: "A",
+      in: """
+      struct A {
+        public memberwise init
+        given let x: Int = 0  
+      }
+      trait P { fun r() }
+      given A is P { fun r() {} }
+      extension T : P { fun h() {} }
+      """)
+    XCTAssert(names.contains("r"))
+    XCTAssert(names.contains("h"))
+    XCTAssert(names.contains("x"))
+    XCTAssertFalse(names.contains(where: { $0.hasPrefix("$") }))
+  }
+
+  func testSubstitutesTypeArgumentsIntoMemberTypes() async throws {
+    // Listing the members of a generic type applied to concrete arguments must substitute those
+    // arguments into the reported member types: on `A<B>`, the member `f(x: T)` has type `f(x: B)`.
+    var p = Program()
+    let (m, f) = await typeChecked(
+      &p,
+      """
+      struct A<T> {
+        public memberwise init
+        public fun f(x: T) {}
+      }
+      struct B { public memberwise init }
+      let v = A<B>()
+      """)
+
+    let v = try XCTUnwrap(p.select(.name(.init(identifier: "v"))).first)
+    let receiver = try XCTUnwrap(p.type(maybeAssignedTo: v))
+    let member = try XCTUnwrap(
+      p.members(of: receiver, in: m, visibleFrom: .init(file: f), static: false)
+        .first(where: { p.name(of: $0.declaration)?.identifier == "f" }))
+
+    XCTAssertEqual(p.show(member.type), "[let A<B>](let B) let -> Void")
+  }
+
+  // MARK: - Helpers
+
+  /// Returns the identifiers of the members `Program.members` reports for the struct named
+  /// `typeName` declared in `source`, selecting instance members.
+  private func instanceMembers(
+    ofStruct typeName: String, in source: SourceFile,
+    file: StaticString = #filePath, line: UInt = #line
+  ) async throws -> Set<String> {
+    try await memberNames(ofStruct: typeName, in: source, static: false, file: file, line: line)
+  }
+
+  /// Returns the identifiers of the members `Program.members` reports for the struct named `name`
+  /// declared in `source`, selecting static members.
+  private func staticMembers(
+    ofStruct name: String, in source: SourceFile,
+    file: StaticString = #filePath, line: UInt = #line
+  ) async throws -> Set<String> {
+    try await memberNames(ofStruct: name, in: source, static: true, file: file, line: line)
+  }
+
+  /// Type-checks `source` as a single-file module and returns the identifiers of the members
+  /// reported for the struct named `typeName`, selecting static members iff `isStatic`.
+  private func memberNames(
+    ofStruct typeName: String, in source: SourceFile, static isStatic: Bool,
+    file: StaticString, line: UInt
+  ) async throws -> Set<String> {
+    var p = Program()
+    let (m, f) = await typeChecked(&p, source)
+
+    let d = try XCTUnwrap(
+      p.select(.and(.tag(StructDeclaration.self), .name(.init(identifier: typeName)))).first,
+      "no struct named '\(typeName)'", file: file, line: line)
+    // The type assigned to a struct declaration is its metatype; `members` normalizes that to the
+    // instance type and selects static or instance members per the flag.
+    let receiver = p.type(assignedTo: d)
+    return Set(
+      p.members(of: receiver, in: m, visibleFrom: .init(file: f), static: isStatic)
+        .compactMap({ p.name(of: $0.declaration)?.identifier }))
+  }
+
+  /// Type-checks `source` as a single-file `Main` module in `p`, returning its module and file.
+  private func typeChecked(
+    _ p: inout Program, _ source: SourceFile
+  ) async -> (module: Module.ID, file: SourceFile.ID) {
+    let m = p.demandModule(.init("Main"))
+    let (_, f) = p[m].addSource(source)
+    await p.assignScopes(m)
+    p.assignTypes(m, loggingInferenceWhere: nil)
+    return (m, f)
+  }
+
+}

--- a/Tests/FrontEndTests/ProgramTests.swift
+++ b/Tests/FrontEndTests/ProgramTests.swift
@@ -107,9 +107,7 @@ final class ProgramTests: XCTestCase {
   }
 
   func testQueryGivenFromCheckedProgram() async throws {
-    var p = Program(forTesting: true)
-    let m = p.demandModule("Main")
-    let (_, f) = p[m].addSource(
+    var (p, m, s) = try await Program.typeCheckedForTesting(
       """
       trait P {}
       struct A { given w1: B is P {} }
@@ -117,11 +115,8 @@ final class ProgramTests: XCTestCase {
       given w2: A is P {}
       """)
 
-    await p.assignScopes(m)
-    p.assignTypes(m, loggingInferenceWhere: nil)
-
     // Query givens visible from the top-level scope of the file.
-    let givens = p.givens(in: m, visibleFrom: .init(file: f))
+    let givens = p.givens(in: m, visibleFrom: .init(file: s))
 
     // The visible given should be the top-level `w2`.
     if case .user(let g) = givens.uniqueElement {
@@ -201,12 +196,8 @@ final class ProgramTests: XCTestCase {
   }
 
   func testDeclarationMaybeReferredToByNil() async throws {
-    var p = Program(forTesting: true)
-    let m = p.demandModule("Main")
-    _ = p[m].addSource("let x = nonexistent.y ; let z = x")
-
-    await p.assignScopes(m)
-    p.assignTypes(m, loggingInferenceWhere: { _, _ in false })
+    let (p, _, _) = try await Program.typeCheckedForTesting(
+      "let x = nonexistent.y ; let z = x", assertingNoDiagnostics: false)
 
     func isVariable(referringTo name: String) -> (AnySyntaxIdentity) -> Bool {
       { (n: AnySyntaxIdentity) -> Bool in
@@ -236,16 +227,78 @@ final class ProgramTests: XCTestCase {
   }
 
   func testTypeMaybeAssignedNil() async throws {
-    var p = Program(forTesting: true)
-    let m = p.demandModule("Main")
-    _ = p[m].addSource("let (ill, typed) = ((), (), ())")
+    let (p, _, _) = try await Program.typeCheckedForTesting(
+      "let (ill, typed) = ((), (), ())",
+      assertingNoDiagnostics: false)
 
-    await p.assignScopes(m)
-    p.assignTypes(m, loggingInferenceWhere: { _, _ in false })
-    
     // `ill` should not have a type; it's not assigned.
     let e = try XCTUnwrap(p.select(.name("ill")).first)
     XCTAssertNil(p.type(maybeAssignedTo: e))
   }
 
+  func testTypeOfSelfIsTheEnclosingTypeWithinAStructScope() async throws {
+    // "Self" inside a struct's body denotes an instance of that struct.
+    var (p, _, _) = try await Program.typeCheckedForTesting(
+      """
+      struct A {
+        public memberwise init
+      }
+      """)
+
+    let d = try XCTUnwrap(
+      p.select(.and(
+        .tag(StructDeclaration.self),
+        .name(.init(identifier: "A")))).first, "no struct named 'A'")
+
+    // The type of `Self` should be spelled as the underlying type.
+    let t = try XCTUnwrap(p.typeOfSelf(in: .init(uncheckedFrom: d.erased)))
+    XCTAssertEqual(p.show(t), "A")
+  }
+
+  func testTypeOfSelfIsNilAtFileScope() async throws {
+    // "Self" is not legal at the top level of a file, where no type encloses the use.
+    var (p, _, s ) = try await Program.typeCheckedForTesting(
+      """
+      struct A {
+        public memberwise init
+      }
+      """)
+
+    XCTAssertNil(p.typeOfSelf(in: .init(file: s)))
+  }
+
+}
+
+extension Program {
+
+  /// Creates a program from a single source file `s`, returning the program, the fixture's module 
+  /// and source file identity.
+  ///
+  /// Throws if `assertNoDiagnostics` is true and the program contains an error.
+  static func typeCheckedForTesting(
+    _ s: SourceFile, assertingNoDiagnostics: Bool = true
+  ) async throws -> (Program, Module.ID, SourceFile.ID) {
+    var p = Program(forTesting: true)
+    let m = p.demandModule("Main")
+    let s = p[m].addSource(s).identity
+
+    await p.assignScopes(m)
+    p.assignTypes(m, loggingInferenceWhere: { _, _ in false })
+
+    if assertingNoDiagnostics && p.containsError {
+      throw CompilationError(DiagnosticSet(p.diagnostics))
+    }
+    return (p, m, s)
+  }
+
+}
+
+/// An error that occurred during compilation.
+struct CompilationError: Error {
+  let diagnostics: DiagnosticSet
+
+  /// The diagnostics of the error.
+  init(_ diagnostics: DiagnosticSet) {
+    self.diagnostics = diagnostics
+  }
 }


### PR DESCRIPTION
I added support for listing type members visible from a given scope. This works similarly as name resolution except we don't filter the results but collect all of them.

There was a funky member showing in the member list when local `given`s were in scope for a type, `$e` and `$f`. These are synthesized during parsing. I extended the `VariableDeclaration` to save whether the variable has a synthesized name or not. Then I filter declarations during member enumeration based on this.

I believe this enumeration can be quite expensive as we add more declarations, so in the future we should find a more gradual approach where we first list native members, then stream results e.g. level by level asynchronously. Maybe we can also make some tree-shaped cache where assembling a final name list may be cheaper than doing it from scratch.