### PR TITLE
Implement synthetic deinitializers for structs

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,7 +3,11 @@
 
 [files]
 # Swifty-LLVM is a separate project. Its spelling is managed upstream.
-extend-exclude = ["Swifty-LLVM"]
+# IR source files may contain mangled and generated symbols.
+extend-exclude = [
+  "Swifty-LLVM",
+  "*-ir.expected",
+]
 
 [default.extend-identifiers]
 # `WriteableArchive` is part of the external `Archivist` dependency's API

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -476,19 +476,26 @@ extension Program {
     _ i: IRSubfield.ID, in ctx: inout FunctionGenerationContext
   ) -> AnyInstructionIdentity? {
     let s = ctx.ir.at(i)
-    let t = ctx.ir.result(of: s.base)!.type
 
     let i32 = ctx.module.llvm.i32
+    let base = ctx.ir.result(of: s.base)!.type
+    var current = base
     var indices = [i32.unsafe[].constant(0).v]
-    var u = t
     for p in s.path {
-      let m = metadata(of: u, in: &ctx.module)
+      // Get the logical index of the property in its concrete representation.
+      let m = metadata(of: current, in: &ctx.module)
+      let i = m.layout.propertyToField[p]
+
+      // Stop if the property has been erased. The resulting path will be that of its container.
+      if i < 0 { break }
+
+      // Otherwise, move to the next component.
       indices.append(i32.unsafe[].constant(m.layout.propertyToField[p]).v)
-      u = fields(of: u, visibleFrom: ctx.module.hylo)![p]
+      current = fields(of: current, visibleFrom: ctx.module.hylo)![p]
     }
 
     let b = ctx.value[s.base]!
-    let m = metadata(of: t, in: &ctx.module)
+    let m = metadata(of: base, in: &ctx.module)
     let x = ctx.module.llvm.insertGetElementPointerInBounds(
       of: b, typed: m.llvm, indices: indices, at: ctx.insertionPoint!)
 

--- a/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
+++ b/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
@@ -107,7 +107,7 @@ extension IREmitter {
   ///   - mono: The identity of an existentialized function.
   ///   - witnesses: witnesses for each type parameter in the original polymorphic function.
   ///   - parameters: The types of the term parameters of the polymorphic function.
-  ///   - f: The function containing`uer`.
+  ///   - f: The function containing `user`.
   private mutating func depolymorphize(
     polymorphicApplyUser user: AnyInstructionIdentity, with mono: IRFunction.ID,
     passing witnesses: [IRValue], to parameters: [AnyTypeIdentity], in f: inout IRFunction
@@ -129,7 +129,7 @@ extension IREmitter {
   /// `mono`, which is the existentialized form of `u`'s callee.
   ///
   /// This method is similar to `depolymorphize(polymorphicApplyUser:with:passing:to:in:)` only for
-  /// the case where `user` is a projection rather thanan application.
+  /// the case where `user` is a projection rather than an application.
   private mutating func depolymorphize(
     polymorphicProjectUser user: AnyInstructionIdentity, with mono: IRFunction.ID,
     passing witnesses: [IRValue], to parameters: [AnyTypeIdentity], in f: inout IRFunction

--- a/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
+++ b/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
@@ -178,7 +178,8 @@ extension IREmitter {
     }
 
     ps.append(contentsOf: poly.termParameters)
-    let mono = IRFunction(name: n, output: poly.output, typeParameters: [], termParameters: ps)
+    let mono = IRFunction(
+      name: n, anchor: poly.anchor, output: poly.output, typeParameters: [], termParameters: ps)
     return program[module].ir.addFunction(mono)
   }
 

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1396,9 +1396,12 @@ internal struct IREmitter {
       tp.accumulatedGenericParameters(visibleFrom: scopeOfDeclaration)
     }
 
+    let anchor = program.anchorForDiagnostics(about: d)
     let (terms, output) = prototype(functionOrConformance: d)
     return program[module].ir.addFunction(
-      IRFunction(name: name, output: output, typeParameters: types, termParameters: terms))
+      IRFunction(
+        name: name, anchor: anchor, output: output,
+        typeParameters: types, termParameters: terms))
   }
 
   /// Returns the identity of the function lowering the implementation of `requirement` for the
@@ -1415,9 +1418,12 @@ internal struct IREmitter {
     if let i = program[module].ir.functions.index(forKey: name) {
       return i
     } else {
-      let (ps, o) = prototype(functionOrConformance: requirement, applying: arguments)
+      let anchor = program.anchorForDiagnostics(about: .init(conformance))
+      let (terms, output) = prototype(functionOrConformance: requirement, applying: arguments)
       return program[module].ir.addFunction(
-        IRFunction(name: name, output: o, typeParameters: [], termParameters: ps))
+        IRFunction(
+          name: name, anchor: anchor, output: output,
+          typeParameters: [], termParameters: terms))
     }
   }
 
@@ -1447,9 +1453,10 @@ internal struct IREmitter {
     let o = program.types.dealiased(program.types[e].inhabitant)
     ps.append(.init(type: o, access: .set, declaration: nil))
 
+    let anchor = program.anchorForDiagnostics(about: .init(d))
     return program[module].ir.addFunction(
       IRFunction(
-        name: name, output: .indirect, typeParameters: ts, termParameters: ps))
+        name: name, anchor: anchor, output: .indirect, typeParameters: ts, termParameters: ps))
   }
 
   /// Returns the IR variable lowering the global binding `d`, declaring it if necessary.
