### PR TITLE
Introduce unlink, link, relink abstractions in `List`

### DIFF
--- a/Sources/StableCollections/List.swift
+++ b/Sources/StableCollections/List.swift
@@ -399,8 +399,8 @@ public struct List<Element> {
     linkNeighborsToPreallocated(address, before: b)
   }
 
-  /// Moves the bucket at `address` to appear after `a`.
-  ///
+  /// Moves the bucket at `address` to appear after `a`, without invalidating addresses.
+  /// 
   /// - Requires: `address` != `a`.
   public mutating func move(_ address: Address, after a: Address) {
     precondition(isInBounds(address), "address out of bounds")
@@ -414,7 +414,8 @@ public struct List<Element> {
     linkNeighborsToPreallocated(address, after: a)
   }
 
-  /// Moves the element at `address` to appear at the start of the list.
+  /// Moves the element at `address` to appear at the start of the list without invalidating
+  /// addresses.
   public mutating func moveToStart(_ address: Address) {
     precondition(isInBounds(address), "address out of bounds")
     
@@ -432,7 +433,8 @@ public struct List<Element> {
     headOffset = address.rawValue
   }
 
-  /// Moves the element at `address` to appear at the end of the list.
+  /// Moves the element at `address` to appear at the end of the list without invalidating
+  /// addresses.
   public mutating func moveToEnd(_ address: Address) {
     precondition(isInBounds(address), "address out of bounds")
     

--- a/Sources/StableCollections/List.swift
+++ b/Sources/StableCollections/List.swift
@@ -250,15 +250,33 @@ public struct List<Element> {
         element: newElement)
     }
 
+    linkNeighborsToPreallocated(newAddress, after: address)
+
+    count += 1
+    return newAddress
+  }
+
+  /// Links up an already allocated bucket at `newAddress` right after `address`.
+  ///
+  /// - Requires:
+  ///   - `newAddress` and `address` must be valid and unique addresses in `self`.
+  ///   - `newAddress`'s bucket is already linked towards the neighbors but not vice versa.
+  @inline(__always) 
+  private mutating func linkNeighborsToPreallocated(
+    _ newAddress: Address, after address: Address
+  ) {
+    assert(isInBounds(newAddress), "newAddress out of bounds")
+    assert(isInBounds(address), "address out of bounds")
+    assert(newAddress != address)
+    assert(storage[newAddress.rawValue].previousOffset == address.rawValue)
+    assert(storage[newAddress.rawValue].nextOffset == storage[address.rawValue].nextOffset)
+
     if address.rawValue == tailOffset {
       tailOffset = newAddress.rawValue
     } else {
       storage[storage[address.rawValue].nextOffset].previousOffset = newAddress.rawValue
     }
     storage[address.rawValue].nextOffset = newAddress.rawValue
-
-    count += 1
-    return newAddress
   }
 
   /// Inserts `newElement` before the element at `address` and returns its address.
@@ -288,15 +306,30 @@ public struct List<Element> {
         element: newElement)
     }
 
+    linkNeighborsToPreallocated(newAddress, before: address)
+    count += 1
+    return newAddress
+  }
+
+  /// Links up an already allocated bucket at `newAddress` right before `address`.
+  ///
+  /// - Requires:
+  ///   - `newAddress` and `address` must be valid and unique addresses in `self`.
+  ///   - `newAddress`'s bucket is already linked towards the neighbors but not vice versa.
+  @inline(__always)
+  private mutating func linkNeighborsToPreallocated(_ newAddress: Address, before address: Address) {
+    assert(isInBounds(newAddress), "newAddress out of bounds")
+    assert(isInBounds(address), "address out of bounds")
+    assert(newAddress != address)
+    assert(storage[newAddress.rawValue].previousOffset == storage[address.rawValue].previousOffset)
+    assert(storage[newAddress.rawValue].nextOffset == address.rawValue)
+
     if address.rawValue == headOffset {
       headOffset = newAddress.rawValue
     } else {
       storage[storage[address.rawValue].previousOffset].nextOffset = newAddress.rawValue
     }
     storage[address.rawValue].previousOffset = newAddress.rawValue
-
-    count += 1
-    return newAddress
   }
 
   /// Inserts `newElement` at the given position and returns its address.
