### PR TITLE
Deinitialize the receiver member-wise in user-defined deinits

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2551,6 +2551,13 @@ internal struct IREmitter {
       return true
 
     case .nontrivial(let w):
+      // If `s` is the receiver of the very deinit implementing `t`'s conformance, applying the
+      // witness would call the current function recursively; the receiver's parts are destroyed
+      // individually instead.
+      if case .parameter = s, currentFunctionIsDeinit(referredToBy: w) {
+        return _emitDeinitialize(members: s, instanceOf: t)
+      }
+
       let deinitializable = _emit(witness: w)
       let member = program.standardLibraryDeclaration(.deinitializableDeinit)
       let t0 = program.types.demand(
@@ -2570,6 +2577,40 @@ internal struct IREmitter {
 
       return true
     }
+  }
+
+  /// Returns `true` iff the function being lowered is the implementation of the `deinit`
+  /// requirement in the conformance referred to by `w`.
+  private mutating func currentFunctionIsDeinit(referredToBy w: WitnessExpression) -> Bool {
+    guard
+      case .lowered(let d) = currentFunction.name,
+      let c = w.declaration.flatMap({ (x) in program.cast(x, to: ConformanceDeclaration.self) })
+    else { return false }
+    let r = program.standardLibraryDeclaration(.deinitializableDeinit)
+    return program.implementations(definedBy: c).member(implementing: r)?.target == d
+  }
+
+  /// Implements `_emitDeinitialize(_:)` by deinitializing each stored part of `s` individually.
+  private mutating func _emitDeinitialize(
+    members s: IRValue, instanceOf t: AnyTypeIdentity
+  ) -> Bool {
+    guard let ms = program.withTyper(typing: module, { (tp) in tp.fields(of: t) }) else {
+      _ = _apply_builtin(.trap, to: [])
+      return false
+    }
+
+    // Is the record empty?
+    if ms.isEmpty {
+      _assume_state(s, initialized: false)
+      return true
+    }
+
+    // Otherwise, deinitialize each stored part individually.
+    for (i, m) in ms.enumerated() {
+      let s = _subfield(s, at: [i])
+      if !_emitDeinitialize(s, instanceOf: m) { return false }
+    }
+    return true
   }
 
   /// Implements `_emitDeinitialize(_:)` for tuples..

--- a/Tests/CompilerTests/positive/deinit-empty.hylo
+++ b/Tests/CompilerTests/positive/deinit-empty.hylo
@@ -1,0 +1,16 @@
+// The receiver is still fully initialized when this deinit returns, so deinitialization is
+// inserted at its exit. That deinitialization must not go through the Deinitializable witness,
+// which would call the deinit recursively.
+
+struct Wrapper is Deinitializable {
+  var value: Int
+
+  memberwise init
+
+  fun deinit() sink {}
+}
+
+public fun main() -> Int32 {
+  let w = Wrapper(value: 1)
+  return 0
+}

--- a/Tests/CompilerTests/positive/deinit-nested.hylo
+++ b/Tests/CompilerTests/positive/deinit-nested.hylo
@@ -1,0 +1,23 @@
+// Deinitializing the receiver of `Outer.deinit` member-wise must still deinitialize `i` through
+// `Inner`'s witness, running `Inner.deinit`.
+
+struct Inner is Deinitializable {
+  var n: Int
+
+  memberwise init
+
+  fun deinit() sink {}
+}
+
+struct Outer is Deinitializable {
+  var i: Inner
+
+  memberwise init
+
+  fun deinit() sink {}
+}
+
+public fun main() -> Int32 {
+  let o = Outer(i: Inner(n: 1))
+  return 0
+}

--- a/Tests/CompilerTests/positive/deinit-sink-parameter.hylo
+++ b/Tests/CompilerTests/positive/deinit-sink-parameter.hylo
@@ -1,0 +1,17 @@
+// The value dies as an unused sink parameter, so its deinitialization is inserted at the return
+// of an ordinary function rather than at the end of `main`.
+
+struct Wrapper is Deinitializable {
+  var value: Int
+
+  memberwise init
+
+  fun deinit() sink {}
+}
+
+fun take(_ w: sink Wrapper) {}
+
+public fun main() -> Int32 {
+  take(w: Wrapper(value: 1))
+  return 0
+}


### PR DESCRIPTION
Each of the added tests compiles to a binary that overflows the stack:

- `deinit-empty.hylo`: a local of a type with an empty user-defined `deinit` dies at the end of `main`.
- `deinit-sink-parameter.hylo`: the value dies as an unused `sink` parameter of an ordinary function instead.
- `deinit-nested.hylo`: a struct with a user-defined `deinit` is stored inside another one.

What they have in common: a value of a type with a user-defined `deinit` whose receiver is still fully initialized when that `deinit` returns. Lifetime normalization inserts deinitialization of the residual receiver before the `return`, and `_emitDeinitialize(whole:instanceOf:)` lowers it through the type's `Deinitializable` witness. The member implementing the requirement is the function being compiled, so the deinit calls itself recursively through the conformance's interface function:

```
fun Wrapper.deinit(sink %p0: Wrapper, set %p1: Void) {
%b0:
  %r0 = access [set] %p1
  %r1 = assume_state %r0 initialized
  %r2 = end %r0
  %r4 = project Wrapper.$<ConformanceDeclaration at deinit-empty:5.19>[]
  %r5 = alloca Void, #preferred
  %r6 = access [sink] %p0
  %r7 = access [set] %r5
  %r8 = property "deinit" of %r4
  %r9 = access [let] %r8
  %r10 = apply %r9(%r6) => %r7
  ...
}
```

With this change, `_emitDeinitialize(whole:instanceOf:)` recognizes that the value is the receiver of the deinit implementing the resolved conformance and destroys its stored parts individually instead of applying the witness:

```
fun Wrapper.deinit(sink %p0: Wrapper, set %p1: Void) {
%b0:
  %r0 = access [set] %p1
  %r1 = assume_state %r0 initialized
  %r2 = end %r0
  %r4 = subfield %p0 at 0 as Int
  %r5 = access [sink] %r4
  %r6 = assume_state %r5 uninitialized
  %r7 = end %r5
  %r3 = return
}
```

Parts whose types have their own non-trivial witnesses still go through them: in `deinit-nested.hylo`, `Outer.deinit` applies `Inner`'s witness for its field, running `Inner.deinit`.

The reproducers keep a single value per scope so that lowering does not also run into the plateau prologue issue fixed separately in #255.
