### PR TITLE
Fix missing IRProperty InstructionRelevance

### DIFF
--- a/Sources/BackEnd/SubscriptDecomposition.swift
+++ b/Sources/BackEnd/SubscriptDecomposition.swift
@@ -551,7 +551,8 @@ extension IRFunction {
     switch tag(of: i) {
     case IRAlloca.self, IRProject.self:
       return .captured
-    case IRAccess.self, IRCase.self, IRGlobalAccess.self, IRPlaceCast.self, IRSubfield.self:
+    case IRAccess.self, IRCase.self, IRGlobalAccess.self, IRPlaceCast.self, IRSubfield.self,
+      IRProperty.self:
       return .redefined
     default:
       return .none


### PR DESCRIPTION
`IRProperty` was missing its `InstructionRelevance` in `relevanceInSlideOrPlateau`. A lot more instructions are also missing and using the `none` relevance by default. Should we change this to an exhaustive switch and define the instruction relevance for all instructions?