@@ -1468,8 +1475,9 @@ internal struct IREmitter {
     // Declare the global's initializer.
     let t = program.types.dealiased(program.type(assignedTo: d))
     let o = IRParameter(type: t, access: .set, declaration: nil)
+    let a = program.anchorForDiagnostics(about: .init(d))
     let i = IRFunction(
-      name: .initializer(d), output: .indirect, typeParameters: [], termParameters: [o])
+      name: .initializer(d), anchor: a, output: .indirect, typeParameters: [], termParameters: [o])
     let f = program[module].ir.addFunction(i)
 
     // Declare the global itself.

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -75,16 +75,12 @@ internal struct IREmitter {
         switch me.program.tag(of: d) {
         case StructDeclaration.self:
           let s = me.program.castUnchecked(d, to: StructDeclaration.self)
-          if me.program.storedProperties(of: s).isEmpty {
-            me._assume_state(.parameter(1), initialized: false)
-          } else {
-            me.program.forEachStoredProperty(of: s) { (m, p) in
-              let x = me._subfield(.parameter(1), at: p)
-              let t = me.program.type(assignedTo: m, assuming: RemoteType.self)
-              let u = me.program.types.substitute(a, in: me.program.types[t].projectee)
-              let v = me.program.types.dealiased(u)
-              _ = me._emitDeinitialize(x, instanceOf: v)
-            }
+          me.program.forEachStoredProperty(of: s) { (m, p) in
+            let x = me._subfield(.parameter(1), at: p)
+            let t = me.program.type(assignedTo: m, assuming: RemoteType.self)
+            let u = me.program.types.substitute(a, in: me.program.types[t].projectee)
+            let v = me.program.types.dealiased(u)
+            _ = me._emitDeinitialize(x, instanceOf: v)
           }
 
         case EnumDeclaration.self:

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -34,6 +34,81 @@ internal struct IREmitter {
     }
   }
 
+  /// Generates the definitions of synthesized functions.
+  internal mutating func implementSynthesizedFunctions() {
+    // TODO: Remove once the standard library compiles.
+    if program[module].isStandardLibrary { return }
+
+    for f in program[module].ir.functions.values.indices {
+      guard case .synthesized(let d, let a) =  program[module].ir[f].name else { continue }
+
+      switch d {
+      case program.standardLibraryDeclaration(.deinitializableDeinit):
+        implementSynthesizedDeinitializer(f, for: a)
+      default:
+        continue // TODO
+      }
+    }
+  }
+
+  /// Generates the body of `f`, which is a synthetic implementation of `Deinitializable.deinit` in
+  /// some conformance declaration.
+  private mutating func implementSynthesizedDeinitializer(
+    _ f: IRFunction.ID, for a: TypeArguments
+  ) {
+    // Nothing to do if the function has already been defined.
+    if program[module].ir[f].isDefined { return }
+
+    // Otherwise, generate an implementation.
+    defining(f, at: program[module].ir[f].anchor) { (me) in
+      // The first parameter of `f` is a witness of `Deinitializable` and the second parameter is
+      // the instance to deinitialize.
+      let receiver = me.currentFunction.termParameters[1].type
+
+      // Is the receiver trivial to deinitialize?
+      if case .trivial = me.witnessOfDeinitializable(for: receiver) {
+        me._assume_state(.parameter(1), initialized: false)
+      }
+
+      // Is the receiver an instance of a struct or enum?
+      else if let d = me.program.declaration(of: receiver) {
+        switch me.program.tag(of: d) {
+        case StructDeclaration.self:
+          let s = me.program.castUnchecked(d, to: StructDeclaration.self)
+          if me.program.storedProperties(of: s).isEmpty {
+            me._assume_state(.parameter(1), initialized: false)
+          } else {
+            me.program.forEachStoredProperty(of: s) { (m, p) in
+              let x = me._subfield(.parameter(1), at: p)
+              let t = me.program.type(assignedTo: m, assuming: RemoteType.self)
+              let u = me.program.types.substitute(a, in: me.program.types[t].projectee)
+              let v = me.program.types.dealiased(u)
+              _ = me._emitDeinitialize(x, instanceOf: v)
+            }
+          }
+
+        case EnumDeclaration.self:
+          break // TODO
+
+        default:
+          break // TODO
+        }
+      }
+
+      // Give up if it's none of the above.
+      else {
+        unimplemented(
+          """
+          synthetic implementation of 'Deinitializable.deinit(:)' for \
+          '\(me.program.show(receiver))'
+          """)
+      }
+
+      me._assume_state(me.currentFunction.returnRegister!, initialized: true)
+      me._return()
+    }
+  }
+
   // MARK: Lowering
 
   /// Generates the IR of `d`.
@@ -990,8 +1065,8 @@ internal struct IREmitter {
         }
       }
 
-    default:
-      unreachable()
+    case .synthetic:
+      unreachable("cannot generate callee from a reference to a synthetic definition")
     }
   }
 