@@ -317,6 +350,18 @@ public struct List<Element> {
   public mutating func remove(at address: Address) -> Element {
     precondition(isInBounds(address), "address out of bounds")
 
+    unlink(address)
+
+    storage[address.rawValue].nextOffset = freeOffset
+
+    count -= 1
+    freeOffset = address.rawValue
+
+    return storage[address.rawValue].element.sink()
+  }
+
+  /// Unlinks the node at `address` from its neighbors without changing the free list.
+  private mutating func unlink(_ address: Address) {
     let previous = storage[address.rawValue].previousOffset
     if previous != -1 {
       storage[previous].nextOffset = storage[address.rawValue].nextOffset
@@ -327,18 +372,78 @@ public struct List<Element> {
       storage[next].previousOffset = storage[address.rawValue].previousOffset
     }
 
-    storage[address.rawValue].nextOffset = freeOffset
-
-    count -= 1
-    freeOffset = address.rawValue
     if address.rawValue == headOffset {
       headOffset = next
     }
     if address.rawValue == tailOffset {
       tailOffset = previous
     }
+  }
 
-    return storage[address.rawValue].element.sink()
+  /// Relinks the bucket at `address` to appear before `b`.
+  ///
+  /// - Requires: `address` != `b`.
+  public mutating func relink(_ address: Address, before b: Address) {
+    precondition(isInBounds(address), "address out of bounds")
+    precondition(isInBounds(b), "b out of bounds")
+    precondition(address != b, "address and b must be different")
+    unlink(address)
+
+    storage[address.rawValue].previousOffset = storage[b.rawValue].previousOffset
+    storage[address.rawValue].nextOffset = b.rawValue
+
+    linkNeighborsToPreallocated(address, before: b)
+  }
+
+  /// Relinks the bucket at `address` to appear after `a`.
+  ///
+  /// - Requires: `address` != `a`.
+  public mutating func relink(_ address: Address, after a: Address) {
+    precondition(isInBounds(address), "address out of bounds")
+    precondition(isInBounds(a), "a out of bounds")
+    precondition(address != a, "address and a must be different")
+    unlink(address)
+
+    storage[address.rawValue].previousOffset = a.rawValue
+    storage[address.rawValue].nextOffset = storage[a.rawValue].nextOffset
+
+    linkNeighborsToPreallocated(address, after: a)
+  }
+
+  /// Relinks the element at `address` to appear at the start of the list.
+  public mutating func relinkToStart(_ address: Address) {
+    precondition(isInBounds(address), "address out of bounds")
+    
+    guard address.rawValue != headOffset else { return } // Already at start.
+
+    unlink(address)
+   
+    storage[address.rawValue].previousOffset = -1
+    storage[address.rawValue].nextOffset = headOffset
+    
+    if headOffset != -1 {
+      storage[headOffset].previousOffset = address.rawValue
+    }
+    
+    headOffset = address.rawValue
+  }
+
+  /// Relinks the element at `address` to appear at the end of the list.
+  public mutating func relinkToEnd(_ address: Address) {
+    precondition(isInBounds(address), "address out of bounds")
+    
+    guard address.rawValue != tailOffset else { return } // Already at end.
+    
+    unlink(address)
+    
+    storage[address.rawValue].previousOffset = tailOffset
+    storage[address.rawValue].nextOffset = -1
+    
+    if tailOffset != -1 {
+      storage[tailOffset].nextOffset = address.rawValue
+    }
+    
+    tailOffset = address.rawValue 
   }
 
   /// Reserves enough space to store the `minimumCapacity` elements without allocating new storage.

--- a/Sources/StableCollections/List.swift
+++ b/Sources/StableCollections/List.swift
@@ -225,7 +225,7 @@ public struct List<Element> {
 
   /// Inserts `newElement` after the element at `address` and returns its address.
   ///
-  /// - Requires: `address` must be a valid an address in `self`.
+  /// - Requires: `address` must be a valid address in `self`.
   @discardableResult
   public mutating func insert(_ newElement: Element, after address: Address) -> Address {
     precondition(isInBounds(address), "address out of bounds")
@@ -314,10 +314,12 @@ public struct List<Element> {
   /// Links up an already allocated bucket at `newAddress` right before `address`.
   ///
   /// - Requires:
-  ///   - `newAddress` and `address` must be valid and unique addresses in `self`.
+  ///   - `newAddress` and `address` must be present and unique addresses in `self`.
   ///   - `newAddress`'s bucket is already linked towards the neighbors but not vice versa.
   @inline(__always)
-  private mutating func linkNeighborsToPreallocated(_ newAddress: Address, before address: Address) {
+  private mutating func linkNeighborsToPreallocated(
+    _ newAddress: Address, before address: Address
+  ) {
     assert(isInBounds(newAddress), "newAddress out of bounds")
     assert(isInBounds(address), "address out of bounds")
     assert(newAddress != address)
@@ -380,10 +382,12 @@ public struct List<Element> {
     }
   }
 
-  /// Relinks the bucket at `address` to appear before `b`.
+  /// Moves the element at `address` to appear before `b`.
   ///
-  /// - Requires: `address` != `b`.
-  public mutating func relink(_ address: Address, before b: Address) {
+  /// - Requires:
+  ///   - `address` != `b`
+  ///   - `address` and `b` are both live addresses in `self`.
+  public mutating func move(_ address: Address, before b: Address) {
     precondition(isInBounds(address), "address out of bounds")
     precondition(isInBounds(b), "b out of bounds")
     precondition(address != b, "address and b must be different")
@@ -395,10 +399,10 @@ public struct List<Element> {
     linkNeighborsToPreallocated(address, before: b)
   }
 
-  /// Relinks the bucket at `address` to appear after `a`.
+  /// Moves the bucket at `address` to appear after `a`.
   ///
   /// - Requires: `address` != `a`.
-  public mutating func relink(_ address: Address, after a: Address) {
+  public mutating func move(_ address: Address, after a: Address) {
     precondition(isInBounds(address), "address out of bounds")
     precondition(isInBounds(a), "a out of bounds")
     precondition(address != a, "address and a must be different")
@@ -410,8 +414,8 @@ public struct List<Element> {
     linkNeighborsToPreallocated(address, after: a)
   }
 
-  /// Relinks the element at `address` to appear at the start of the list.
-  public mutating func relinkToStart(_ address: Address) {
+  /// Moves the element at `address` to appear at the start of the list.
+  public mutating func moveToStart(_ address: Address) {
     precondition(isInBounds(address), "address out of bounds")
     
     guard address.rawValue != headOffset else { return } // Already at start.
@@ -428,8 +432,8 @@ public struct List<Element> {
     headOffset = address.rawValue
   }
 
-  /// Relinks the element at `address` to appear at the end of the list.
-  public mutating func relinkToEnd(_ address: Address) {
+  /// Moves the element at `address` to appear at the end of the list.
+  public mutating func moveToEnd(_ address: Address) {
     precondition(isInBounds(address), "address out of bounds")
     
     guard address.rawValue != tailOffset else { return } // Already at end.

--- a/Tests/StableCollectionsTests/ListTests.swift
+++ b/Tests/StableCollectionsTests/ListTests.swift
@@ -116,4 +116,163 @@ final class ListTests: XCTestCase {
     XCTAssertGreaterThanOrEqual(s.capacity, 100)
   }
 
+  /// Exhaustively checks `relink(_:before:)` and `relink(_:after:)` against a reference
+  /// implementation on lists of 2 to 5 elements, for every pair of distinct positions.
+  func testRelinkMatchesReferenceImplementation() {
+    for n in 2 ... 5 {
+      let elements = (0 ..< n).map(String.init)
+
+      for i in 0 ..< n {
+        for j in 0 ..< n where i != j {
+          assertRelinkBefore(elements, moving: i, target: j)
+          assertRelinkAfter(elements, moving: i, target: j)
+        }
+      }
+    }
+  }
+
+  /// Asserts that relinking the element at position `i` before the one at position `j` produces
+  /// the same order as the equivalent move on a plain `Array`.
+  private func assertRelinkBefore(
+    _ elements: [String], moving i: Int, target j: Int,
+    file: StaticString = #filePath, line: UInt = #line
+  ) {
+    var s = List(elements)
+    let addresses = Array(s.addresses)
+
+    // Reference: remove the moved element, then re-insert it before the target's value.
+    var expected = elements
+    let moved = expected.remove(at: i)
+    let target = expected.firstIndex(of: elements[j])!
+    expected.insert(moved, at: target)
+
+    s.relink(addresses[i], before: addresses[j])
+
+    assertConsistent(s, equals: expected, "moving \(i) before \(j)", file: file, line: line)
+  }
+
+  /// Asserts that relinking the element at position `i` after the one at position `j` produces
+  /// the same order as the equivalent move on a plain `Array`.
+  private func assertRelinkAfter(
+    _ elements: [String], moving i: Int, target j: Int,
+    file: StaticString = #filePath, line: UInt = #line
+  ) {
+    var s = List(elements)
+    let addresses = Array(s.addresses)
+
+    // Reference: remove the moved element, then re-insert it after the target's value.
+    var expected = elements
+    let moved = expected.remove(at: i)
+    let target = expected.firstIndex(of: elements[j])!
+    expected.insert(moved, at: target + 1)
+
+    s.relink(addresses[i], after: addresses[j])
+
+    assertConsistent(s, equals: expected, "moving \(i) after \(j)", file: file, line: line)
+  }
+
+  /// Checks `relinkToStart(_:)` against a reference implementation on randomly generated lists,
+  /// moving every element in turn to the start.
+  ///
+  /// The property under test is that relinking the element at position `i` to the start yields the
+  /// same order as removing that element from a plain `Array` and re-inserting it at the front.
+  func testRelinkToStartMatchesReferenceImplementation() {
+    var rng = SplitMix64(seed: 0x5EED_CAFE)
+
+    for _ in 0 ..< 100 {
+      let elements = randomElements(maxCount: 8, using: &rng)
+      guard !elements.isEmpty else { continue }
+
+      let i = Int.random(in: 0 ..< elements.count, using: &rng)
+
+      var s = List(elements)
+
+      var expected = elements
+      let moved = expected.remove(at: i)
+      expected.insert(moved, at: 0)
+
+      let a = Array(s.addresses)[i]
+      s.relinkToStart(a)
+
+      assertConsistent(s, equals: expected, "moving \(i) to start")
+    }
+  }
+
+  /// Checks `relinkToEnd(_:)` against a reference implementation on randomly generated lists,
+  /// moving every element in turn to the end.
+  ///
+  /// The property under test is that relinking the element at position `i` to the end yields the
+  /// same order as removing that element from a plain `Array` and appending it at the back.
+  func testRelinkToEndMatchesReferenceImplementation() {
+    var rng = SplitMix64(seed: 0xC0FF_EE42)
+
+    for _ in 0 ..< 100 {
+      let elements = randomElements(maxCount: 8, using: &rng)
+      guard !elements.isEmpty else { continue }
+
+      let i = Int.random(in: 0 ..< elements.count, using: &rng)
+
+      var s = List(elements)
+
+      var expected = elements
+      let moved = expected.remove(at: i)
+      expected.append(moved)
+
+      let a = Array(s.addresses)[i]
+      s.relinkToEnd(a)
+
+      assertConsistent(s, equals: expected, "moving \(i) to end")
+    }
+  }
+
+  /// Returns a list of between `0` and `maxCount` distinct elements, drawn using `rng`.
+  private func randomElements<R: RandomNumberGenerator>(
+    maxCount: Int, using rng: inout R
+  ) -> [String] {
+    let n = Int.random(in: 0 ... maxCount, using: &rng)
+    return (0 ..< n).map(String.init)
+  }
+
+  /// Asserts that `s` holds exactly `expected` when traversed forwards, backwards, and that its
+  /// `count` agrees, so that both the `nextOffset` and `previousOffset` links are checked.
+  private func assertConsistent(
+    _ s: List<String>, equals expected: [String], _ message: String,
+    file: StaticString = #filePath, line: UInt = #line
+  ) {
+    let context = "n=\(expected.count) \(message)"
+
+    XCTAssertEqual(Array(s), expected, "forwards: \(context)", file: file, line: line)
+    XCTAssertEqual(s.count, expected.count, "count: \(context)", file: file, line: line)
+
+    // Walk the list from its tail to its head following `previousOffset` links.
+    var backwards: [String] = []
+    var address = s.lastAddress
+    while let a = address {
+      backwards.append(s[a])
+      address = s.address(before: a)
+    }
+    XCTAssertEqual(
+      backwards, Array(expected.reversed()), "backwards: \(context)", file: file, line: line)
+  }
+
+}
+
+/// A deterministic, seedable pseudo-random number generator, used to make the property-based
+/// tests reproducible.
+private struct SplitMix64: RandomNumberGenerator {
+
+  private var state: UInt64
+
+  init(seed: UInt64) {
+    self.state = seed
+  }
+
+  mutating func next() -> UInt64 {
+    state &+= 0x9E37_79B9_7F4A_7C15
+    var z = state
+    z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+    z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+    return z ^ (z >> 31)
+  }
+
 }

--- a/Tests/StableCollectionsTests/ListTests.swift
+++ b/Tests/StableCollectionsTests/ListTests.swift
@@ -116,24 +116,24 @@ final class ListTests: XCTestCase {
     XCTAssertGreaterThanOrEqual(s.capacity, 100)
   }
 
-  /// Exhaustively checks `relink(_:before:)` and `relink(_:after:)` against a reference
+  /// Exhaustively checks `move(_:before:)` and `move(_:after:)` against a reference
   /// implementation on lists of 2 to 5 elements, for every pair of distinct positions.
-  func testRelinkMatchesReferenceImplementation() {
+  func testMoveMatchesReferenceImplementation() {
     for n in 2 ... 5 {
       let elements = (0 ..< n).map(String.init)
 
       for i in 0 ..< n {
         for j in 0 ..< n where i != j {
-          assertRelinkBefore(elements, moving: i, target: j)
-          assertRelinkAfter(elements, moving: i, target: j)
+          assertMoveBefore(elements, moving: i, target: j)
+          assertMoveAfter(elements, moving: i, target: j)
         }
       }
     }
   }
 
-  /// Asserts that relinking the element at position `i` before the one at position `j` produces
+  /// Asserts that moving the element at position `i` before the one at position `j` produces
   /// the same order as the equivalent move on a plain `Array`.
-  private func assertRelinkBefore(
+  private func assertMoveBefore(
     _ elements: [String], moving i: Int, target j: Int,
     file: StaticString = #filePath, line: UInt = #line
   ) {
@@ -146,14 +146,14 @@ final class ListTests: XCTestCase {
     let target = expected.firstIndex(of: elements[j])!
     expected.insert(moved, at: target)
 
-    s.relink(addresses[i], before: addresses[j])
+    s.move(addresses[i], before: addresses[j])
 
     assertConsistent(s, equals: expected, "moving \(i) before \(j)", file: file, line: line)
   }
 
-  /// Asserts that relinking the element at position `i` after the one at position `j` produces
+  /// Asserts that moving the element at position `i` after the one at position `j` produces
   /// the same order as the equivalent move on a plain `Array`.
-  private func assertRelinkAfter(
+  private func assertMoveAfter(
     _ elements: [String], moving i: Int, target j: Int,
     file: StaticString = #filePath, line: UInt = #line
   ) {
@@ -166,17 +166,17 @@ final class ListTests: XCTestCase {
     let target = expected.firstIndex(of: elements[j])!
     expected.insert(moved, at: target + 1)
 
-    s.relink(addresses[i], after: addresses[j])
+    s.move(addresses[i], after: addresses[j])
 
     assertConsistent(s, equals: expected, "moving \(i) after \(j)", file: file, line: line)
   }
 
-  /// Checks `relinkToStart(_:)` against a reference implementation on randomly generated lists,
+  /// Checks `moveToStart(_:)` against a reference implementation on randomly generated lists,
   /// moving every element in turn to the start.
   ///
-  /// The property under test is that relinking the element at position `i` to the start yields the
+  /// The property under test is that moving the element at position `i` to the start yields the
   /// same order as removing that element from a plain `Array` and re-inserting it at the front.
-  func testRelinkToStartMatchesReferenceImplementation() {
+  func testMoveToStartMatchesReferenceImplementation() {
     var rng = SplitMix64(seed: 0x5EED_CAFE)
 
     for _ in 0 ..< 100 {
@@ -192,18 +192,18 @@ final class ListTests: XCTestCase {
       expected.insert(moved, at: 0)
 
       let a = Array(s.addresses)[i]
-      s.relinkToStart(a)
+      s.moveToStart(a)
 
       assertConsistent(s, equals: expected, "moving \(i) to start")
     }
   }
 
-  /// Checks `relinkToEnd(_:)` against a reference implementation on randomly generated lists,
+  /// Checks `moveToEnd(_:)` against a reference implementation on randomly generated lists,
   /// moving every element in turn to the end.
   ///
-  /// The property under test is that relinking the element at position `i` to the end yields the
+  /// The property under test is that moving the element at position `i` to the end yields the
   /// same order as removing that element from a plain `Array` and appending it at the back.
-  func testRelinkToEndMatchesReferenceImplementation() {
+  func testMoveToEndMatchesReferenceImplementation() {
     var rng = SplitMix64(seed: 0xC0FF_EE42)
 
     for _ in 0 ..< 100 {
@@ -219,7 +219,7 @@ final class ListTests: XCTestCase {
       expected.append(moved)
 
       let a = Array(s.addresses)[i]
-      s.relinkToEnd(a)
+      s.moveToEnd(a)
 
       assertConsistent(s, equals: expected, "moving \(i) to end")
     }


### PR DESCRIPTION
I extracted this commit out of my old while loop PR. The node relinking abstraction in `List` may be useful in the future.