### PR TITLE
Give a predefined identity to 'Hylo.Never'

### DIFF
--- a/Sources/FrontEnd/IR/Mangling/ManglingContext.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingContext.swift
@@ -112,7 +112,7 @@ internal struct ManglingContext {
   }
 
   /// Records `s` in the symbol lookup table if it is not reserved or already recorded.
-  internal mutating func record(symbol s: MangledSymbol, in program: Program) {
+  internal mutating func record(symbol s: MangledSymbol) {
     if symbolPosition.keys.contains(s) || reserved.keys.contains(s) { return }
     symbolPosition[s] = symbolPosition.count
   }
@@ -126,8 +126,8 @@ internal struct ManglingContext {
 
   /// Writes a lookup reference to `s` iff `s` is reserved or has already been inserted in the
   /// symbol lookup table.
-  internal mutating func addIf(reservedOrRecorded s: MangledSymbol, in program: Program) -> Bool {
-    addIf(reserved: s) || addIf(recorded: s, in: program)
+  internal mutating func addIf(reservedOrRecorded s: MangledSymbol) -> Bool {
+    addIf(reserved: s) || addIf(recorded: s)
   }
 
   /// Writes a lookup reference to `s` iff `s` is a reserved mangling symbol.
@@ -146,7 +146,7 @@ internal struct ManglingContext {
   }
 
   /// Writes a lookup reference to `s` iff `s` is in the lookup table.
-  private mutating func addIf(recorded s: MangledSymbol, in program: Program) -> Bool {
+  private mutating func addIf(recorded s: MangledSymbol) -> Bool {
     if let p = symbolPosition[s] {
       if case .type = s {
         add(operator: .lookupType)

--- a/Sources/FrontEnd/IR/Mangling/ManglingContext.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingContext.swift
@@ -30,8 +30,7 @@ internal struct ManglingContext {
 
   /// Initializes the table of reserved symbols.
   private mutating func initializeReservedSymbols(program: Program) {
-    var types = program.types
-    reserved[.type(AnyTypeIdentity(types.never()))] = .never
+    reserved[.type(.never)] = .never
     reserved[.type(.void)] = .void
     if program.containsStandardLibrary {
       let stdlib = program.modules.values.first(where: { (m) in m.isStandardLibrary })!

--- a/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
@@ -76,7 +76,7 @@ internal struct ManglingEncoding: Sendable {
 
   /// Writes the mangled representation of `d` to `output`.
   private mutating func append(decl d: DeclarationIdentity, to output: inout ManglingContext) {
-    if output.addIf(reservedOrRecorded: .node(.init(d)), in: program) { return }
+    if output.addIf(reservedOrRecorded: .node(.init(d))) { return }
 
     // First add the qualification of the declaration.
     appendQualification(of: d, to: &output)
@@ -106,7 +106,7 @@ internal struct ManglingEncoding: Sendable {
       program.unexpected(d)
     }
 
-    output.record(symbol: .node(AnySyntaxIdentity(d)), in: program)
+    output.record(symbol: .node(AnySyntaxIdentity(d)))
   }
 
   /// Demangles a (possibly qualified) entity from `source`.
@@ -216,10 +216,10 @@ internal struct ManglingEncoding: Sendable {
     var earlyExit = false
     let p = program.parent(containing: n)
     for s in program.scopes(from: p) {
-      if s.node != nil, output.addIf(reservedOrRecorded: .node(s.node!), in: program) {
+      if s.node != nil, output.addIf(reservedOrRecorded: .node(s.node!)) {
         earlyExit = true
         break
-      } else if output.addIf(reservedOrRecorded: s.asSymbol, in: program) {
+      } else if output.addIf(reservedOrRecorded: s.asSymbol) {
         earlyExit = true
         break
       } else if output.addIf(qualification: s) {
@@ -233,11 +233,11 @@ internal struct ManglingEncoding: Sendable {
     // Write the mangled representation of the qualification's suffix.
     if !earlyExit {
       append(module: p.module, to: &output)
-      output.record(symbol: .module(p.module), in: program)
+      output.record(symbol: .module(p.module))
     }
     for s in qs.reversed() {
       append(scope: s, to: &output)
-      output.record(symbol: s.asSymbol, in: program)
+      output.record(symbol: s.asSymbol)
     }
   }
 
@@ -305,7 +305,7 @@ internal struct ManglingEncoding: Sendable {
 
   /// Writes the mangled representation of `m` to `output`.
   private mutating func append(module m: Module.ID, to output: inout ManglingContext) {
-    if output.addIf(reservedOrRecorded: .module(m), in: program) { return }
+    if output.addIf(reservedOrRecorded: .module(m)) { return }
     output.add(operator: .module)
     output.add(string: program[m].name.description)
   }
@@ -317,7 +317,7 @@ internal struct ManglingEncoding: Sendable {
 
   /// Writes the mangled representation of `s` to `output`.
   private mutating func append(scope s: ScopeIdentity, to output: inout ManglingContext) {
-    if output.addIf(reservedOrRecorded: s.asSymbol, in: program) { return }
+    if output.addIf(reservedOrRecorded: s.asSymbol) { return }
 
     let q = output.record(qualification: s)
 
@@ -359,7 +359,7 @@ internal struct ManglingEncoding: Sendable {
       append(translationUnit: s.file, to: &output)
     }
     _ = output.record(qualification: q)
-    output.record(symbol: s.asSymbol, in: program)
+    output.record(symbol: s.asSymbol)
   }
 
   /// Writes the mangled representation of `d` to `output`.
@@ -671,7 +671,7 @@ internal struct ManglingEncoding: Sendable {
 
   /// Writes the mangled representation of `s` to `output`.
   private mutating func append(type s: AnyTypeIdentity, to output: inout ManglingContext) {
-    if output.addIf(reservedOrRecorded: .type(s), in: program) { return }
+    if output.addIf(reservedOrRecorded: .type(s)) { return }
 
     let a = program.types[s]
     switch a {
@@ -720,7 +720,7 @@ internal struct ManglingEncoding: Sendable {
     default:
       unreachable()
     }
-    output.record(symbol: .type(s), in: program)
+    output.record(symbol: .type(s))
   }
 
   /// Demangles a type from `source`.

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
@@ -3,9 +3,9 @@ import Utilities
 extension IRFunction {
 
   /// Removes the code after calls returning `Never`.
-  internal mutating func removeCodeAfterCallsReturning(never: AnyTypeIdentity) {
+  internal mutating func removeCodeAfterNeverReturningCalls() {
     for b in blocks.addresses {
-      if let i = instructions(in: b).first(where: { (i) in returns(never: never, i) }) {
+      if let i = instructions(in: b).first(where: { (i) in neverReturns(i) }) {
         removeAll(after: i)
 
         let a = at(i).anchor
@@ -81,12 +81,12 @@ extension IRFunction {
   /// wrapped into a type application so that the it matches the expected type. This method can
   /// therefore identify the instruction denoting the lowered form of a never-returning expression
   /// right before any type application.
-  private func returns(never: AnyTypeIdentity, _ i: AnyInstructionIdentity) -> Bool {
+  private func neverReturns(_ i: AnyInstructionIdentity) -> Bool {
     // Note that it's fine to compare the return type of applications with `Never` because the
     // expression should still have the form `<T> T` at this point.
     switch at(i) {
     case let s as IRApply:
-      return result(of: s.result)?.type == never
+      return result(of: s.result)?.type == .never
     default:
       return false
     }

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -126,7 +126,7 @@ public struct Program: Sendable {
       for i in work.indices {
         work[i].function.foldRedundantInstructions()
         work[i].function.simplifyControlFlow()
-        work[i].function.removeCodeAfterCallsReturning(never: .never)
+        work[i].function.removeCodeAfterNeverReturningCalls()
         work[i].function.removeUnreachableBlocks()
         work[i].function.removedUnusedDefinitions()
         // reifyBundles

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -122,13 +122,11 @@ public struct Program: Sendable {
         return ir.functions.values.endIndex
       }
 
-      let never = typer.program.types.never()
-
       // Mandatory intra-procedural passes.
       for i in work.indices {
         work[i].function.foldRedundantInstructions()
         work[i].function.simplifyControlFlow()
-        work[i].function.removeCodeAfterCallsReturning(never: never.erased)
+        work[i].function.removeCodeAfterCallsReturning(never: .never)
         work[i].function.removeUnreachableBlocks()
         work[i].function.removedUnusedDefinitions()
         // reifyBundles

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -399,8 +399,7 @@ extension BuiltinFunction {
 
     switch self {
     case .trap:
-      let t0 = s.never().erased
-      return s.demand(Arrow(inputs: [], output: t0))
+      return s.demand(Arrow(inputs: [], output: .never))
 
     case .addressOf:
       let t0 = s.fresh().erased

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4099,8 +4099,7 @@ public struct Typer {
       return [.init(reference: .builtin(.alias), type: u.erased)]
 
     case "Never":
-      let t = program.types.never()
-      let u = demand(Metatype(inhabitant: t.erased))
+      let u = demand(Metatype(inhabitant: .never))
       return [.init(reference: .builtin(.alias), type: u.erased)]
 
     case "Void":

--- a/Sources/FrontEnd/Types/TypeIdentity.swift
+++ b/Sources/FrontEnd/Types/TypeIdentity.swift
@@ -114,6 +114,9 @@ public struct AnyTypeIdentity: Hashable, Sendable {
   /// The identity of `Hylo.Void`, which is an empty tuple.
   public static let void = AnyTypeIdentity(predefined: 1, properties: [])
 
+  /// The identity of `Hylo.Never`, which is equivalent to `<T> T`.
+  public static let never = AnyTypeIdentity(predefined: 2, properties: [])
+
 }
 
 extension AnyTypeIdentity: TypeIdentity {

--- a/Sources/FrontEnd/Types/TypeStore.swift
+++ b/Sources/FrontEnd/Types/TypeStore.swift
@@ -24,10 +24,19 @@ public struct TypeStore: Sendable {
   /// The identifier of the next fresh variable.
   private var nextFreshIdentifier: Int
 
+  /// The identity of a type equal to `Hylo.Never`.
+  private var never: AnyTypeIdentity
+
   /// Creates an empty instance.
   public init() {
     self.types = []
     self.nextFreshIdentifier = 0
+    self.never = .init(uncheckedFrom: .error)
+
+    // Create `Hylo.Never`.
+    let p = demand(GenericParameter.nth(0, .proper))
+    let u = insert(UniversalType(parameters: [p], head: p.erased))
+    self.never = .init(uncheckedFrom: u)
   }
 
   /// Returns a number less than the number of types created with this store.
@@ -44,13 +53,6 @@ public struct TypeStore: Sendable {
   public mutating func fresh() -> TypeVariable.ID {
     defer { nextFreshIdentifier += 1 }
     return .init(uncheckedFrom: AnyTypeIdentity(variable: nextFreshIdentifier))
-  }
-
-  /// Returns the identity of `Hylo.Never`, which is equivalent to `<T> T`.
-  public mutating func never() -> UniversalType.ID {
-    let p = demand(GenericParameter.nth(0, .proper))
-    let t = demand(UniversalType(parameters: [p], head: p.erased))
-    return t
   }
 
   /// Returns the body of `f` with each parameter substituted with its corresponding argument.
@@ -81,13 +83,20 @@ public struct TypeStore: Sendable {
       return AnyTypeIdentity.error
     case let u as Tuple where u == .empty:
       return AnyTypeIdentity.void
+    case let u as UniversalType where (self[never] as! UniversalType) == u:
+      return AnyTypeIdentity.never
     case let u as TypeVariable:
       return AnyTypeIdentity(variable: u.identifier)
     default:
-      let i = types.insert(.init(t)).position
-      assert(i < (1 << 55), "too many types")  // 8 bits are reserved for the properties.
-      return .init(offset: i, properties: t.properties)
+      return insert(t)
     }
+  }
+
+  /// Inserts `t` in `self` and returns its identity, assuming `t` is not present in `self`.
+  private mutating func insert(_ t: any TypeTree) -> AnyTypeIdentity {
+    let i = types.insert(.init(t)).position
+    assert(i < (1 << 55), "too many types")  // 8 bits are reserved for the properties.
+    return .init(offset: i, properties: t.properties)
   }
 
   /// Returns the unique type corresponding to the given signature, creating it if necessary.
@@ -677,6 +686,8 @@ public struct TypeStore: Sendable {
         yield ErrorType()
       case AnyTypeIdentity.void.offset:
         yield Tuple.empty
+      case AnyTypeIdentity.never.offset:
+        yield self[never]
       case let i where n.isVariable:
         yield TypeVariable(identifier: Int(UInt64(i) & ((1 << 54) - 1)))
       case let i:

--- a/Sources/FrontEnd/Types/TypeStore.swift
+++ b/Sources/FrontEnd/Types/TypeStore.swift
@@ -24,19 +24,15 @@ public struct TypeStore: Sendable {
   /// The identifier of the next fresh variable.
   private var nextFreshIdentifier: Int
 
-  /// The identity of a type equal to `Hylo.Never`.
-  private var never: AnyTypeIdentity
+  /// The identity of a proper generic type parameter.
+  private var alpha: GenericParameter.ID
 
   /// Creates an empty instance.
   public init() {
     self.types = []
     self.nextFreshIdentifier = 0
-    self.never = .init(uncheckedFrom: .error)
-
-    // Create `Hylo.Never`.
-    let p = demand(GenericParameter.nth(0, .proper))
-    let u = insert(UniversalType(parameters: [p], head: p.erased))
-    self.never = .init(uncheckedFrom: u)
+    self.alpha = .init(uncheckedFrom: .error)
+    self.alpha = demand(GenericParameter.nth(0, .proper))
   }
 
   /// Returns a number less than the number of types created with this store.
@@ -83,7 +79,7 @@ public struct TypeStore: Sendable {
       return AnyTypeIdentity.error
     case let u as Tuple where u == .empty:
       return AnyTypeIdentity.void
-    case let u as UniversalType where (self[never] as! UniversalType) == u:
+    case let u as UniversalType where isNever(u):
       return AnyTypeIdentity.never
     case let u as TypeVariable:
       return AnyTypeIdentity(variable: u.identifier)
@@ -163,6 +159,11 @@ public struct TypeStore: Sendable {
     } else {
       return false
     }
+  }
+
+  /// Returns `true` iff `u` is a representation of `Hylo.Never`.
+  public func isNever(_ u: UniversalType) -> Bool {
+    (u.head == alpha) && (u.parameters.uniqueElement == alpha)
   }
 
   /// Returns `true` iff `n` is a universal type or an implication.
@@ -687,7 +688,7 @@ public struct TypeStore: Sendable {
       case AnyTypeIdentity.void.offset:
         yield Tuple.empty
       case AnyTypeIdentity.never.offset:
-        yield self[never]
+        yield UniversalType(parameters: [alpha], head: alpha.erased)
       case let i where n.isVariable:
         yield TypeVariable(identifier: Int(UInt64(i) & ((1 << 54) - 1)))
       case let i:

--- a/Tests/FrontEndTests/CompileTime/Types/TypeStoreTests.swift
+++ b/Tests/FrontEndTests/CompileTime/Types/TypeStoreTests.swift
@@ -20,19 +20,21 @@ final class TypeStoreTests: XCTestCase {
     XCTAssertEqual(store[i], t)
   }
 
+  func testDemandNever() {
+    var store = TypeStore()
+    let p = store.demand(GenericParameter.nth(0, .proper))
+    let t = UniversalType(parameters: [p], head: p.erased)
+    let i = store.demand(t)
+    XCTAssertEqual(i.erased, AnyTypeIdentity.never)
+    XCTAssertEqual(store[i], t)
+  }
+
   func testDemandVariable() {
     var store = TypeStore()
     let t = TypeVariable(identifier: 123)
     let i = store.demand(t)
     XCTAssertEqual(i.erased, AnyTypeIdentity(variable: 123))
     XCTAssertEqual(store[i], t)
-  }
-
-  func testDemandNever() {
-    var store = TypeStore()
-    let t = store.never()
-    let u = store.never()
-    XCTAssertEqual(t, u)
   }
 
   func testDemand() {

--- a/Tests/FrontEndTests/Mangling/ManglingTests.swift
+++ b/Tests/FrontEndTests/Mangling/ManglingTests.swift
@@ -371,8 +371,7 @@ final class ManglingTests: XCTestCase {
 
   /// Tests the mangling and demangling of reserved types in `program`.
   private func testReservedTypesMangling(program: inout Program) {
-    let never = AnyTypeIdentity(program.types.never())
-    assertManglingOf(type: never, in: program, is: "Never")
+    assertManglingOf(type: .never, in: program, is: "Never")
     assertManglingOf(type: .void, in: program, is: "Void")
   }
 


### PR DESCRIPTION
This PR gives `Hylo.Never` a predefined identity so that one longer needs to mutate a type store to get an instance.