### PR TITLE
Report hylo errors legibly during testing

### DIFF
--- a/Sources/Driver/CompilationError.swift
+++ b/Sources/Driver/CompilationError.swift
@@ -1,9 +1,13 @@
 import FrontEnd
 
 /// An error that occurred during compilation.
-public struct CompilationError: Error {
+public struct CompilationError: Error, CustomStringConvertible {
 
   /// The diagnostics of the error.
   public let diagnostics: DiagnosticSet
+
+  public var description: String {
+    "\(diagnostics)"
+  }
 
 }

--- a/Sources/FrontEnd/Diagnostic.swift
+++ b/Sources/FrontEnd/Diagnostic.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A diagnostic related to a region of Hylo source code.
 public struct Diagnostic: Hashable, Sendable {
 
@@ -75,11 +73,7 @@ extension Diagnostic: Comparable {
 extension Diagnostic: CustomStringConvertible {
 
   public var description: String {
-    var r = ""
-    render(
-      into: &r, showingPaths: .relative(to: FileManager.default.currentDirectoryURL),
-      style: .unstyled)
-    return r
+    "\(site.gnuStandardText()): \(level): \(message)"
   }
 
 }

--- a/Sources/FrontEnd/Diagnostic.swift
+++ b/Sources/FrontEnd/Diagnostic.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// A diagnostic related to a region of Hylo source code.
 public struct Diagnostic: Hashable, Sendable {
 
@@ -73,7 +75,11 @@ extension Diagnostic: Comparable {
 extension Diagnostic: CustomStringConvertible {
 
   public var description: String {
-    "\(site.gnuStandardText()): \(level): \(message)"
+    var r = ""
+    render(
+      into: &r, showingPaths: .relative(to: FileManager.default.currentDirectoryURL),
+      style: .unstyled)
+    return r
   }
 
 }

--- a/Sources/FrontEnd/DiagnosticSet.swift
+++ b/Sources/FrontEnd/DiagnosticSet.swift
@@ -1,4 +1,5 @@
 import OrderedCollections
+import Foundation
 
 /// A set of diagnostics.
 public struct DiagnosticSet: Hashable, Sendable, CustomStringConvertible {
@@ -34,7 +35,13 @@ public struct DiagnosticSet: Hashable, Sendable, CustomStringConvertible {
   }
 
   public var description: String {
-    "\n" + elements.lazy.map(\.description).joined(separator: "\n")
+    var r = ""
+    let cwd = FileManager.default.currentDirectoryURL
+    for x in elements {
+      r.append("\n")
+      x.render(into: &r, showingPaths: .relative(to: cwd), style: .unstyled)
+    }
+    return r
   }
 
 }

--- a/Sources/FrontEnd/DiagnosticSet.swift
+++ b/Sources/FrontEnd/DiagnosticSet.swift
@@ -1,7 +1,7 @@
 import OrderedCollections
 
 /// A set of diagnostics.
-public struct DiagnosticSet: Hashable, Sendable {
+public struct DiagnosticSet: Hashable, Sendable, CustomStringConvertible {
 
   /// The diagnostics in the set.
   public private(set) var elements: OrderedSet<Diagnostic>
@@ -31,6 +31,10 @@ public struct DiagnosticSet: Hashable, Sendable {
   public init<S: Sequence<Diagnostic>>(_ ds: S) {
     self.init()
     for d in ds { insert(d) }
+  }
+
+  public var description: String {
+    "\n" + elements.lazy.map(\.description).joined(separator: "\n")
   }
 
 }

--- a/Tests/CompilerTests/DriverTests.swift
+++ b/Tests/CompilerTests/DriverTests.swift
@@ -1,6 +1,7 @@
-import Driver
+@testable import Driver
 import SwiftyLLVM
 import XCTest
+import FrontEnd
 
 final class DriverTests: XCTestCase {
 
@@ -70,6 +71,28 @@ final class DriverTests: XCTestCase {
         }
       }
     }
+  }
+
+}
+
+final class CompilationErrorTests: XCTestCase {
+
+  func testStringRepresentation() {
+    let f: SourceFile = "Hello."
+    let s = SourceSpan(f.startIndex ..< f.index(f.startIndex, offsetBy: 2), in: f)
+    let e = Diagnostic(.error, "bang", at: s)
+    let c = CompilationError(diagnostics: DiagnosticSet(CollectionOfOne(e)))
+
+    XCTAssertEqual(
+      "\(c)",
+      """
+
+      virtual:///1ssiyy33rbj6z:1.1-3: error: bang
+      Hello.
+      ~~
+
+      """)
+
   }
 
 }

--- a/Tests/FrontEndTests/DiagnosticSetTest.swift
+++ b/Tests/FrontEndTests/DiagnosticSetTest.swift
@@ -33,7 +33,7 @@ final class DiagnosticSetTests: XCTestCase {
     XCTAssertEqual(
       "\(d)",
       """
-
+      
       virtual:///1ssiyy33rbj6z:1.1-3: error: bang
       Hello.
       ~~

--- a/Tests/FrontEndTests/DiagnosticSetTest.swift
+++ b/Tests/FrontEndTests/DiagnosticSetTest.swift
@@ -24,4 +24,21 @@ final class DiagnosticSetTests: XCTestCase {
     XCTAssertEqual(log.elements.count, 3)
   }
 
+  func testStringRepresentation() {
+    let f: SourceFile = "Hello."
+    let s = SourceSpan(f.startIndex ..< f.index(f.startIndex, offsetBy: 2), in: f)
+    let e = Diagnostic(.error, "bang", at: s)
+    let d = DiagnosticSet(CollectionOfOne(e))
+
+    XCTAssertEqual(
+      "\(d)",
+      """
+
+      virtual:///1ssiyy33rbj6z:1.1-3: error: bang
+      Hello.
+      ~~
+
+      """)
+  }
+
 }


### PR DESCRIPTION
That the errors come out looking like compiler output matters both for humans and for tools.