@@ -2546,7 +2621,7 @@ internal struct IREmitter {
 
   /// Implements `_emitDeinitialize(_:)` for types that cannot be decomposed structurally.
   private mutating func _emitDeinitialize(
-    whole s: IRValue, instanceOf t: AnyTypeIdentity
+    whole: IRValue, instanceOf t: AnyTypeIdentity
   ) -> Bool {
     switch witnessOfDeinitializable(for: t) {
     case .none:
@@ -2554,19 +2629,48 @@ internal struct IREmitter {
       return false
 
     case .trivial:
-      _assume_state(s, initialized: false)
+      _assume_state(whole, initialized: false)
       return true
 
     case .nontrivial(let w):
+      let r = program.standardLibraryDeclaration(.deinitializableDeinit)
+
+      // Can we dispatch statically?
+      if let d = w.declaration, let c = program.cast(d, to: ConformanceDeclaration.self) {
+        let table = program.implementations(definedBy: c)
+        if let implementation = table.member(implementing: r) {
+          // Make sure we're not applying the function being lowered recursively, which may happen
+          // if `s` is the receiver of a function implementing `Deinitializable.deinit` for the
+          // witness that's been resolved.
+          if let j = implementation.target, currentFunction.name.isLoweredForm(of: j) {
+            let m = """
+              implicit deinitialization of instances of '\(program.show(t))' causes infinite \
+              recursion in this context
+              """
+            report(.init(.error, m, at: currentAnchor.site))
+            _ = _apply_builtin(.trap, to: [])
+            return false
+          } else if !implementation.isSynthetic {
+            let o = _alloca(.void)
+            let f = loweredCallee(
+              implementation, qualifiedBy: nil, markedForMutationBy: nil,
+              output: o, at: currentAnchor)
+            let xs = Array(whole, prependedTo: f.arguments)
+            _ = _apply(f.value, xs, into: f.result, afterFormingAccesses: true)
+            return true
+          }
+        }
+      }
+
+      // Emit a call to the witness.
       let deinitializable = _emit(witness: w)
-      let member = program.standardLibraryDeclaration(.deinitializableDeinit)
       let t0 = program.types.demand(
         Arrow(inputs: [.init(access: .sink, type: t)], output: .void))
 
       let x0 = _alloca(.void)
-      let x1 = _access([.sink], from: s)
+      let x1 = _access([.sink], from: whole)
       let x2 = _access([.set], from: x0)
-      let x3 = _property(member, of: deinitializable, withType: t0.erased)
+      let x3 = _property(r, of: deinitializable, withType: t0.erased)
       let x4 = _access([.let], from: x3)
 
       _ = _apply(x4, [x1], into: x2, afterFormingAccesses: false)
@@ -2579,7 +2683,7 @@ internal struct IREmitter {
     }
   }
 
-  /// Implements `_emitDeinitialize(_:)` for tuples..
+  /// Implements `_emitDeinitialize(_:)` for tuples.
   private mutating func _emitDeinitialize(tuple s: IRValue, instanceOf t: Tuple.ID) -> Bool {
     // Is the tuple empty?
     let (ms, _) = program.types.members(of: t)

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2058,9 +2058,8 @@ internal struct IREmitter {
   internal mutating func _property(
     _ property: DeclarationIdentity, of record: IRValue, withType propertyType: AnyTypeIdentity
   ) -> IRValue {
-    let s = IRProperty(
-      record: record, property: property, propertyType: propertyType,
-      anchor: currentAnchor)
+    let t = program.types.dealiased(propertyType)
+    let s = IRProperty(record: record, property: property, propertyType: t, anchor: currentAnchor)
     return insert(s)!
   }
 

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -33,6 +33,26 @@ public struct IRFunction: Sendable {
     /// The identity of a plateau resulting from subscript decomposition.
     indirect case plateau(IRFunction.Name, Int)
 
+    /// Returns `true` iff `self` is the name of a function that implements `d` in Hylo IR.
+    public func isLoweredForm(of d: DeclarationIdentity) -> Bool {
+      switch self {
+      case .lowered(let x):
+        return d == x
+      case .initializer(let x):
+        return d == x
+      case .synthesized(let x, _):
+        return d == x
+      case .implementation(let x, _, _):
+        return d == x
+      case .existentialized(let n):
+        return n.isLoweredForm(of: d)
+      case .slide(let n, _):
+        return n.isLoweredForm(of: d)
+      case .plateau(let n, _):
+        return n.isLoweredForm(of: d)
+      }
+    }
+
   }
 
   /// The way in which an IR function returns its result.

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -111,6 +111,9 @@ public struct IRFunction: Sendable {
   /// The name of the function.
   public let name: Name
 
+  /// The region of the code to which this function is associated.
+  public let anchor: Anchor
+
   /// The way in which the function returns its result.
   public let output: Output
 
@@ -134,10 +137,11 @@ public struct IRFunction: Sendable {
 
   /// Creates an instance with the given properties.
   public init(
-    name: Name, output: Output,
-    typeParameters: [GenericParameter.ID], termParameters: [IRParameter],
+    name: Name, anchor: Anchor,
+    output: Output, typeParameters: [GenericParameter.ID], termParameters: [IRParameter],
   ) {
     self.name = name
+    self.anchor = anchor
     self.output = output
     self.typeParameters = typeParameters
     self.termParameters = termParameters
@@ -767,7 +771,8 @@ public struct IRFunction: Sendable {
   /// moved back into `self` using `take(definition:)`.
   public mutating func move() -> IRFunction {
     var other = IRFunction(
-      name: name, output: output, typeParameters: typeParameters, termParameters: termParameters)
+      name: name, anchor: anchor, output: output,
+      typeParameters: typeParameters, termParameters: termParameters)
 
     swap(&self.bindings, &other.bindings)
     swap(&self.slots, &other.slots)
@@ -906,6 +911,7 @@ extension IRFunction: Archivable {
 
   public init<A>(from archive: inout ReadableArchive<A>, in context: inout Any) throws {
     self.name = try archive.read(Name.self, in: &context)
+    self.anchor = try archive.read(Anchor.self, in: &context)
     self.output = try archive.read(Output.self, in: &context)
     self.typeParameters = try archive.read([GenericParameter.ID].self, in: &context)
     self.termParameters = try archive.read([IRParameter].self, in: &context)
@@ -943,6 +949,7 @@ extension IRFunction: Archivable {
 
   public func write<A>(to archive: inout WriteableArchive<A>, in context: inout Any) throws {
     try archive.write(name, in: &context)
+    try archive.write(anchor, in: &context)
     try archive.write(output, in: &context)
     try archive.write(typeParameters, in: &context)
     try archive.write(termParameters, in: &context)

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -1063,7 +1063,10 @@ public struct Parser {
     // If we parsed an empty body and we're in the body of a function or initializer, then insert
     // a return statement.
     if ss.isEmpty && (head != .subscript) {
-      let r = file.insert(Return(introducer: nil, value: nil, site: .empty(at: position)))
+      // `position` is immediately after the last consumed token, which was a right brace.
+      let e = tokens.source.index(before: position.index)
+      let p = SourcePosition(e, in: tokens.source)
+      let r = file.insert(Return(introducer: nil, value: nil, site: .empty(at: p)))
       ss.append(.init(r))
     }
 
@@ -2644,7 +2647,12 @@ public struct Parser {
     }
   }
 
-  /// Parses an instance of `T` enclosed in `delimiters`.
+  /// Parses an instance of `T` enclosed in `delimiters`, returning the parsed instance along with
+  /// the right delimiter.
+  ///
+  /// The result is an instance of `T` parsed immediately after the left delimiter and immediately
+  /// before the right delimiter. The method throws if it cannot consume the left delimiter but
+  /// only reports an error if it cannot consume the right one.
   private mutating func between<T>(
     _ delimiters: (left: Token.Tag, right: Token.Tag),
     _ parse: (inout Self) throws -> T

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1375,8 +1375,8 @@ public struct Program: Sendable {
 
   /// Calls `action` for each stored property declaration in `d`.
   ///
-  /// `action` accepts a variable declaration and an index path identifying its abstract position
-  /// in a record value having the type declared by `d`.
+  /// `action` accepts a variable declaration and a path identifying its abstract position in a
+  /// record value having the type declared by `d`.
   public func forEachStoredProperty(
     of d: StructDeclaration.ID,
     do action: (VariableDeclaration.ID, IndexPath) -> Void
@@ -1392,20 +1392,20 @@ public struct Program: Sendable {
 
   /// Calls `action` for each variable declaration introduced by `d`.
   ///
-  /// `action` accepts a variable declaration and an index path relative to `path`, which identies
-  /// the abstract position of the declaration in the record value having the same type as `p`.
+  /// `action` accepts a variable declaration and a path relative to `root`, which identities the
+  /// abstract position of the declaration in the record value having the same type as `d`.
   public func forEachVariable(
     introducedBy d: BindingDeclaration.ID,
-    relativeTo path: IndexPath = [],
+    relativeTo root: IndexPath = [],
     do action: (VariableDeclaration.ID, IndexPath) -> Void
   ) {
-    forEachVariable(introducedBy: self[self[d].pattern].pattern, relativeTo: path, do: action)
+    forEachVariable(introducedBy: self[self[d].pattern].pattern, relativeTo: root, do: action)
   }
 
   /// Calls `action` for each variable declaration introduced in `p`.
   ///
-  /// `action` accepts a variable declaration and an index path relative to `path`, which identies
-  /// the abstract position of the declaration in the record value having the same type as `p`.
+  /// `action` accepts a variable declaration and a path relative to `root`, which identities the
+  /// abstract position of the declaration in the record value having the same type as `p`.
   public func forEachVariable(
     introducedBy p: PatternIdentity,
     relativeTo path: IndexPath = [],

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1382,45 +1382,44 @@ public struct Program: Sendable {
     do action: (VariableDeclaration.ID, IndexPath) -> Void
   ) {
     var i = 0
-    for m in self[d].members {
-      if let b = cast(m, to: BindingDeclaration.self) {
-        forEachVariable(introducedBy: self[self[b].pattern].pattern) { (v, _) in
-          action(v, [i])
-          i += 1
-        }
+    for m in collect(BindingDeclaration.self, in: self[d].members) where !isStatic(m) {
+      forEachVariable(introducedBy: self[self[m].pattern].pattern) { (v, _) in
+        action(v, [i])
+        i += 1
       }
     }
   }
 
   /// Calls `action` for each variable declaration introduced by `d`.
   ///
-  /// `action` accepts a variable declaration and an index path identifying its abstract position
-  /// in the a record value having the type of `d`.
+  /// `action` accepts a variable declaration and an index path relative to `path`, which identies
+  /// the abstract position of the declaration in the record value having the same type as `p`.
   public func forEachVariable(
     introducedBy d: BindingDeclaration.ID,
+    relativeTo path: IndexPath = [],
     do action: (VariableDeclaration.ID, IndexPath) -> Void
   ) {
-    forEachVariable(introducedBy: self[self[d].pattern].pattern, do: action)
+    forEachVariable(introducedBy: self[self[d].pattern].pattern, relativeTo: path, do: action)
   }
 
   /// Calls `action` for each variable declaration introduced in `p`.
   ///
-  /// `action` accepts a variable declaration and an index path identifying its abstract position
-  /// in the a record value having the type of `p`.
+  /// `action` accepts a variable declaration and an index path relative to `path`, which identies
+  /// the abstract position of the declaration in the record value having the same type as `p`.
   public func forEachVariable(
     introducedBy p: PatternIdentity,
-    at path: IndexPath = [],
+    relativeTo path: IndexPath = [],
     do action: (VariableDeclaration.ID, IndexPath) -> Void
   ) {
     switch tag(of: p) {
     case BindingPattern.self:
       let q = castUnchecked(p, to: BindingPattern.self)
-      forEachVariable(introducedBy: self[q].pattern, at: path, do: action)
+      forEachVariable(introducedBy: self[q].pattern, relativeTo: path, do: action)
 
     case TuplePattern.self:
       let q = castUnchecked(p, to: TuplePattern.self)
       for (i, e) in self[q].elements.enumerated() {
-        forEachVariable(introducedBy: e, at: path.appending(i), do: action)
+        forEachVariable(introducedBy: e, relativeTo: path.appending(i), do: action)
       }
 
     case VariableDeclaration.self:

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -107,6 +107,7 @@ public struct Program: Sendable {
     // Generate raw IR from the syntax tree.
     var emitter = IREmitter(insertingIn: m, of: consume self)
     emitter.incorporateTopLevelDeclarations()
+    emitter.implementSynthesizedFunctions()
     self = emitter.release()
   }
 

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1587,6 +1587,11 @@ public struct Program: Sendable {
     }
   }
 
+  /// Returns an anchor suitable to generate debug information related to `d` as a whole.
+  public func anchorForDiagnostics(about d: DeclarationIdentity) -> Anchor {
+    .init(site: spanForDiagnostic(about: d), scope: parent(containing: d))
+  }
+
   /// Returns `message` with placeholders replaced by their corresponding values in `arguments`.
   ///
   /// Use this method to generate strings containing one or several elements whose description is

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -974,25 +974,6 @@ public struct Typer {
 
   /// Returns whether a conformance of each stored part of `conformer` to `concept` can be derived
   /// (i.e., resolved or synthesized) in `scopeOfUse`.
-  ///
-  /// - Requires: conformances to `concept` may be synthesized by the compiler.
-  private mutating func structurallyConforms(
-    _ conformer: Tuple.ID, to concept: TraitDeclaration.ID,
-    in scopeOfUse: ScopeIdentity
-  ) -> StructuralConformanceLookupResult {
-    switch program.types[conformer] {
-    case .cons(let head, let tail):
-      return
-        isDerivable(conformanceTo: concept, for: head, in: scopeOfUse)
-        && isDerivable(conformanceTo: concept, for: tail, in: scopeOfUse)
-
-    case .empty:
-      return .success(true)
-    }
-  }
-
-  /// Returns whether a conformance of each stored part of `conformer` to `concept` can be derived
-  /// (i.e., resolved or synthesized) in `scopeOfUse`.
   private mutating func isDerivable(
     conformanceTo concept: TraitDeclaration.ID, for conformer: AnyTypeIdentity,
     in scopeOfUse: ScopeIdentity

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -215,9 +215,19 @@ private typealias Module = FrontEnd.Module
       try await perform("generating executable", for: module) {
         try driver.generateExecutable(from: module, writingTo: binaryFile(product))
       }
-    } catch let e as CompilationError {
+    }
+
+    // Catch compiler failures.
+    catch let e as CompilationError {
       render(e.diagnostics.elements)
       CommandLine.exit(withError: ExitCode.failure)
+    }
+
+    // Catch linker failures.
+    catch let e as Process.NonzeroExit {
+      var stderr = StandardError()
+      print(e.standardError, to: &stderr)
+      CommandLine.exit(withError: ExitCode(e.exitCode))
     }
 
     /// Performs `action`, logs its duration, and exits with diagnostics if it resulted in an error.

--- a/Tests/CompilerTests/negative/empty-initialization.diagnostics.expected
+++ b/Tests/CompilerTests/negative/empty-initialization.diagnostics.expected
@@ -1,3 +1,3 @@
-negative/empty-initialization.hylo:7.40: error: 'set' parameter not initialized before exit
+negative/empty-initialization.hylo:7.39: error: 'set' parameter not initialized before exit
 fun illegal<T, U>(xs: set {T, ...U}) {}
-                                       ^
+                                      ^

--- a/Tests/CompilerTests/negative/recursive-implicit-deinit.diagnostics.expected
+++ b/Tests/CompilerTests/negative/recursive-implicit-deinit.diagnostics.expected
@@ -1,0 +1,3 @@
+negative/recursive-implicit-deinit.hylo:4.22: error: implicit deinitialization of instances of 'S' causes infinite recursion in this context
+  fun deinit() sink {}
+                     ^

--- a/Tests/CompilerTests/negative/recursive-implicit-deinit.hylo
+++ b/Tests/CompilerTests/negative/recursive-implicit-deinit.hylo
@@ -1,0 +1,9 @@
+struct S is Deinitializable {
+  let x: Int
+  memberwise init
+  fun deinit() sink {}
+}
+
+public fun main() {
+  _ = S(x: 1)
+}

--- a/Tests/CompilerTests/positive/big-return.hylo
+++ b/Tests/CompilerTests/positive/big-return.hylo
@@ -1,7 +1,7 @@
 //! exit-status:42
 
 // A type larger than a pointer should be passed correctly.
-struct Triple /* todo is Deinitializable */ {
+struct Triple is Deinitializable  {
   let (a, b, c): {Int32, Int32, Int32}
   memberwise init
 }

--- a/Tests/CompilerTests/positive/synthesized-deinit.hylo
+++ b/Tests/CompilerTests/positive/synthesized-deinit.hylo
@@ -1,0 +1,19 @@
+//! stage:llvm
+
+// `S0` has a user-defined deinitializer, meaning that it is not trivially deinitializable.
+// `S1` has a synthesized deinitializer, which is no-op.
+// `S2` has a synthesized deinitializer, which deinitializes each property individually.
+
+struct S0 is Deinitializable {
+  var i: Int
+  fun deinit() sink { _ = self.i }
+}
+
+struct S1 is Deinitializable {}
+
+struct S2 is Deinitializable {
+  let i: Int
+  let r: {S0, S1}
+}
+
+public fun main() {}

--- a/Tests/CompilerTests/positive/synthesized-deinit.llvm-ir.expected
+++ b/Tests/CompilerTests/positive/synthesized-deinit.llvm-ir.expected
@@ -1,0 +1,29 @@
+define private void @"M6TestUksynthesizeddeinitS4S0F08deinitlT08tR516selfsTK2tR5$jJ"(%"sTM6TestUksynthesizeddeinitS4S0$lJ" %0) {
+  %2 = alloca {}, align 8
+  %3 = alloca %"sTM6TestUksynthesizeddeinitS4S0$lJ", align 8
+  store %"sTM6TestUksynthesizeddeinitS4S0$lJ" %0, ptr %3, align 8
+  %4 = getelementptr inbounds %"sTM6TestUksynthesizeddeinitS4S0$lJ", ptr %3, i32 0, i32 0
+  ret void
+}
+
+define void @"xFR0UhDeinitializableC10F08deinitlT08tR516selfgcTK10tR51L2sTM6TestUksynthesizeddeinitS4S1$PsJ"(%"pTcTR0UhDeinitializableC101gcTK10sTM6TestUksynthesizeddeinitS4S1$P3J" %0) {
+  %2 = alloca {}, align 8
+  %3 = alloca %"pTcTR0UhDeinitializableC101gcTK10sTM6TestUksynthesizeddeinitS4S1$P3J", align 8
+  store %"pTcTR0UhDeinitializableC101gcTK10sTM6TestUksynthesizeddeinitS4S1$P3J" %0, ptr %3, align 8
+  %4 = alloca {}, align 8
+  ret void
+}
+
+define void @"xFR0UhDeinitializableC10F08deinitlT08tR516selfgcTK10tR51L2sTM6TestUksynthesizeddeinitS4S2$PsJ"(%"pTcTR0UhDeinitializableC101gcTK10sTM6TestUksynthesizeddeinitS4S2$P3J" %0, ptr %1) {
+  %3 = alloca %tR5, align 1
+  %4 = alloca {}, align 8
+  %5 = alloca %"pTcTR0UhDeinitializableC101gcTK10sTM6TestUksynthesizeddeinitS4S2$P3J", align 8
+  store %"pTcTR0UhDeinitializableC101gcTK10sTM6TestUksynthesizeddeinitS4S2$P3J" %0, ptr %5, align 8
+  %6 = getelementptr inbounds %"sTM6TestUksynthesizeddeinitS4S2$lJ", ptr %1, i32 0, i32 0
+  %7 = getelementptr inbounds %"sTM6TestUksynthesizeddeinitS4S2$lJ", ptr %1, i32 0, i32 1
+  %8 = getelementptr inbounds %"tTsTM6TestUksynthesizeddeinitS4S0tTsTK1S4S1tR5$nJ", ptr %7, i32 0, i32 0
+  %9 = load %"sTM6TestUksynthesizeddeinitS4S0$lJ", ptr %8, align 1
+  call void @"M6TestUksynthesizeddeinitS4S0F08deinitlT08tR516selfsTK2tR5$jJ"(%"sTM6TestUksynthesizeddeinitS4S0$lJ" %9)
+  %10 = getelementptr inbounds %"tTsTM6TestUksynthesizeddeinitS4S0tTsTK1S4S1tR5$nJ", ptr %7, i32 0
+  ret void
+}


### PR DESCRIPTION
This PR implements the generation of synthetic deinitializers for structs. It does not yet handle user-defined initializers of empty structs. It does not handle synthetic deinitializers for other data structures (e.g., enums).