### PR TITLE
Exclude static properties from memberwise initializers

### DIFF
--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -1349,7 +1349,7 @@ public struct Typer {
       // We don't use `program.storedProperties(of:)` because we have to ensure that all stored
       // properties are typed before we can form a corresponding parameter.
       for b in program.collect(BindingDeclaration.self, in: program[s].members) {
-        // Static properties are not excluded.
+        // Static properties are excluded.
         if program.isStatic(b) { continue }
 
         // Non-static properties are reflected in the parameter list.

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -1349,6 +1349,10 @@ public struct Typer {
       // We don't use `program.storedProperties(of:)` because we have to ensure that all stored
       // properties are typed before we can form a corresponding parameter.
       for b in program.collect(BindingDeclaration.self, in: program[s].members) {
+        // Static properties are not excluded.
+        if program.isStatic(b) { continue }
+
+        // Non-static properties are reflected in the parameter list.
         _ = declaredType(of: b)
         program.forEachVariable(introducedBy: b) { (v, _) in
           let l = program[v].identifier.value

--- a/Tests/CompilerTests/positive/memberwise-init-2.hylo
+++ b/Tests/CompilerTests/positive/memberwise-init-2.hylo
@@ -11,6 +11,14 @@ struct B {
   public let (m0, _, m1): {Void, Void, Void}
 }
 
+struct C {
+  public memberwise init
+  public let m0: Void
+  public static let m1 = ()
+}
+
 fun a() -> A { A(m0: (), m1: ()) }
 
 fun b() -> B { B(m0: (), m1: ()) }
+
+fun c() -> C { C(m0: ()) }


### PR DESCRIPTION
Fixes #213 