### PR TITLE
Fix yield coherence checking BFS recursion criteria

### DIFF
--- a/Sources/FrontEnd/IR/Transforms/IRFunction+YieldCoherence.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+YieldCoherence.swift
@@ -75,7 +75,7 @@ extension IRFunction {
       }
 
       // Collect the next blocks to visit.
-      for s in successors(of: b) where !visited.contains(b) {
+      for s in successors(of: b) where !visited.contains(s) {
         slide[s] = y
         work.append(s)
       }

--- a/Tests/CompilerTests/negative/illegal-nested-yield.diagnostics.expected
+++ b/Tests/CompilerTests/negative/illegal-nested-yield.diagnostics.expected
@@ -1,0 +1,6 @@
+negative/illegal-nested-yield.hylo:8.7: error: subscript cannot project more than once
+      yield true
+      ^
+negative/illegal-nested-yield.hylo:4.3: note: value already projected here
+  yield false
+  ^

--- a/Tests/CompilerTests/negative/illegal-nested-yield.hylo
+++ b/Tests/CompilerTests/negative/illegal-nested-yield.hylo
@@ -1,0 +1,11 @@
+//! stage:lowering
+
+subscript f(x: Bool, y: Bool) -> Bool {
+  yield false
+  if x {
+    if y {
+      // Second yield is nested in two basic blocks after the first yield.
+      yield true
+    }
+  }
+}


### PR DESCRIPTION
The recursive step checked the wrong variable for visited, so some problems, like the one in the attached test case were never diagnosed.