### PR TITLE
Driver: loading stdlib should enable standard library dependency

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -278,7 +278,7 @@ public struct Driver {
     // Compile the module from sources.
     let m = program.demandModule(module)
 
-    if addStandardLibraryDependency {
+    if addStandardLibraryDependency && module != Module.standardLibraryName {
       program[m].addDependency(Module.standardLibraryName)
     }
 

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -42,9 +42,6 @@ public struct Driver {
   /// `true` iff the standard library and its shim should be excluded from compilation and linking.
   public var noStandardLibrary: Bool = false
 
-  /// `true` iff a standard library dependency should be added to loaded modules.
-  private var addStandardLibraryDependency: Bool = false
-
   /// The program being compiled by the driver.
   public var program: Program
 
@@ -278,7 +275,7 @@ public struct Driver {
     // Compile the module from sources.
     let m = program.demandModule(module)
 
-    if addStandardLibraryDependency && module != Module.standardLibraryName {
+    if !noStandardLibrary && module != Module.standardLibraryName {
       program[m].addDependency(Module.standardLibraryName)
     }
 
@@ -316,7 +313,7 @@ public struct Driver {
     let sourceRoot = localStandardLibrarySources
     #endif
     try await load(Module.standardLibraryName, withSourcesAt: sourceRoot)
-    addStandardLibraryDependency = true
+    noStandardLibrary = false
   }
 
   /// Searches for an archive of `module` in `librarySearchPaths`, returning it if found.

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -42,6 +42,9 @@ public struct Driver {
   /// `true` iff the standard library and its shim should be excluded from compilation and linking.
   public var noStandardLibrary: Bool = false
 
+  /// `true` iff a standard library dependency should be added to loaded modules.
+  private var addStandardLibraryDependency: Bool = false
+
   /// The program being compiled by the driver.
   public var program: Program
 
@@ -275,6 +278,10 @@ public struct Driver {
     // Compile the module from sources.
     let m = program.demandModule(module)
 
+    if addStandardLibraryDependency {
+      program[m].addDependency(Module.standardLibraryName)
+    }
+
     await parse(sources, into: m)
     try throwIfContainsError(m)
 
@@ -297,7 +304,8 @@ public struct Driver {
     }
   }
 
-  /// Loads the standard library with `load(_:withSourcesAt:)`.
+  /// Loads the standard library with `load(_:withSourcesAt:)` and makes
+  /// standard library a dependency of modules loaded thereafter.
   /// 
   /// Use the `USE_BUNDLED_STANDARD_LIBRARY` compiler flag to control whether the  bundled or local
   /// standard library is used. Defaults to local.
@@ -308,6 +316,7 @@ public struct Driver {
     let sourceRoot = localStandardLibrarySources
     #endif
     try await load(Module.standardLibraryName, withSourcesAt: sourceRoot)
+    addStandardLibraryDependency = true
   }
 
   /// Searches for an archive of `module` in `librarySearchPaths`, returning it if found.

--- a/Tests/InterpreterTests/Utilities.swift
+++ b/Tests/InterpreterTests/Utilities.swift
@@ -9,7 +9,7 @@ extension Program {
   static func loadForInterpretation(sourceRoot r: URL) async throws -> Program {
     var d = Driver(targetSpecification: try .host())
     try await d.loadStandardLibrary()
-    try await d.load("Main", withSourcesAt: r, dependingOnStandardLibrary: true)
+    try await d.load("Main", withSourcesAt: r)
     return d.program
   }
 
@@ -25,24 +25,6 @@ extension Program {
       print(show(executor.currentInstruction))
       try executor.step()
     }
-  }
-
-}
-
-extension Driver {
-
-  /// Loads `m` from `root`, making it depend on the standard library if
-  /// `dependingOnStandardLibrary` is `true`.
-  fileprivate mutating func load(
-    _ m: Module.Name,
-    withSourcesAt root: URL,
-    dependingOnStandardLibrary: Bool
-  ) async throws {
-    if dependingOnStandardLibrary {
-      let r = program.demandModule(m)
-      program[r].addDependency(Module.standardLibraryName)
-    }
-    try await load(m, withSourcesAt: root)
   }
 
 }


### PR DESCRIPTION
Posted by @dabrahams as [comment](https://github.com/hylo-lang/hylo-new/pull/270#discussion_r3561096491)
> I find it weird that we have to both load the standard library and tell the driver that the program depends on it. One of those should be sufficient.