### PR TITLE
Modify 'place_cast' so that it projects its result with a capability

### DIFF
--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -173,6 +173,8 @@ extension Program {
       return incorporate(ctx.ir.castUnchecked(i, to: IRMemoryCopy.self), in: &ctx)
     case IRPlaceCast.self:
       return incorporate(ctx.ir.castUnchecked(i, to: IRPlaceCast.self), in: &ctx)
+    case IRPlaceCast.End.self:
+      return ctx.ir.instruction(after: i)
     case IRProject.self:
       return incorporate(ctx.ir.castUnchecked(i, to: IRProject.self), in: &ctx)
     case IRProperty.self:

--- a/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
+++ b/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
@@ -63,9 +63,6 @@ extension IREmitter {
     let poly = program[module].ir[c]
     let mono = demandExistentialized(poly)
 
-    // Get the types of the parameters of the original poloymorphic function.
-    let parameters = poly.termParameters.map(\.type)
-
     // Create an array with a type witness for each of the type argument passed to `i`. These
     // witnesses will be concatenated with the term arguments of each use application of `c`
     // instantiated by `i`.
@@ -82,12 +79,12 @@ extension IREmitter {
         // `i` is used as a callee in an ordinary function application.
         depolymorphize(
           polymorphicApplyUser: u.user, with: mono,
-          passing: witnesses, to: parameters, in: &f)
+          passing: witnesses, to: poly.termParameters, in: &f)
 
       case IRProject.self where u.index == 0:
         depolymorphize(
           polymorphicProjectUser: u.user, with: mono,
-          passing: witnesses, to: parameters, in: &f)
+          passing: witnesses, to: poly.termParameters, in: &f)
 
       default:
         unimplemented()
@@ -98,52 +95,60 @@ extension IREmitter {
     f.remove(i.erased)
   }
 
-  /// Replaces `u`, which is the application of a polymorphic abstraction, with an application of
-  /// `mono`, which is the existentialized form of `u`'s callee.
+  /// Replaces `user`, which is the application of a polymorphic abstraction, with an application
+  /// of `mono`, which is the existentialized form of `u`'s callee.
   ///
   /// - Parameters:
-  ///   - user: The user of a `type_apply` instantiating the polymorphic function of which `mono`is
-  ///     the existentialization.
+  ///   - user: An `apply` instruction whose callee is the result of a `type_apply` instantiating
+  ///     the polymorphic function, of which `mono`is the existentialization.
   ///   - mono: The identity of an existentialized function.
   ///   - witnesses: witnesses for each type parameter in the original polymorphic function.
   ///   - parameters: The types of the term parameters of the polymorphic function.
   ///   - f: The function containing `user`.
   private mutating func depolymorphize(
     polymorphicApplyUser user: AnyInstructionIdentity, with mono: IRFunction.ID,
-    passing witnesses: [IRValue], to parameters: [AnyTypeIdentity], in f: inout IRFunction
+    passing witnesses: [IRValue], to parameters: [IRParameter], in f: inout IRFunction
   ) {
     let old = f.at(user) as! IRApply
 
     var xs = witnesses
     let result = lowering(before: user, in: &f) { (e) in
-      for (a, p) in zip(old.arguments, parameters) { xs.append(e._emitCast(a, to: p)) }
-      return e._emitCast(old.result, to: parameters.last!)
+      for (a, p) in zip(old.arguments, parameters) {
+        xs.append(e._emitCast(a, to: p.access, p.type))
+      }
+      let last = parameters.last!
+      return e._emitCast(old.result, to: last.access, last.type)
     }
 
     let referenceToMono = functionReference(to: mono)
-    let s = IRApply(callee: referenceToMono, arguments: xs, result: result, anchor: old.anchor)
-    f.replace(user, with: s)
+    f.replace(
+      user,
+      with: IRApply(callee: referenceToMono, arguments: xs, result: result, anchor: old.anchor))
+
+    f.closeOpenEndedRegions()
   }
 
-  /// Replaces `u`, which is the application of a polymorphic abstraction, with an application of
-  /// `mono`, which is the existentialized form of `u`'s callee.
+  /// Replaces `user`, which is the application of a polymorphic abstraction, with an application
+  /// of `mono`, which is the existentialized form of `u`'s callee.
   ///
-  /// This method is similar to `depolymorphize(polymorphicApplyUser:with:passing:to:in:)` only for
-  /// the case where `user` is a projection rather than an application.
+  /// This method is similar to `depolymorphize(polymorphicApplyUser:with:passing:to:in:)`, except
+  /// that `user` is a `project` instruction rather than an `apply`.
   private mutating func depolymorphize(
     polymorphicProjectUser user: AnyInstructionIdentity, with mono: IRFunction.ID,
-    passing witnesses: [IRValue], to parameters: [AnyTypeIdentity], in f: inout IRFunction
+    passing witnesses: [IRValue], to parameters: [IRParameter], in f: inout IRFunction
   ) {
     let old = f.at(user) as! IRProject
 
     var xs = witnesses
     lowering(before: user, in: &f) { (e) in
-      for (a, p) in zip(old.arguments, parameters) { xs.append(e._emitCast(a, to: p)) }
+      for (a, p) in zip(old.arguments, parameters) {
+        xs.append(e._emitCast(a, to: p.access, p.type))
+      }
     }
 
     let referenceToMono = functionReference(to: mono)
     let s = IRProject(
-      callee: referenceToMono, arguments: xs, projectee: old.projectee, access: old.access,
+      callee: referenceToMono, arguments: xs, access: old.access, projectee: old.projectee,
       anchor: old.anchor)
 
     // Cast the result of the projection if necessary.
@@ -152,9 +157,13 @@ extension IREmitter {
       assert(t == f.resolved(s.type)!.type)
       f.replace(user, with: s)
     } else {
-      let x0 = lowering(before: user, in: &f, { $0.insert(s) })
-      f.replace(user, with: IRPlaceCast(source: x0!, target: t, anchor: old.anchor))
+      let x = lowering(before: user, in: &f, { $0.insert(s) })!
+      f.replace(
+        user,
+        with: IRPlaceCast(source: x, access: old.access, target: t, anchor: old.anchor))
     }
+
+    f.closeOpenEndedRegions()
   }
 
   /// Returns the identity of the existentialized form of the polymorphic function `f`.

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2104,9 +2104,11 @@ internal struct IREmitter {
   }
 
   /// Inserts a `place_cast` instruction.
-  internal mutating func _place_cast<T: TypeIdentity>(_ source: IRValue, as target: T) -> IRValue {
+  internal mutating func _place_cast<T: TypeIdentity>(
+    _ source: IRValue, as access: AccessEffect, _ target: T
+  ) -> IRValue {
     let t = program.types.dealiased(target.erased)
-    let s = IRPlaceCast(source: source, target: t, anchor: currentAnchor)
+    let s = IRPlaceCast(source: source, access: access, target: t, anchor: currentAnchor)
     return insert(s)!
   }
 
@@ -2562,15 +2564,20 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR for casting `source` to a place of type `target`.
+  /// Generates the IR for defining a place projecting `source` as a place of type `target` with
+  /// capability `access`.
+  ///
+  /// The result if an `access` if `target` is the type of `source`. Otherwise, the result is a
+  /// `place_cast`, implying that `target` is layout-compatible with the type of `source`. In both
+  /// cases, the result defines a region in which `source` is unavailable unless `access` is `let`.
   internal mutating func _emitCast(
-    _ source: IRValue, to target: AnyTypeIdentity
+    _ source: IRValue, to access: AccessEffect, _ target: AnyTypeIdentity
   ) -> IRValue {
     if target[.hasGenericParameter] {
-      return _place_cast(source, as: target)
+      return _place_cast(source, as: access, target)
     } else {
       assert(target == currentFunction.result(of: source)!.type)
-      return source
+      return _access([access], from: source)
     }
   }
 

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2127,10 +2127,11 @@ internal struct IREmitter {
       _emitArgumentAccesses(&arguments, toApplyOrProject: callee, typed: t)
     }
 
+    let o = program.types.dealiased(program.types[t].output)
     let s = IRProject(
       callee: callee, arguments: arguments,
-      projectee: program.types[t].output,
       access: program.types[t].effect,
+      projectee: o,
       anchor: currentAnchor)
     return insert(s)!
   }

--- a/Sources/FrontEnd/IR/Instructions/IRPlaceCast.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRPlaceCast.swift
@@ -1,11 +1,15 @@
 import Archivist
 
-/// Converts a place of type `A` to a place of type `B`.
+/// Projects a value at a different type.
 ///
-/// The conversion is not checked. Accessing the resulting place has undefined behavior unless `B`
-/// is layout-compatible with `A`.
+///     place_cast <source : value> as <access : effect> <target : type>
+///
+/// `place_cast` projects the value of `source` as a value of type `target` into a region, using
+/// `effect` to determine the expected memory state of the source before and after that region. The
+/// conversion is not checked. Accessing the resulting place has undefined behavior unless `target`
+/// is layout-compatible with the type of `source`.
 @Archivable
-public struct IRPlaceCast: Instruction {
+public struct IRPlaceCast: IRRegionEntry {
 
   /// The operands of the instruction.
   public let operands: [IRValue]
@@ -13,13 +17,17 @@ public struct IRPlaceCast: Instruction {
   /// The region of the code corresponding to this instruction.
   public let anchor: Anchor
 
+  /// The capability of the access formed on the place.
+  public let access: AccessEffect
+
   /// The type of the resulting place.
   public let target: AnyTypeIdentity
 
   /// Creates an instance with the given properties.
-  public init(source: IRValue, target: AnyTypeIdentity, anchor: Anchor) {
+  public init(source: IRValue, access: AccessEffect, target: AnyTypeIdentity, anchor: Anchor) {
     self.operands = [source]
     self.anchor = anchor
+    self.access = access
     self.target = target
   }
 
@@ -27,9 +35,9 @@ public struct IRPlaceCast: Instruction {
   public init(_ other: Self, substituting properties: IRSubstitutionTable) {
     self.operands = [properties[other.source]]
     self.anchor = properties.anchor(other)
+    self.access = other.access
     self.target = other.target
   }
-
 
   /// The place being converted.
   public var source: IRValue {
@@ -52,7 +60,7 @@ extension IRPlaceCast: Showable {
 
   /// Returns a textual representation of `self` using `printer`.
   public func show(using printer: inout TreePrinter) -> String {
-    "place_cast \(printer.show(source)) as \(printer.show(target))"
+    "place_cast \(printer.show(source)) as \(access) \(printer.show(target))"
   }
 
 }

--- a/Sources/FrontEnd/IR/Instructions/IRProject.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRProject.swift
@@ -11,15 +11,15 @@ public struct IRProject: IRRegionEntry {
   /// The region of the code corresponding to this instruction.
   public let anchor: Anchor
 
-  /// The type of the projected value.
-  public let projectee: AnyTypeIdentity
-
   /// The capabilities of the projection.
   public let access: AccessEffect
 
+  /// The type of the projected value.
+  public let projectee: AnyTypeIdentity
+
   /// Creates an instance with the given properties.
   public init(
-    callee: IRValue, arguments: [IRValue], projectee: AnyTypeIdentity, access: AccessEffect,
+    callee: IRValue, arguments: [IRValue], access: AccessEffect, projectee: AnyTypeIdentity,
     anchor: Anchor
   ) {
     var operands = Array<IRValue>(minimumCapacity: arguments.count + 1)
@@ -28,16 +28,16 @@ public struct IRProject: IRRegionEntry {
 
     self.operands = operands
     self.anchor = anchor
-    self.projectee = projectee
     self.access = access
+    self.projectee = projectee
   }
 
   /// Creates a copy of `other`, substituting its properties with `properties`.
   public init(_ other: Self, substituting properties: IRSubstitutionTable) {
     self.operands = other.operands.map({ (o) in properties[o] })
     self.anchor = properties.anchor(other)
-    self.projectee = other.projectee
     self.access = other.access
+    self.projectee = other.projectee
   }
 
   /// The subscript being applied.

--- a/Sources/FrontEnd/IR/Instructions/InstructionTag.swift
+++ b/Sources/FrontEnd/IR/Instructions/InstructionTag.swift
@@ -43,6 +43,7 @@ public struct InstructionTag: Sendable {
     IRMove.self,
     IRPartialApply.self,
     IRPlaceCast.self,
+    IRPlaceCast.End.self,
     IRProject.self,
     IRProject.End.self,
     IRProperty.self,

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+RegionClosing.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+RegionClosing.swift
@@ -18,6 +18,8 @@ extension IRFunction {
         close(IRAccess.self, i, computingLivenessWith: g)
       case IRCase.self:
         close(IRCase.self, i, computingLivenessWith: g)
+      case IRPlaceCast.self:
+        close(IRPlaceCast.self, i, computingLivenessWith: g)
       case IRProject.self:
         close(IRProject.self, i, computingLivenessWith: g)
       default:


### PR DESCRIPTION
This patch modifies the `place_cast` instruction so that it behaves like `project`. This change is necessary to implement synthesized deinitializers of enums.