### PR TITLE
Fix the insertion of deinitialization in custom deinitializers

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -72,7 +72,7 @@ internal struct IREmitter {
 
       // Is the receiver an instance of a struct or enum?
       else if let d = me.program.declaration(whereStructOrEnum: receiver) {
-        me._emitDeinitializeStructurally(whole: .parameter(1), instanceOf: d, instantiatedWith: a)
+        me._emitDeinitializeMemberwise(.parameter(1), instanceOf: d, instantiatedWith: a)
       }
 
       // Give up if it's none of the above.
@@ -94,6 +94,8 @@ internal struct IREmitter {
   /// Generates the IR of `d`.
   private mutating func lower(_ d: DeclarationIdentity) {
     switch program.tag(of: d) {
+    case AssociatedTypeDeclaration.self:
+      break
     case BindingDeclaration.self:
       lower(program.castUnchecked(d, to: BindingDeclaration.self))
     case ConformanceDeclaration.self:
@@ -114,6 +116,8 @@ internal struct IREmitter {
       lower(program.castUnchecked(d, to: StructDeclaration.self))
     case TraitDeclaration.self:
       lower(program.castUnchecked(d, to: TraitDeclaration.self))
+    case TypeAliasDeclaration.self:
+      break
     case VariableDeclaration.self:
       break
     default:
@@ -1645,16 +1649,16 @@ internal struct IREmitter {
       // If `d` is a trait requirement, the trait receiver comes next.
       if let c = program.traitRequiring(d) {
         let t = program.withTyper(typing: c.module, { (tp) in tp.typeOfTraitSelf(in: c) })
-        let u = program.types.dealiased(t)
-        let v = program.types.substitute(substitutions, in: u)
+        let u = program.types.substitute(substitutions, in: t)
+        let v = program.types.dealiased(u)
         terms.append(IRParameter(type: v, access: .let, declaration: nil))
       }
 
       // Explicit parameters come next.
       for p in parameters.explicit {
         let t = program.type(assignedTo: p, assuming: RemoteType.self)
-        let u = program.types.dealiased(program.types[t].projectee)
-        let v = program.types.substitute(substitutions, in: u)
+        let u = program.types.substitute(substitutions, in: program.types[t].projectee)
+        let v = program.types.dealiased(u)
         let k = program.types[t].access.unlessAuto(program.types[shape].effect)
         assert((k != .auto) || program.tag(of: d) == FunctionBundleDeclaration.self)
         terms.append(IRParameter(type: v, access: k, declaration: .init(p)))
@@ -1663,8 +1667,8 @@ internal struct IREmitter {
 
     // Return register comes last.
     let r = program.types.resultOfApplying(typeOfDeclaration.head, mutably: usedMutably)!
-    let s = program.types.dealiased(r)
-    let t = program.types.substitute(substitutions, in: s)
+    let s = program.types.substitute(substitutions, in: r)
+    let t = program.types.dealiased(s)
     if program.types[shape].style == .parenthesized {
       terms.append(IRParameter(type: t, access: .set, declaration: nil))
       return (terms, .indirect)
@@ -2592,7 +2596,7 @@ internal struct IREmitter {
     _end(IRAccess.self, openedBy: x0)
   }
 
-  /// Generates the for initializing `target` with an instance of the enum case declared by `d`.
+  /// Generates the IR initializing `target` with an instance of the enum case declared by `d`.
   private mutating func _emitInitialize(
     _ target: IRValue, withConstantCase d: EnumCaseDeclaration.ID
   ) {
@@ -2601,34 +2605,57 @@ internal struct IREmitter {
     _assume_state(x0, initialized: true)
   }
 
-  /// Generates the IR for deinitializing `source` and returns `true` iff `source` or its parts can
-  /// be deinitialized. Otherwise, inserts a trap and returns `false`.
+  /// Generates the IR deinitializing `s` and returns `true` iff `s` is deinitializable; otherwise,
+  /// inserts a trap and returns `false`.
   ///
-  /// If `s` is instance of a structural type (e.g., a tuple), the method attempts to deinitialize
-  /// each part inidividually rather than the whole. Otherwise, deinitialization is done using a
-  /// witness of `Deinitializable`.
+  /// This method deinitializes values in one of two ways, thereafter referred to as "whole" and
+  /// "memberwise" deinitialization. The former applies the implementation of `deinit` defined by
+  /// the whole's conformance to `Hylo.Deinitializable`. The latter consists of deinitializing each
+  /// part of the whole individually. It applies only if `s` is instance of a structural type or if
+  /// `s` is instance of a struct or enum and this method is used to deinitialize it implicitly at
+  /// the end of a custom deinitializer. The following illustrates:
+  ///
+  ///     struct S is Deinitializable {
+  ///       var x: T[]
+  ///       fun deinit() sink { print("Au revoir!") }
+  ///     }
+  ///
+  /// In the above example, the compiler will call `_emitDeinitialize(_:)` while processing the IR
+  /// of the custom deinitializer, which will insert memberwise deinitialization.
+  ///
+  /// This method returns `true` iff `s` could be deinitialized, in which case `s` is fully
+  /// fully deinitialized immediately after the last instruction inserted. Otherwise, the method
+  /// inserts a trap and returns `false`. In either case, all generated IR is refined and the
+  /// control-flow graph of the function is not modified.
   @discardableResult
-  internal mutating func _emitDeinitialize(_ source: IRValue) -> Bool {
-    let (t, _) = currentFunction.result(of: source) ?? badOperand()
-    return _emitDeinitialize(source, instanceOf: t)
+  internal mutating func _emitDeinitialize(_ s: IRValue) -> Bool {
+    let (t, _) = currentFunction.result(of: s) ?? badOperand()
+    return _emitDeinitialize(s, instanceOf: t)
   }
 
-  /// Implements `_emitDeinitialize(_:)` for arbitrary types.
+  /// Generates the IR deinitializing `s`, which is an instance of `t`, and returns `true` iff `s`
+  /// is deinitializable; otherwise, inserts a trap and returns `false`.
+  ///
+  /// This method implements the specification of `_emitDeinitialize(_:)`, using `t` to determine
+  /// whether it should apply membewise initialization or find an instance of `Deinitializable`.
   private mutating func _emitDeinitialize(
     _ s: IRValue, instanceOf t: AnyTypeIdentity
   ) -> Bool {
     switch program.types.tag(of: t) {
     case Tuple.self:
       let u = program.types.castUnchecked(t, to: Tuple.self)
-      return _emitDeinitialize(tuple: s, instanceOf: u)
+      return _emitDeinitializeMemberwise(s, instanceOf: u)
     default:
-      return _emitDeinitialize(whole: s, instanceOf: t)
+      return _emitDeinitializeWhole(s, instanceOf: t)
     }
   }
 
-  /// Implements `_emitDeinitialize(_:)` for types that cannot be decomposed structurally.
-  private mutating func _emitDeinitialize(
-    whole: IRValue, instanceOf t: AnyTypeIdentity
+  /// Generates the IR deinitializing `s`, which is an instance of `t`, and returns `true` iff `s`
+  /// is deinitializable; otherwise, inserts a trap and returns `false`.
+  ///
+  /// This method implements parts of `_emitDeinitialize(_:)`, covering whole deinitialization.
+  private mutating func _emitDeinitializeWhole(
+    _ s: IRValue, instanceOf t: AnyTypeIdentity
   ) -> Bool {
     switch witnessOfDeinitializable(for: t) {
     case .none:
@@ -2636,23 +2663,25 @@ internal struct IREmitter {
       return false
 
     case .trivial:
-      _assume_state(whole, initialized: false)
+      _assume_state(s, initialized: false)
       return true
 
     case .nontrivial(let w):
       let r = program.standardLibraryDeclaration(.deinitializableDeinit)
 
       // Can we dispatch statically?
-      if let implementation = program.implementation(of: r, in: w) {
+      if let (conformance, implementation) = program.implementation(of: r, in: w) {
         // Make sure we're not applying the function being lowered recursively, which may happen
         // if `s` is the receiver of a function implementing `Deinitializable.deinit` for the
         // witness that's been resolved.
         if let j = implementation.target, currentFunction.name.isLoweredForm(of: j) {
           // Use memberwise deinitialization for structs and enums, so that one can write a custom
           // deinitializer that does not have to explicitly consume its receiver.
-          let (x, a) = program.types.seenAsBaseTypeApplication(t)
-          if let base = program.declaration(whereStructOrEnum: x) {
-            _emitDeinitializeStructurally(whole: whole, instanceOf: base, instantiatedWith: a)
+          let (x, _) = program.types.seenAsBaseTypeApplication(t)
+          if program.declaration(whereStructOrEnum: x) != nil {
+            _emitDeinitializeWhole(
+              structOrEnum: s, instanceOf: t,
+              applyingDeinitializerSynthesizedFor: w, declaredBy: conformance)
             return true
           }
 
@@ -2675,35 +2704,82 @@ internal struct IREmitter {
           let f = loweredCallee(
             implementation, qualifiedBy: nil, markedForMutationBy: nil,
             output: o, at: currentAnchor)
-          let xs = Array(whole, prependedTo: f.arguments)
+          let xs = Array(s, prependedTo: f.arguments)
           _ = _apply(f.value, xs, into: f.result, afterFormingAccesses: true)
           return true
         }
       }
 
       // Emit a call to the witness.
-      let deinitializable = _emit(witness: w)
-      let t0 = program.types.demand(
-        Arrow(inputs: [.init(access: .sink, type: t)], output: .void))
-
-      let x0 = _alloca(.void)
-      let x1 = _access([.sink], from: whole)
-      let x2 = _access([.set], from: x0)
-      let x3 = _property(r, of: deinitializable, withType: t0.erased)
-      let x4 = _access([.let], from: x3)
-
-      _ = _apply(x4, [x1], into: x2, afterFormingAccesses: false)
-
-      _end(IRAccess.self, openedBy: x4)
-      _end(IRAccess.self, openedBy: x2)
-      _end(IRAccess.self, openedBy: x1)
-
+      _emitDeinitializeWhole(s, instanceOf: t, usingNonTrivialConformance: w)
       return true
     }
   }
 
-  /// Implements `_emitDeinitialize(_:)` for tuples.
-  private mutating func _emitDeinitialize(tuple s: IRValue, instanceOf t: Tuple.ID) -> Bool {
+  /// Generates the IR deinitializing `s`, which is an instance of `t`, using the conformance to
+  /// `Deinitializable` expressed by `w`.
+  private mutating func _emitDeinitializeWhole(
+    _ s: IRValue, instanceOf t: AnyTypeIdentity, usingNonTrivialConformance w: WitnessExpression
+  ) {
+    let requirement = program.standardLibraryDeclaration(.deinitializableDeinit)
+    let table = _emit(witness: w)
+    let t0 = program.types.demand(
+      Arrow(inputs: [.init(access: .sink, type: t)], output: .void))
+
+    let x0 = _alloca(.void)
+    let x1 = _access([.sink], from: s)
+    let x2 = _access([.set], from: x0)
+    let x3 = _property(requirement, of: table, withType: t0.erased)
+    let x4 = _access([.let], from: x3)
+
+    _ = _apply(x4, [x1], into: x2, afterFormingAccesses: false)
+
+    _end(IRAccess.self, openedBy: x4)
+    _end(IRAccess.self, openedBy: x2)
+    _end(IRAccess.self, openedBy: x1)
+  }
+
+  /// Generates the IR deinitializing `s`, which is an instance of `t`, generating and applying a
+  /// synthesized memberwise deinitializer associated with the conformance witnessed by `w` and
+  /// declared by `conformance`.
+  private mutating func _emitDeinitializeWhole(
+    structOrEnum s: IRValue, instanceOf t: AnyTypeIdentity,
+    applyingDeinitializerSynthesizedFor w: WitnessExpression,
+    declaredBy conformance: ConformanceDeclaration.ID
+  ) {
+    let requirement = program.standardLibraryDeclaration(.deinitializableDeinit)
+    let receiver = program.withTyper(typing: module) { (tp) in
+      tp.typeOfSelf(in: .init(uncheckedFrom: requirement.erased))!
+    }
+
+    let a = TypeArguments.init(
+      mapping: [program.types.castUnchecked(receiver, to: GenericParameter.self)], to: [t])
+    let f = demandLoweredDeclaration(
+      implementationOf: requirement, synthesized: true, for: conformance, a)
+    implementSynthesizedDeinitializer(f, for: a)
+
+    let x0 = functionReference(to: f)
+    let x1 = _emit(witness: w)
+    let x2 = _alloca(.void)
+    let x3 = _access([.let], from: x1)
+    let x4 = _access([.sink], from: s)
+    let x5 = _access([.set], from: x2)
+
+    _ = _apply(x0, [x3, x4], into: x5, afterFormingAccesses: false)
+
+    _end(IRAccess.self, openedBy: x5)
+    _end(IRAccess.self, openedBy: x4)
+    _end(IRAccess.self, openedBy: x3)
+  }
+
+  /// Generates the IR deinitializing `s`, which is an instance of `t`, and returns `true` iff each
+  /// individual part of `s` is deinitializable; otherwise, inserts a trap and returns `false`.
+  ///
+  /// This method implements part of `_emitDeinitialize(_:)`, covering memberwise deinitialization
+  /// for instances of tuples.
+  private mutating func _emitDeinitializeMemberwise(
+    _ s: IRValue, instanceOf t: Tuple.ID
+  ) -> Bool {
     // Is the tuple empty?
     let (ms, _) = program.types.members(of: t)
     if ms.isEmpty {
@@ -2719,31 +2795,29 @@ internal struct IREmitter {
     return true
   }
 
-  /// Generates the IR for deinitializing each individual part of `whole`, which is an instance of
-  /// the type declared by `d` whose type parameters are assigned in `a`.
-  private mutating func _emitDeinitializeStructurally(
-    whole: IRValue, instanceOf d: DeclarationIdentity, instantiatedWith a: TypeArguments
+  /// Generates the IR deinitializing each individual part of `s`, which is an instance of the type
+  /// declared by `d` whose type parameters are assigned in `a`.
+  private mutating func _emitDeinitializeMemberwise(
+    _ s: IRValue, instanceOf d: DeclarationIdentity, instantiatedWith a: TypeArguments
   ) {
     switch program.tag(of: d) {
     case StructDeclaration.self:
-      _emitDeinitializeStructurally(
-        whole: whole,
-        instanceOf: program.castUnchecked(d, to: StructDeclaration.self), instantiatedWith: a)
+      _emitDeinitializeMemberwise(
+        s, instanceOf: program.castUnchecked(d, to: StructDeclaration.self), instantiatedWith: a)
 
     case EnumDeclaration.self:
-      _emitDeinitializeStructurally(
-        whole: whole,
-        instanceOf: program.castUnchecked(d, to: EnumDeclaration.self), instantiatedWith: a)
+      _emitDeinitializeMemberwise(
+        s, instanceOf: program.castUnchecked(d, to: EnumDeclaration.self), instantiatedWith: a)
 
     default:
       program.unexpected(d)
     }
   }
 
-  /// Generates the IR for deinitializing each individual part of `whole`, which is an instance of
-  /// the type declared by `d` whose type parameters are assigned in `a`.
-  private mutating func _emitDeinitializeStructurally(
-    whole: IRValue, instanceOf d: StructDeclaration.ID, instantiatedWith a: TypeArguments
+  /// Generates the IR deinitializing each individual part of `s`, which is an instance of the type
+  /// declared by `d` whose type parameters are assigned in `a`.
+  private mutating func _emitDeinitializeMemberwise(
+    _ s: IRValue, instanceOf d: StructDeclaration.ID, instantiatedWith a: TypeArguments
   ) {
     var properties: [AnyTypeIdentity] = []
     program.forEachStoredProperty(of: d) { (m, _) in
@@ -2752,26 +2826,26 @@ internal struct IREmitter {
       properties.append(program.types.dealiased(u))
     }
     let t = program.types.tuple(of: properties)
-    let x = _place_cast(whole, as: .sink, t)
+    let x = _place_cast(s, as: .sink, t)
     _ = _emitDeinitialize(x, instanceOf: t)
   }
 
-  /// Generates the IR for deinitializing each individual part of `whole`, which is an instance of
-  /// the type declared by `d` whose type parameters are assigned in `a`.
-  private mutating func _emitDeinitializeStructurally(
-    whole: IRValue, instanceOf d: EnumDeclaration.ID, instantiatedWith a: TypeArguments
+  /// Generates the IR deinitializing each individual part of `s`, which is an instance of the type
+  /// declared by `d` whose type parameters are assigned in `a`.
+  private mutating func _emitDeinitializeMemberwise(
+    _ s: IRValue, instanceOf d: EnumDeclaration.ID, instantiatedWith a: TypeArguments
   ) {
     assert(program[d].representation == nil)
     let cases = Array(program.collect(EnumCaseDeclaration.self, in: program[d].members))
     let successors = cases.map({ _ in _addBlock() })
     let end = _addBlock()
 
-    let tag = _enum_tag(whole)
+    let tag = _enum_tag(s)
     _switch(on: tag, to: successors)
     for i in successors.indices {
       insertionContext.point = .end(of: successors[i])
       let t = program.withTyper(typing: module, { (tp) in tp.underlyingType(of: cases[i]) })
-      let x = _case(cases[i], of: whole)
+      let x = _case(cases[i], of: s)
       let y = _place_cast(x, as: .sink, t)
       _ = _emitDeinitialize(y, instanceOf: t)
       _br(end)

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -71,7 +71,7 @@ internal struct IREmitter {
       }
 
       // Is the receiver an instance of a struct or enum?
-      else if let d = me.program.declaration(of: receiver) {
+      else if let d = me.program.declaration(whereStructOrEnum: receiver) {
         me._emitDeinitializeStructurally(whole: .parameter(1), instanceOf: d, instantiatedWith: a)
       }
 
@@ -2643,13 +2643,21 @@ internal struct IREmitter {
       let r = program.standardLibraryDeclaration(.deinitializableDeinit)
 
       // Can we dispatch statically?
-      if let d = w.declaration, let c = program.cast(d, to: ConformanceDeclaration.self) {
-        let table = program.implementations(definedBy: c)
-        if let implementation = table.member(implementing: r) {
-          // Make sure we're not applying the function being lowered recursively, which may happen
-          // if `s` is the receiver of a function implementing `Deinitializable.deinit` for the
-          // witness that's been resolved.
-          if let j = implementation.target, currentFunction.name.isLoweredForm(of: j) {
+      if let implementation = program.implementation(of: r, in: w) {
+        // Make sure we're not applying the function being lowered recursively, which may happen
+        // if `s` is the receiver of a function implementing `Deinitializable.deinit` for the
+        // witness that's been resolved.
+        if let j = implementation.target, currentFunction.name.isLoweredForm(of: j) {
+          // Use memberwise deinitialization for structs and enums, so that one can write a custom
+          // deinitializer that does not have to explicitly consume its receiver.
+          let (x, a) = program.types.seenAsBaseTypeApplication(t)
+          if let base = program.declaration(whereStructOrEnum: x) {
+            _emitDeinitializeStructurally(whole: whole, instanceOf: base, instantiatedWith: a)
+            return true
+          }
+
+          // In other cases, complain about infinite recursion.
+          else {
             let m = """
               implicit deinitialization of instances of '\(program.show(t))' causes infinite \
               recursion in this context
@@ -2657,15 +2665,19 @@ internal struct IREmitter {
             report(.init(.error, m, at: currentAnchor.site))
             _ = _apply_builtin(.trap, to: [])
             return false
-          } else if !implementation.isSynthetic {
-            let o = _alloca(.void)
-            let f = loweredCallee(
-              implementation, qualifiedBy: nil, markedForMutationBy: nil,
-              output: o, at: currentAnchor)
-            let xs = Array(whole, prependedTo: f.arguments)
-            _ = _apply(f.value, xs, into: f.result, afterFormingAccesses: true)
-            return true
           }
+        }
+
+        // Otherwise, if the implementation is not synthetic, we can apply it directly without
+        // constructing a witness table.
+        else if !implementation.isSynthetic {
+          let o = _alloca(.void)
+          let f = loweredCallee(
+            implementation, qualifiedBy: nil, markedForMutationBy: nil,
+            output: o, at: currentAnchor)
+          let xs = Array(whole, prependedTo: f.arguments)
+          _ = _apply(f.value, xs, into: f.result, afterFormingAccesses: true)
+          return true
         }
       }
 

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -870,7 +870,7 @@ extension IRFunction.Name: Showable {
 
     case .synthesized(let d, let a):
       let xs = a.elements.map({ (p, v) in "\(printer.show(p)): \(printer.show(v))" })
-      return "\(printer.program.debugName(of: d))<\(list: xs)>"
+      return "\(printer.program.debugName(of: d))$synthesized<\(list: xs)>"
 
     case .implementation(let d, _, let a):
       let xs = a.elements.map({ (p, v) in "\(printer.show(p)): \(printer.show(v))" })

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -918,6 +918,24 @@ public struct Program: Sendable {
     self[d.module].implementations(definedBy: d) ?? unreachable("untyped node at \(self[d].site)")
   }
 
+  /// If `witness` expresses the application of a closed and concrete conformance declaration,
+  /// returns the implementation of `requirement` for that conformance; otherwise, returns `nil`.
+  ///
+  /// `requirement` is the declaration of a requirement of the trait whose conformance is being
+  /// witnessed by the value computed by `witness`. The result is non-`nil` iff `witness` is an
+  /// application of a concrete conformance declaration that does not capture any local binding.
+  ///
+  /// - Requires: The module containing `d` is typed.
+  public func implementation(
+    of requirement: DeclarationIdentity, in witness: WitnessExpression
+  ) -> DeclarationReference? {
+    if let d = witness.declaration, let c = cast(d, to: ConformanceDeclaration.self) {
+      return implementations(definedBy: c).member(implementing: requirement)
+    } else {
+      return nil
+    }
+  }
+
   /// If `n` is a requirement, returns the traits that introduces it. Otherwise, returns `nil`.
   ///
   /// - Requires: The module containing `n` is scoped.
@@ -1085,13 +1103,30 @@ public struct Program: Sendable {
     return self[d.file].variableToBinding[d.offset]
   }
 
-  /// Returns the declaration of the type of which `t` is an instance, if any.
+  /// Returns the declaration of the base type of `t` iff that is a struct or enum.
+  public func declaration(whereStructOrEnum t: AnyTypeIdentity) -> DeclarationIdentity? {
+    guard let d = declaration(of: t) else { return nil }
+    switch tag(of: d) {
+    case StructDeclaration.self, EnumDeclaration.self:
+      return d
+    default:
+      return nil
+    }
+  }
+
+  /// Returns the declaration of the base type of `t`, if any.
   public func declaration(of t: AnyTypeIdentity) -> DeclarationIdentity? {
     switch types.tag(of: t) {
+    case AssociatedType.self:
+      return .init(types[types.castUnchecked(t, to: AssociatedType.self)].declaration)
     case Enum.self:
       return .init(types[types.castUnchecked(t, to: Enum.self)].declaration)
+    case GenericParameter.self:
+      return declaration(of: types.castUnchecked(t, to: GenericParameter.self))
     case Struct.self:
       return .init(types[types.castUnchecked(t, to: Struct.self)].declaration)
+    case Trait.self:
+      return .init(types[types.castUnchecked(t, to: Trait.self)].declaration)
     case TypeAlias.self:
       return declaration(of: types[types.castUnchecked(t, to: TypeAlias.self)].aliasee)
     case TypeApplication.self:
@@ -1099,6 +1134,11 @@ public struct Program: Sendable {
     default:
       return nil
     }
+  }
+
+  /// Returns the declaration of the type of which `t` is an instance, if any.
+  public func declaration(of t: GenericParameter.ID) -> DeclarationIdentity? {
+    types[t].declaration.map(DeclarationIdentity.init(_:))
   }
 
   /// Returns the types of stored parts of `t` iff its layout is visible from `module`.

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -918,8 +918,8 @@ public struct Program: Sendable {
     self[d.module].implementations(definedBy: d) ?? unreachable("untyped node at \(self[d].site)")
   }
 
-  /// If `witness` expresses the application of a closed and concrete conformance declaration,
-  /// returns the implementation of `requirement` for that conformance; otherwise, returns `nil`.
+  /// If `witness` expresses the application of some closed and concrete conformance declaration,
+  /// returns that conformance along with its implementation of `requirement`.
   ///
   /// `requirement` is the declaration of a requirement of the trait whose conformance is being
   /// witnessed by the value computed by `witness`. The result is non-`nil` iff `witness` is an
@@ -928,9 +928,9 @@ public struct Program: Sendable {
   /// - Requires: The module containing `d` is typed.
   public func implementation(
     of requirement: DeclarationIdentity, in witness: WitnessExpression
-  ) -> DeclarationReference? {
+  ) -> (ConformanceDeclaration.ID, DeclarationReference)? {
     if let d = witness.declaration, let c = cast(d, to: ConformanceDeclaration.self) {
-      return implementations(definedBy: c).member(implementing: requirement)
+      return implementations(definedBy: c).member(implementing: requirement).map({ (m) in (c, m) })
     } else {
       return nil
     }

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -3084,7 +3084,7 @@ public struct Typer {
 
   /// Returns the type of an instance of `Self` in `s`, or `nil` if `s` isn't notionally in the
   /// scope of a type declaration.
-  private mutating func typeOfSelf(in s: ScopeIdentity) -> AnyTypeIdentity? {
+  internal mutating func typeOfSelf(in s: ScopeIdentity) -> AnyTypeIdentity? {
     if let memoized = cache.scopeToTypeOfSelf[s] { return memoized }
 
     guard let n = s.node else { return nil }

--- a/Sources/FrontEnd/Types/TypeStore.swift
+++ b/Sources/FrontEnd/Types/TypeStore.swift
@@ -498,6 +498,27 @@ public struct TypeStore: Sendable {
     }
   }
 
+  /// If `n` is a type application or an alias thereof, returns its abstraction and arguments,
+  /// otherwise, returns `n` along with an empty set of type parameter assignments.
+  public func seenAsBaseTypeApplication<T: TypeIdentity>(
+    _ n: T
+  ) -> (base: AnyTypeIdentity, arguments: TypeArguments) {
+    var base = n.erased
+    var arguments = TypeArguments()
+    while true {
+      if let t = cast(base, to: TypeApplication.self) {
+        base = self[t].abstraction
+        arguments = self[t].arguments.mapValues { (u) in
+          cast(u, to: GenericParameter.self).flatMap({ (p) in arguments[p] }) ?? u
+        }
+      } else if let t = cast(base, to: TypeAlias.self) {
+        base = self[t].aliasee
+      } else {
+        return (base, arguments)
+      }
+    }
+  }
+
   /// Returns `[Void](A...) -> T)` iff `n` has the form `[Void](self: set T, A...) -> Void`.
   public mutating func asConstructor(_ n: AnyTypeIdentity) -> AnyTypeIdentity? {
     let (c, h) = contextAndHead(n.erased)

--- a/Tests/CompilerTests/negative/recursive-implicit-deinit.diagnostics.expected
+++ b/Tests/CompilerTests/negative/recursive-implicit-deinit.diagnostics.expected
@@ -1,3 +1,3 @@
-negative/recursive-implicit-deinit.hylo:4.22: error: implicit deinitialization of instances of 'S' causes infinite recursion in this context
-  fun deinit() sink {}
-                     ^
+negative/recursive-implicit-deinit.hylo:12.24: error: implicit deinitialization of instances of 'T' causes infinite recursion in this context
+    fun deinit() sink {}
+                       ^

--- a/Tests/CompilerTests/negative/recursive-implicit-deinit.diagnostics.expected
+++ b/Tests/CompilerTests/negative/recursive-implicit-deinit.diagnostics.expected
@@ -1,3 +1,6 @@
-negative/recursive-implicit-deinit.hylo:12.24: error: implicit deinitialization of instances of 'T' causes infinite recursion in this context
-    fun deinit() sink {}
-                       ^
+negative/recursive-implicit-deinit.hylo:27.53: error: implicit deinitialization of instances of '(Self::P).A' causes infinite recursion in this context
+    given A is Deinitializable { fun deinit() sink {} }
+                                                    ^
+negative/recursive-implicit-deinit.hylo:33.51: error: implicit deinitialization of instances of 'T' causes infinite recursion in this context
+  given A is Deinitializable { fun deinit() sink {} }
+                                                  ^

--- a/Tests/CompilerTests/negative/recursive-implicit-deinit.hylo
+++ b/Tests/CompilerTests/negative/recursive-implicit-deinit.hylo
@@ -1,18 +1,34 @@
+// Structs and enums can define a custom deinitializer that does not actually consume any property
+// at the user level. In this case the compiler treats `self` like a tuple and emits memberwise
+// deinitialization at the end of the scope, thus avoiding infinite recursion.
+
 struct S is Deinitializable {
   let x: Int
-  memberwise init
-  fun deinit() sink {
-    // The compiler treats `self` like a tuple and emits memberwise deinitialization to avoid
-    // infinite recursion.
+  fun deinit() sink {}
+}
+
+enum E is Deinitializable {
+  case a(x: Int)
+  case b(x: Bool)
+  fun deinit() sink {}
+}
+
+// The deinitialization of tuples is always structural. Custom initializers are never applied.
+
+given {S, S} is Deinitializable {
+  fun deinit() sink {}
+}
+
+// The following types have no memberwise deinitialization.
+
+trait P {
+  type A
+  fun foo() {
+    given A is Deinitializable { fun deinit() sink {} }
   }
 }
 
 public fun foo<T>() {
-  given T is Deinitializable {
-    fun deinit() sink {}
-  }
-}
-
-public fun main() {
-  _ = S(x: 1)
+  type A = T
+  given A is Deinitializable { fun deinit() sink {} }
 }

--- a/Tests/CompilerTests/negative/recursive-implicit-deinit.hylo
+++ b/Tests/CompilerTests/negative/recursive-implicit-deinit.hylo
@@ -1,7 +1,16 @@
 struct S is Deinitializable {
   let x: Int
   memberwise init
-  fun deinit() sink {}
+  fun deinit() sink {
+    // The compiler treats `self` like a tuple and emits memberwise deinitialization to avoid
+    // infinite recursion.
+  }
+}
+
+public fun foo<T>() {
+  given T is Deinitializable {
+    fun deinit() sink {}
+  }
 }
 
 public fun main() {

--- a/Tests/CompilerTests/positive/synthesized-deinit.hylo
+++ b/Tests/CompilerTests/positive/synthesized-deinit.hylo
@@ -1,19 +1,39 @@
 //! stage:lowering
 
 // `S0` has a user-defined deinitializer, meaning that it is not trivially deinitializable.
-// `S1` has a synthesized deinitializer, which is no-op.
-// `S2` has a synthesized deinitializer, which deinitializes each property individually.
+// `S1` has a user-defined deinitializer that delegates to memberwise deinitialization.
+// `S2` has a synthesized deinitializer that is no-op.
+// `S3` has a synthesized deinitializer that deinitializes each property individually.
 
 struct S0 is Deinitializable {
   var i: Int
   fun deinit() sink { _ = self.i }
 }
 
-struct S1 is Deinitializable {}
+struct S1 is Deinitializable {
+  fun deinit() sink {}
+}
 
-struct S2 is Deinitializable {
+struct S2 is Deinitializable {}
+
+struct S3 is Deinitializable {
   let i: Int
   let r: {S0, S1}
+}
+
+// Enums behave similarly as structs.
+
+enum E0 is Deinitializable {
+  case a(i: Int)
+  case b(i: Int)
+  fun deinit() sink {}
+}
+
+enum E2 is Deinitializable {}
+
+enum E3 is Deinitializable {
+  case a(i: S0)
+  case b(i: S1)
 }
 
 public fun main() {}

--- a/Tests/CompilerTests/positive/synthesized-deinit.refined-ir.expected
+++ b/Tests/CompilerTests/positive/synthesized-deinit.refined-ir.expected
@@ -1,5 +1,4 @@
-
-fun S0.$<ConformanceDeclaration at synthesized-deinit:7.14>() let <: Deinitializable<S0> {
+fun S0.$<ConformanceDeclaration at synthesized-deinit:8.14>() let <: Deinitializable<S0> {
 %b0:
   %r0 = alloca Deinitializable<S0>, #preferred
   %r1 = witnesstable {Deinitializable.deinit<Self: S0>} as Deinitializable<S0>
@@ -37,7 +36,7 @@ fun S0.deinit(sink %p0: S0, set %p1: Void) {
   %r7 = return
 }
 
-fun S1.$<ConformanceDeclaration at synthesized-deinit:12.14>() let <: Deinitializable<S1> {
+fun S1.$<ConformanceDeclaration at synthesized-deinit:13.14>() let <: Deinitializable<S1> {
 %b0:
   %r0 = alloca Deinitializable<S1>, #preferred
   %r1 = witnesstable {Deinitializable.deinit<Self: S1>} as Deinitializable<S1>
@@ -56,18 +55,47 @@ fun S1.$<ConformanceDeclaration at synthesized-deinit:12.14>() let <: Deinitiali
 fun Deinitializable.deinit<Self: S1>(let %p0: Deinitializable<S1>, sink %p1: S1, set %p2: Void) {
 %b0:
   %r0 = access [sink] %p1
-  %r1 = assume_state %r0 uninitialized
-  %r2 = end %r0
-  %r3 = access [set] %p2
-  %r4 = assume_state %r3 initialized
-  %r5 = end %r3
-  %r6 = return
+  %r1 = access [set] %p2
+  %r2 = apply S1.deinit(%r0) => %r1
+  %r5 = end %r1
+  %r4 = end %r0
+  %r3 = return
 }
 
-fun S2.$<ConformanceDeclaration at synthesized-deinit:14.14>() let <: Deinitializable<S2> {
+fun S1.deinit(sink %p0: S1, set %p1: Void) {
+%b0:
+  %r0 = access [set] %p1
+  %r1 = assume_state %r0 initialized
+  %r2 = end %r0
+  %r4 = project S1.$<ConformanceDeclaration at synthesized-deinit:13.14>[]
+  %r5 = alloca Void, #preferred
+  %r6 = access [let] %r4
+  %r7 = access [sink] %p0
+  %r8 = access [set] %r5
+  %r9 = apply Deinitializable.deinit$synthesized<Self: S1>(%r6, %r7) => %r8
+  %r10 = end %r8
+  %r11 = end %r7
+  %r12 = end %r6
+  %r13 = end %r4
+  %r3 = return
+}
+
+fun Deinitializable.deinit$synthesized<Self: S1>(let %p0: Deinitializable<S1>, sink %p1: S1, set %p2: Void) {
+%b0:
+  %r0 = place_cast %p1 as sink Void
+  %r1 = access [sink] %r0
+  %r2 = assume_state %r1 uninitialized
+  %r3 = end %r1
+  %r4 = access [set] %p2
+  %r5 = assume_state %r4 initialized
+  %r6 = end %r4
+  %r7 = return
+}
+
+fun S2.$<ConformanceDeclaration at synthesized-deinit:17.14>() let <: Deinitializable<S2> {
 %b0:
   %r0 = alloca Deinitializable<S2>, #preferred
-  %r1 = witnesstable {Deinitializable.deinit<Self: S2>} as Deinitializable<S2>
+  %r1 = witnesstable {Deinitializable.deinit$synthesized<Self: S2>} as Deinitializable<S2>
   %r2 = access [set] %r0
   %r3 = store %r1 to %r2
   %r4 = end %r2
@@ -80,7 +108,18 @@ fun S2.$<ConformanceDeclaration at synthesized-deinit:14.14>() let <: Deinitiali
   %r11 = return
 }
 
-fun Deinitializable.deinit<Self: S2>(let %p0: Deinitializable<S2>, sink %p1: S2, set %p2: Void) {
+fun Deinitializable.deinit$synthesized<Self: S2>(let %p0: Deinitializable<S2>, sink %p1: S2, set %p2: Void) {
+%b0:
+  %r0 = access [sink] %p1
+  %r1 = assume_state %r0 uninitialized
+  %r2 = end %r0
+  %r3 = access [set] %p2
+  %r4 = assume_state %r3 initialized
+  %r5 = end %r3
+  %r6 = return
+}
+
+fun Deinitializable.deinit$synthesized<Self: S3>(let %p0: Deinitializable<S3>, sink %p1: S3, set %p2: Void) {
 %b0:
   %r0 = place_cast %p1 as sink {Int, {S0, S1}}
   %r1 = subfield %r0 at 0 as Int
@@ -93,18 +132,148 @@ fun Deinitializable.deinit<Self: S2>(let %p0: Deinitializable<S2>, sink %p1: S2,
   %r8 = access [sink] %r6
   %r9 = access [set] %r7
   %r10 = apply S0.deinit(%r8) => %r9
-  %r21 = end %r9
-  %r20 = end %r8
+  %r22 = end %r9
+  %r21 = end %r8
   %r11 = subfield %r5 at 1 as S1
-  %r12 = access [sink] %r11
-  %r13 = assume_state %r12 uninitialized
-  %r14 = end %r12
-  %r19 = end %r0
-  %r15 = access [set] %p2
-  %r16 = assume_state %r15 initialized
-  %r17 = end %r15
-  %r22 = access [sink] %r7
-  %r23 = assume_state %r22 uninitialized
-  %r24 = end %r22
-  %r18 = return
+  %r12 = alloca Void, #preferred
+  %r13 = access [sink] %r11
+  %r14 = access [set] %r12
+  %r15 = apply S1.deinit(%r13) => %r14
+  %r24 = end %r14
+  %r23 = end %r13
+  %r20 = end %r0
+  %r16 = access [set] %p2
+  %r17 = assume_state %r16 initialized
+  %r18 = end %r16
+  %r25 = access [sink] %r7
+  %r26 = assume_state %r25 uninitialized
+  %r27 = end %r25
+  %r28 = access [sink] %r12
+  %r29 = assume_state %r28 uninitialized
+  %r30 = end %r28
+  %r19 = return
+}
+
+fun E0.$<ConformanceDeclaration at synthesized-deinit:26.12>() let <: Deinitializable<E0> {
+%b0:
+  %r0 = alloca Deinitializable<E0>, #preferred
+  %r1 = witnesstable {Deinitializable.deinit<Self: E0>} as Deinitializable<E0>
+  %r2 = access [set] %r0
+  %r3 = store %r1 to %r2
+  %r4 = end %r2
+  %r5 = access [let] %r0
+  %r6 = yield %r5
+  %r7 = end %r5
+  %r8 = access [sink] %r0
+  %r9 = assume_state %r8 uninitialized
+  %r10 = end %r8
+  %r11 = return
+}
+
+fun Deinitializable.deinit<Self: E0>(let %p0: Deinitializable<E0>, sink %p1: E0, set %p2: Void) {
+%b0:
+  %r0 = access [sink] %p1
+  %r1 = access [set] %p2
+  %r2 = apply E0.deinit(%r0) => %r1
+  %r5 = end %r1
+  %r4 = end %r0
+  %r3 = return
+}
+
+fun E0.deinit(sink %p0: E0, set %p1: Void) {
+%b0:
+  %r0 = access [set] %p1
+  %r1 = assume_state %r0 initialized
+  %r2 = end %r0
+  %r4 = project E0.$<ConformanceDeclaration at synthesized-deinit:26.12>[]
+  %r5 = alloca Void, #preferred
+  %r6 = access [let] %r4
+  %r7 = access [sink] %p0
+  %r8 = access [set] %r5
+  %r9 = apply Deinitializable.deinit$synthesized<Self: E0>(%r6, %r7) => %r8
+  %r10 = end %r8
+  %r11 = end %r7
+  %r12 = end %r6
+  %r13 = end %r4
+  %r3 = return
+}
+
+fun E2.$<ConformanceDeclaration at synthesized-deinit:32.12>() let <: Deinitializable<E2> {
+%b0:
+  %r0 = alloca Deinitializable<E2>, #preferred
+  %r1 = witnesstable {Deinitializable.deinit$synthesized<Self: E2>} as Deinitializable<E2>
+  %r2 = access [set] %r0
+  %r3 = store %r1 to %r2
+  %r4 = end %r2
+  %r5 = access [let] %r0
+  %r6 = yield %r5
+  %r7 = end %r5
+  %r8 = access [sink] %r0
+  %r9 = assume_state %r8 uninitialized
+  %r10 = end %r8
+  %r11 = return
+}
+
+fun Deinitializable.deinit$synthesized<Self: E2>(let %p0: Deinitializable<E2>, sink %p1: E2, set %p2: Void) {
+%b0:
+  %r0 = access [sink] %p1
+  %r1 = assume_state %r0 uninitialized
+  %r2 = end %r0
+  %r3 = access [set] %p2
+  %r4 = assume_state %r3 initialized
+  %r5 = end %r3
+  %r6 = return
+}
+
+fun E3.$<ConformanceDeclaration at synthesized-deinit:34.12>() let <: Deinitializable<E3> {
+%b0:
+  %r0 = alloca Deinitializable<E3>, #preferred
+  %r1 = witnesstable {Deinitializable.deinit$synthesized<Self: E3>} as Deinitializable<E3>
+  %r2 = access [set] %r0
+  %r3 = store %r1 to %r2
+  %r4 = end %r2
+  %r5 = access [let] %r0
+  %r6 = yield %r5
+  %r7 = end %r5
+  %r8 = access [sink] %r0
+  %r9 = assume_state %r8 uninitialized
+  %r10 = end %r8
+  %r11 = return
+}
+
+fun Deinitializable.deinit$synthesized<Self: E3>(let %p0: Deinitializable<E3>, sink %p1: E3, set %p2: Void) {
+%b0:
+  %r0 = enum_tag %p1
+  %r1 = switch %r0, %b1, %b2
+%b1:
+  %r2 = case "a" of %p1
+  %r3 = place_cast %r2 as sink {S0}
+  %r4 = subfield %r3 at 0 as S0
+  %r5 = alloca Void, #preferred
+  %r6 = access [sink] %r4
+  %r7 = access [set] %r5
+  %r8 = apply S0.deinit(%r6) => %r7
+  %r25 = end %r7
+  %r24 = end %r6
+  %r23 = end %r3
+  %r22 = end %r2
+  %r9 = br %b3
+%b2:
+  %r10 = case "b" of %p1
+  %r11 = place_cast %r10 as sink {S1}
+  %r12 = subfield %r11 at 0 as S1
+  %r13 = alloca Void, #preferred
+  %r14 = access [sink] %r12
+  %r15 = access [set] %r13
+  %r16 = apply S1.deinit(%r14) => %r15
+  %r29 = end %r15
+  %r28 = end %r14
+  %r27 = end %r11
+  %r26 = end %r10
+  %r17 = br %b3
+%b3:
+  %r18 = access [set] %p2
+  %r19 = assume_state %r18 initialized
+  %r20 = end %r18
+  %r21 = return
 }


### PR DESCRIPTION
This patch makes it possible to write the following:

```hylo
struct S is Deinitializable {
  let x: Int
  memberwise init
  fun deinit() sink {}
}
```

The compiler must deinitialize `self` implicitly in `deinit` without causing infinite recursion. To that end, the compiler detects whether it is processing a reinitialization and inserts memberwise deinitialization rather than calling the witness itself.