### PR TITLE
Fix the subfield paths of stored properties

### DIFF
--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1375,9 +1375,7 @@ public struct Program: Sendable {
   /// Calls `action` for each stored property declaration in `d`.
   ///
   /// `action` accepts a variable declaration and an index path identifying its abstract position
-  /// in a record value having the type declared by `d`. That position is the offset of the
-  /// property in the flattened list of all the stored properties of `d`, consistent with the
-  /// fields of the record type of instances of `d`.
+  /// in a record value having the type declared by `d`.
   public func forEachStoredProperty(
     of d: StructDeclaration.ID,
     do action: (VariableDeclaration.ID, IndexPath) -> Void

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1375,14 +1375,20 @@ public struct Program: Sendable {
   /// Calls `action` for each stored property declaration in `d`.
   ///
   /// `action` accepts a variable declaration and an index path identifying its abstract position
-  /// in a record value having the type declared by `d`.
+  /// in a record value having the type declared by `d`. That position is the offset of the
+  /// property in the flattened list of all the stored properties of `d`, consistent with the
+  /// fields of the record type of instances of `d`.
   public func forEachStoredProperty(
     of d: StructDeclaration.ID,
     do action: (VariableDeclaration.ID, IndexPath) -> Void
   ) {
+    var i = 0
     for m in self[d].members {
       if let b = cast(m, to: BindingDeclaration.self) {
-        forEachVariable(introducedBy: self[self[b].pattern].pattern, do: action)
+        forEachVariable(introducedBy: self[self[b].pattern].pattern) { (v, _) in
+          action(v, [i])
+          i += 1
+        }
       }
     }
   }

--- a/Tests/CompilerTests/positive/memberwise-init-3.hylo
+++ b/Tests/CompilerTests/positive/memberwise-init-3.hylo
@@ -1,0 +1,11 @@
+//! stage:llvm
+
+struct Pair is Deinitializable {
+  let a: Int
+  let b: Int
+  memberwise init
+}
+
+public fun main() {
+  _ = Pair(a: 1, b: 2)
+}

--- a/Tests/CompilerTests/positive/memberwise-init-3.raw-ir.expected
+++ b/Tests/CompilerTests/positive/memberwise-init-3.raw-ir.expected
@@ -1,0 +1,21 @@
+fun main(set %p0: Void) {
+%b0:
+  %r0 = alloca Pair, #preferred
+  %r1 = subfield %r0 at 0 as Int
+  %r2 = subfield %r1 at 0 as word
+  %r3 = access [set] %r2
+  %r4 = store word 1 to %r3
+  %r5 = end %r3
+  %r6 = subfield %r0 at 1 as Int
+  %r7 = subfield %r6 at 0 as word
+  %r8 = access [set] %r7
+  %r9 = store word 2 to %r8
+  %r10 = end %r8
+  %r11 = access [sink] %r0
+  %r12 = assume_state %r11 uninitialized
+  %r13 = end %r11
+  %r14 = access [set] %p0
+  %r15 = assume_state %r14 initialized
+  %r16 = end %r14
+  %r17 = return
+}


### PR DESCRIPTION
`forEachStoredProperty` passed its callback the position of each variable within its own binding pattern rather than its offset among all of the struct's individual variable declarations.