### PR TITLE
Attempt to update CodeCov's server record of our YAML

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,5 @@
 ignore:
   - '!(Sources|StandardLibrary)/'
-
 comment:
   require_changes: true
 


### PR DESCRIPTION
The website shows a JSON schema error, and

> This is the default YAML for the current repository, after validation. This YAML takes precedence over the global YAML, but will be overwritten if a YAML change is included in a commit.

So this makes a whitespace change.