### PR TITLE
Implement built-in support for converting pointers to places and vice versa

### DIFF
--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -191,6 +191,8 @@ extension Program {
       return incorporate(ctx.ir.castUnchecked(i, to: IRSubfield.self), in: &ctx)
     case IRSwitch.self:
       return incorporate(ctx.ir.castUnchecked(i, to: IRSwitch.self), in: &ctx)
+    case IRUnreachable.self:
+      return incorporate(ctx.ir.castUnchecked(i, to: IRUnreachable.self), in: &ctx)
     case IRWitnessTable.self:
       return incorporate(ctx.ir.castUnchecked(i, to: IRWitnessTable.self), in: &ctx)
     case IRYield.self:
@@ -258,6 +260,8 @@ extension Program {
     let s = ctx.ir.at(i)
 
     switch s.callee {
+    case .trap:
+      insertTrap(in: &ctx)
     case .addressOf:
       ctx.value[.register(i.erased)] = ctx.value[s.arguments[0]]!
     default:
@@ -577,6 +581,14 @@ extension Program {
       on: ctx.value[s.scrutinee]!,
       cases: bs.dropLast(1), default: last.1, at: ctx.insertionPoint!)
     return nil
+  }
+
+  /// Generates the LLVM IR code corresponding to `i`.
+  internal mutating func incorporate(
+    _ i: IRUnreachable.ID, in ctx: inout FunctionGenerationContext
+  ) -> AnyInstructionIdentity? {
+    ctx.module.llvm.insertUnreachable(at: ctx.insertionPoint!)
+    return ctx.ir.instruction(after: i.erased)
   }
 
   /// Generates the LLVM IR code corresponding to `i`.
@@ -988,6 +1000,12 @@ extension Program {
       // TODO: alignment
       ctx.module.llvm.insertReturn(y, at: ctx.insertionPoint!)
     }
+  }
+
+  /// Inserts a call to the `llvm.trap` intrinsic.
+  private func insertTrap(in ctx: inout FunctionGenerationContext) {
+    let f = ctx.module.llvm.intrinsic(named: IntrinsicFunction.llvm.trap, for: [])!
+    _ = ctx.module.llvm.insertCall(f, on: [], at: ctx.insertionPoint!)
   }
 
   /// Defines a "main" function calling `f`, which is the module's entry point.

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -179,6 +179,8 @@ extension Program {
       return incorporate(ctx.ir.castUnchecked(i, to: IRPlaceCast.self), in: &ctx)
     case IRPlaceCast.End.self:
       return ctx.ir.instruction(after: i)
+    case IRPointerToPlace.self:
+      return incorporate(ctx.ir.castUnchecked(i, to: IRPointerToPlace.self), in: &ctx)
     case IRProject.self:
       return incorporate(ctx.ir.castUnchecked(i, to: IRProject.self), in: &ctx)
     case IRProperty.self:
@@ -388,6 +390,16 @@ extension Program {
   /// Generates the LLVM IR code corresponding to `i`.
   internal mutating func incorporate(
     _ i: IRPlaceCast.ID, in ctx: inout FunctionGenerationContext
+  ) -> AnyInstructionIdentity? {
+    let s = ctx.ir.at(i)
+    let v = FrontEnd.IRValue.register(i.erased)
+    ctx.value[v] = .some(ctx.value[s.source]!)
+    return ctx.ir.instruction(after: i.erased)
+  }
+
+  /// Generates the LLVM IR code corresponding to `i`.
+  internal mutating func incorporate(
+    _ i: IRPointerToPlace.ID, in ctx: inout FunctionGenerationContext
   ) -> AnyInstructionIdentity? {
     let s = ctx.ir.at(i)
     let v = FrontEnd.IRValue.register(i.erased)

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -155,6 +155,8 @@ extension Program {
       return incorporate(ctx.ir.castUnchecked(i, to: IRAlloca.self), in: &ctx)
     case IRApply.self:
       return incorporate(ctx.ir.castUnchecked(i, to: IRApply.self), in: &ctx)
+    case IRApplyBuiltin.self:
+      return incorporate(ctx.ir.castUnchecked(i, to: IRApplyBuiltin.self), in: &ctx)
     case IRAssumeState.self:
       return ctx.ir.instruction(after: i)
     case IRBranch.self:
@@ -244,6 +246,22 @@ extension Program {
       let p = prototype(types[a], in: &ctx.module)
       let x = insertArguments(s.arguments, mappedWith: p.mapping, in: &ctx)
       insertCall(applying: f, describedBy: p, to: x, writingResultTo: s.result, in: &ctx)
+    }
+
+    return ctx.ir.instruction(after: i.erased)
+  }
+
+  /// Generates the LLVM IR code corresponding to `i`.
+  internal mutating func incorporate(
+    _ i: IRApplyBuiltin.ID, in ctx: inout FunctionGenerationContext
+  ) -> AnyInstructionIdentity? {
+    let s = ctx.ir.at(i)
+
+    switch s.callee {
+    case .addressOf:
+      ctx.value[.register(i.erased)] = ctx.value[s.arguments[0]]!
+    default:
+      unimplemented(String(describing: s.callee))
     }
 
     return ctx.ir.instruction(after: i.erased)

--- a/Sources/BackEnd/SubscriptDecomposition.swift
+++ b/Sources/BackEnd/SubscriptDecomposition.swift
@@ -556,9 +556,17 @@ extension IRFunction {
     switch tag(of: i) {
     case IRAlloca.self, IRProject.self:
       return .captured
-    case IRAccess.self, IRCase.self, IRGlobalAccess.self, IRPlaceCast.self, IRSubfield.self,
-      IRProperty.self:
+
+    case
+      IRAccess.self,
+      IRCase.self,
+      IRGlobalAccess.self,
+      IRPlaceCast.self,
+      IRPointerToPlace.self,
+      IRProperty.self,
+      IRSubfield.self:
       return .redefined
+
     default:
       return .none
     }

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -701,9 +701,18 @@ internal struct IREmitter {
 
     // Are we lowering a built-in call?
     else if let f = program.asBuiltinFunction(program[e].callee) {
-      return lowering(e) { (me) in
-        let result = me._lower(builtin: f, appliedTo: me.program[e].arguments)
-        me._emitInitialize(target, with: result)
+      // `Builtin.assume_[un]initialized` is lowered directly to `assume_state`.
+      if case .assumeInitialized(let s) = f {
+        let x0 = lowered(lvalue: program[e].arguments.uniqueElement!.value)
+        lowering(e) { (me) in
+          me._assume_state(x0, initialized: s)
+          me._assume_state(target, initialized: true)
+        }
+      } else {
+        lowering(e) { (me) in
+          let x0 = me._emitApply(builtin: f, to: me.program[e].arguments)
+          me._emitInitialize(target, with: x0)
+        }
       }
     }
 
@@ -1256,17 +1265,6 @@ internal struct IREmitter {
         return me._project(f.value, arguments, afterFormingAccesses: true)
       }
     }
-  }
-
-  /// Generates the IR for loading the result of `function` applied to `arguments` into a register.
-  private mutating func _lower(
-    builtin function: BuiltinFunction, appliedTo arguments: [LabeledExpression],
-  ) -> IRValue {
-    let xs = arguments.map { (a) in
-      let x0 = lowered(lvalue: a.value)
-      return _access([.let], from: x0)
-    }
-    return _apply_builtin(function, to: xs)
   }
 
   /// Generates the IR for computing the place of the value denoted by `e`.
@@ -2033,11 +2031,9 @@ internal struct IREmitter {
 
   /// Inserts a `apply_builtin` instruction.
   internal mutating func _apply_builtin(
-    _ callee: BuiltinFunction, to arguments: [IRValue]
+    _ callee: BuiltinFunction, typed f: Arrow.ID, to arguments: [IRValue]
   ) -> IRValue {
-    let f = callee.type(uniquingTypesWith: &program.types)
     assert(program.types[f].inputs.count == arguments.count)
-
     let p = program.types[f].inputs.map(\.access)
     let s = IRApplyBuiltin(
       callee: callee, inputs: p, output: program.types[f].output, arguments: arguments,
@@ -2597,7 +2593,27 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR for defining a place projecting `source` as a place of type `target` with
+  /// Generates IR for calling `Builtin.trap`.
+  internal mutating func _emitTrap() {
+    let f = BuiltinFunction.trap.type(uniquingTypesWith: &program.types)
+    _ = _apply_builtin(.trap, typed: f, to: [])
+  }
+
+  /// Generates IR for applying `callee` to `arguments`.
+  ///
+  /// `callee` is any built-in function but `assume_[un]initialized`.
+  private mutating func _emitApply(
+    builtin callee: BuiltinFunction, to arguments: [LabeledExpression],
+  ) -> IRValue {
+    let t = callee.type(uniquingTypesWith: &program.types)
+    let xs = zip(program.types[t].inputs, arguments).map { (p, a) in
+      let x0 = lowered(lvalue: a.value)
+      return _access([p.access], from: x0)
+    }
+    return _apply_builtin(callee, typed: t, to: xs)
+  }
+
+  /// Generates IR for defining a place projecting `source` as a place of type `target` with
   /// capability `access`.
   ///
   /// The result if an `access` if `target` is the type of `source`. Otherwise, the result is a
@@ -2685,7 +2701,7 @@ internal struct IREmitter {
   ) -> Bool {
     switch witnessOfDeinitializable(for: t) {
     case .none:
-      _ = _apply_builtin(.trap, to: [])
+      _emitTrap()
       return false
 
     case .trivial:
@@ -2718,7 +2734,7 @@ internal struct IREmitter {
               recursion in this context
               """
             report(.init(.error, m, at: currentAnchor.site))
-            _ = _apply_builtin(.trap, to: [])
+            _emitTrap()
             return false
           }
         }
@@ -2935,7 +2951,7 @@ internal struct IREmitter {
 
     // Other types require a conformance to `Hylo.Movable`.
     guard let w = conformanceWitness(of: typeOfSource, is: .movable) else {
-      _ = _apply_builtin(.trap, to: [])
+      _emitTrap()
       return
     }
 

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1252,22 +1252,14 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR for loading the value denoted by `e` into a register.
-  private mutating func lowered(rvalue e: ExpressionIdentity) -> IRValue {
-    let v = lowered(lvalue: e)
-    return lowering(e) { (me) in
-      let x = me._access([.sink], from: v)
-      let y = me._load(v)
-      me._end(IRAccess.self, openedBy: x)
-      return y
-    }
-  }
-
   /// Generates the IR for loading the result of `function` applied to `arguments` into a register.
   private mutating func _lower(
     builtin function: BuiltinFunction, appliedTo arguments: [LabeledExpression],
   ) -> IRValue {
-    let xs = arguments.map({ (a) in lowered(rvalue: a.value) })
+    let xs = arguments.map { (a) in
+      let x0 = lowered(lvalue: a.value)
+      return _access([.let], from: x0)
+    }
     return _apply_builtin(function, to: xs)
   }
 
@@ -2023,8 +2015,9 @@ internal struct IREmitter {
     let f = callee.type(uniquingTypesWith: &program.types)
     assert(program.types[f].inputs.count == arguments.count)
 
+    let p = program.types[f].inputs.map(\.access)
     let s = IRApplyBuiltin(
-      callee: callee, returnTypeOfCallee: program.types[f].output, arguments: arguments,
+      callee: callee, inputs: p, output: program.types[f].output, arguments: arguments,
       anchor: currentAnchor)
     return insert(s)!
   }

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2101,6 +2101,15 @@ internal struct IREmitter {
     return insert(s)!
   }
 
+  /// Inserts a `pointer_to_place` instruction.
+  internal mutating func _pointer_to_place<T: TypeIdentity>(
+    _ source: IRValue, as access: AccessEffect, _ target: T
+  ) -> IRValue {
+    let t = program.types.dealiased(target.erased)
+    let s = IRPointerToPlace(source: source, access: access, target: t, anchor: currentAnchor)
+    return insert(s)!
+  }
+
   /// Inserts a `project` instruction.
   ///
   /// If `formAccesses` is `true`, an access is created on each argument before the projection,

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -743,18 +743,24 @@ internal struct IREmitter {
 
   /// Implements `lower(store:to:)` for conversion expressions.
   private mutating func lower(store e: Conversion.ID, to target: IRValue) {
-    let lhs = program.type(assignedTo: program[e].source)
-    let rhs = program.type(assignedTo: e)
+    switch program[e].semantics.value {
+    case .pointer:
+      let x0 = lowered(lvalue: e)
+      lowering(e) { (me) in
+        me._emitMove([.inout, .set], x0, to: target)
+      }
 
-    // Trivial if the conversion does not involve any change of representation.
-    if let s = program.types.unifiable(lhs, rhs) {
-      assert(s.isEmpty)
-      lower(store: program[e].source, to: target)
-    }
+    default:
+      let lhs = program.type(assignedTo: program[e].source)
+      let rhs = program.type(assignedTo: e)
 
-    // Otherwise, the semantics of the conversion depends on its direction.
-    else {
-      unimplemented(program.format("conversion from '%T' to '%T'", [lhs, rhs]))
+      // Trivial if the conversion does not involve any change of representation.
+      if let s = program.types.unifiable(lhs, rhs) {
+        assert(s.isEmpty)
+        lower(store: program[e].source, to: target)
+      } else {
+        unimplemented(program.format("conversion from '%T' to '%T'", [lhs, rhs]))
+      }
     }
   }
 
@@ -1305,14 +1311,31 @@ internal struct IREmitter {
 
   /// Implements `lower(lvalue:)` for explicit conversions.
   private mutating func lowered(lvalue e: Conversion.ID) -> IRValue {
-    // Is there any conversion required?
-    let t = program.types.dealiased(program.type(assignedTo: e))
-    let u = program.types.dealiased(program.type(assignedTo: program[e].source))
-    if t == u {
-      return lowered(lvalue: program[e].source)
-    }
+    switch program[e].semantics.value {
+    case .pointer:
+      // The right-hand side is a remote type.
+      let t = program.type(assignedTo: program[e].target, assuming: Metatype.self)
+      let u = program.types.cast(program.types[t].inhabitant, to: RemoteType.self)!
+      let k = program.types[u].access
 
-    unimplemented("conversions involving change of representation")
+      let x0 = lowered(lvalue: program[e].source)
+      return lowering(e) { (me) in
+        let x1 = me._load(x0)
+        return me._pointer_to_place(x1, as: k, me.program.types[u].projectee)
+      }
+
+    default:
+      let lhs = program.type(assignedTo: program[e].source)
+      let rhs = program.type(assignedTo: e)
+
+      // Trivial if the conversion does not involve any change of representation.
+      if let s = program.types.unifiable(lhs, rhs) {
+        assert(s.isEmpty)
+        return lowered(lvalue: program[e].source)
+      } else {
+        unimplemented(program.format("conversion from '%T' to '%T'", [lhs, rhs]))
+      }
+    }
   }
 
   /// Implements `lower(lvalue:)` for inout expressions.
@@ -2643,6 +2666,7 @@ internal struct IREmitter {
   private mutating func _emitDeinitialize(
     _ s: IRValue, instanceOf t: AnyTypeIdentity
   ) -> Bool {
+    assert(!t[.hasAliases])
     switch program.types.tag(of: t) {
     case Tuple.self:
       let u = program.types.castUnchecked(t, to: Tuple.self)

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -242,6 +242,8 @@ public struct IRFunction: Sendable {
       return isBoundImmutably((at(i) as! IRCase).source)
     case IRPlaceCast.self:
       return (at(i) as! IRPlaceCast).access == .let
+    case IRPointerToPlace.self:
+      return (at(i) as! IRPointerToPlace).access == .let
     case IRProject.self:
       return (at(i) as! IRProject).access == .let
     case IRSubfield.self:

--- a/Sources/FrontEnd/IR/Instructions/IRApplyBuiltin.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRApplyBuiltin.swift
@@ -2,7 +2,11 @@ import Archivist
 
 /// Invokes a function of the `Builtin` module.
 ///
-/// Unlike `apply`, this instruction does produce a result.
+///     apply_builtin <callee : builtin-function>(<v0 : value>, ..., <vn : value>)
+///
+/// `apply_builtin` applies the built-in function `callee` on arguments `v0` to `vn`, defining a
+/// register with the result of the application. Note that this behavior is unlike `apply`, which
+/// writes its result to a `set` parameter.
 @Archivable
 public struct IRApplyBuiltin: Instruction {
 
@@ -15,18 +19,22 @@ public struct IRApplyBuiltin: Instruction {
   /// The function being applied.
   public let callee: BuiltinFunction
 
-  /// The type of the value returned by `callee`.
-  public let type: IRType
+  /// The capabilities taken by the callee's parameters.
+  public let inputs: [AccessEffect]
+
+  /// The return type of the callee.
+  public let output: AnyTypeIdentity
 
   /// Creates an instance with the given properties.
   public init(
-    callee: BuiltinFunction, returnTypeOfCallee: AnyTypeIdentity, arguments: [IRValue],
+    callee: BuiltinFunction, inputs: [AccessEffect], output: AnyTypeIdentity, arguments: [IRValue],
     anchor: Anchor
   ) {
     self.operands = arguments
     self.anchor = anchor
     self.callee = callee
-    self.type = .value(returnTypeOfCallee)
+    self.inputs = inputs
+    self.output = output
   }
 
   /// Creates a copy of `other`, substituting its properties with `properties`.
@@ -34,12 +42,18 @@ public struct IRApplyBuiltin: Instruction {
     self.operands = other.operands.map({ (o) in properties[o] })
     self.anchor = properties.anchor(other)
     self.callee = other.callee
-    self.type = other.type
+    self.inputs = other.inputs
+    self.output = other.output
   }
 
   /// The arguments of the call.
   public var arguments: [IRValue] {
     operands
+  }
+
+  /// The type of the storage accessed by this instruction.
+  public var type: IRType {
+    .value(output)
   }
 
 }

--- a/Sources/FrontEnd/IR/Instructions/IRPointerToPlace.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRPointerToPlace.swift
@@ -1,17 +1,14 @@
 import Archivist
 
-/// Projects a value at a different type.
+/// Converts a built-in pointer to a place.
 ///
-///     place_cast <source : value> as <access : effect> <target : type>
+///     pointer_to_place <source : value> as <access : effect> <target : type>
 ///
-/// `place_cast` projects the contents of `source`, which is the result an access instruction, as
-/// contents of type `target` into a region, using `access` to determine the memory state of the
-/// source before and after that region.
-///
-/// The conversion is not checked. Accessing the resulting place has undefined behavior unless
-/// `target` is layout-compatible with the type of `source`.
+/// `pointer_to_place` defines a place of type `target` with the value of `source`, which denotes
+/// the value of a `Builtin.ptr`, using `access` to determine the memory state of the place. The
+/// resulting place unsafely refers to the memory referenced by `source`.
 @Archivable
-public struct IRPlaceCast: IRRegionEntry {
+public struct IRPointerToPlace: IRRegionEntry {
 
   /// The operands of the instruction.
   public let operands: [IRValue]
@@ -19,7 +16,7 @@ public struct IRPlaceCast: IRRegionEntry {
   /// The region of the code corresponding to this instruction.
   public let anchor: Anchor
 
-  /// The capabilities of the projection.
+  /// The capabilities of the place.
   public let access: AccessEffect
 
   /// The type of the resulting place.
@@ -41,7 +38,7 @@ public struct IRPlaceCast: IRRegionEntry {
     self.target = other.target
   }
 
-  /// The place being converted.
+  /// The pointer being converted to a place.
   public var source: IRValue {
     operands[0]
   }
@@ -58,11 +55,11 @@ public struct IRPlaceCast: IRRegionEntry {
 
 }
 
-extension IRPlaceCast: Showable {
+extension IRPointerToPlace: Showable {
 
   /// Returns a textual representation of `self` using `printer`.
   public func show(using printer: inout TreePrinter) -> String {
-    "place_cast \(printer.show(source)) as \(access) \(printer.show(target))"
+    "pointer_to_place \(printer.show(source)) as \(access) \(printer.show(target))"
   }
 
 }

--- a/Sources/FrontEnd/IR/Instructions/InstructionTag.swift
+++ b/Sources/FrontEnd/IR/Instructions/InstructionTag.swift
@@ -45,6 +45,7 @@ public struct InstructionTag: Sendable {
     IRPartialApply.self,
     IRPlaceCast.self,
     IRPlaceCast.End.self,
+    IRPointerToPlace.self,
     IRProject.self,
     IRProject.End.self,
     IRProperty.self,

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
@@ -80,9 +80,9 @@ extension IRFunction {
   /// Returns `true` iff `i` denotes an instruction that never returns control.
   ///
   /// `Never` is encoded as `<T> T`, meaning that a never-returning expression will typically be
-  /// wrapped into a type application so that the it matches the expected type. This method can
-  /// therefore identify the instruction denoting the lowered form of a never-returning expression
-  /// right before any type application.
+  /// wrapped into a type application so that it matches the expected type. This method can thus
+  /// identify the instruction denoting the lowered form of a never-returning expression right
+  /// before any type application.
   private func neverReturns(_ i: AnyInstructionIdentity) -> Bool {
     // Note that it's fine to compare the return type of applications with `Never` because the
     // expression should still have the form `<T> T` at this point.

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
@@ -70,6 +70,8 @@ extension IRFunction {
   /// Returns `true` iff `i` can be removed if it has no use.
   private func isRemovableWhenUnused(_ i: AnyInstructionIdentity) -> Bool {
     switch at(i) {
+    case let s as IRApplyBuiltin:
+      return s.callee != .trap
     case let s:
       return s.type != .nothing
     }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
@@ -87,6 +87,8 @@ extension IRFunction {
     switch at(i) {
     case let s as IRApply:
       return result(of: s.result)?.type == .never
+    case let s as IRApplyBuiltin:
+      return s.callee == .trap
     default:
       return false
     }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -122,6 +122,8 @@ private struct Transfer: AbstractTransferFunction {
         pc = interpret(f.castUnchecked(i, to: IRPlaceCast.self), from: &f)
       case IRPlaceCast.End.self:
         pc = interpret(f.castUnchecked(i, to: IRPlaceCast.End.self), from: &f)
+      case IRPointerToPlace.self:
+        pc = interpret(f.castUnchecked(i, to: IRPointerToPlace.self), from: &f)
       case IRProject.self:
         pc = interpret(f.castUnchecked(i, to: IRProject.self), from: &f)
       case IRProject.End.self:
@@ -213,7 +215,6 @@ private struct Transfer: AbstractTransferFunction {
     return f.instruction(after: i.erased)
   }
 
-
   /// Interprets `i`, which is in `f`.
   private mutating func interpret(
     _ i: IRCase.ID, from f: inout IRFunction
@@ -253,6 +254,14 @@ private struct Transfer: AbstractTransferFunction {
   ) -> AnyInstructionIdentity? {
     context.memory[f.at(i).start] = nil
     context.locals[f.at(i).start] = nil
+    return f.instruction(after: i.erased)
+  }
+
+  /// Interprets `i`, which is in `f`.
+  private mutating func interpret(
+    _ i: IRPointerToPlace.ID, from f: inout IRFunction
+  ) -> AnyInstructionIdentity? {
+    context.declare(i.erased, from: f, initially: .unique)
     return f.instruction(after: i.erased)
   }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -300,9 +300,11 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRApplyBuiltin.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    for a in f.at(i).arguments {
-      consume(object: a, with: i.erased, in: f)
+    let s = f.at(i)
+    for (p, v) in zip(s.inputs, s.arguments) {
+      passArgument(p, v, insertingDeinitializationBefore: i.erased, in: &f)
     }
+
     context.declare(i, from: f, initially: .initialized)
     return f.instruction(after: i.erased)
   }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -126,6 +126,8 @@ private struct Transfer: AbstractTransferFunction {
         pc = interpret(f.castUnchecked(i, to: IRPlaceCast.self), from: &f)
       case IRPlaceCast.End.self:
         pc = interpret(f.castUnchecked(i, to: IRPlaceCast.End.self), from: &f)
+      case IRPointerToPlace.self:
+        pc = interpret(f.castUnchecked(i, to: IRPointerToPlace.self), from: &f)
       case IRProject.self:
         pc = interpret(f.castUnchecked(i, to: IRProject.self), from: &f)
       case IRProject.End.self:
@@ -477,6 +479,16 @@ private struct Transfer: AbstractTransferFunction {
     context.memory[place] = nil
     context.locals[place] = nil
     context.locals.removeAll(where: { (_, p) in p.place?.location.root == place })
+    return f.instruction(after: i.erased)
+  }
+
+  /// Interprets `i`, which is in `f`.
+  private mutating func interpret(
+    _ i: IRPointerToPlace.ID, from f: inout IRFunction
+  ) -> AnyInstructionIdentity? {
+    let s = f.at(i)
+    let v: Domain = (s.access == .set) ? .uninitialized : .initialized
+    context.declare(i.erased, from: f, initially: v)
     return f.instruction(after: i.erased)
   }
 

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -403,9 +403,8 @@ extension BuiltinFunction {
 
     case .addressOf:
       let t0 = s.fresh().erased
-      let t1 = s.demand(RemoteType(projectee: t0, access: .let)).erased
-      let t2 = s.demand(MachineType.ptr).erased
-      return s.demand(Arrow(inputs: [.init(label: "of", access: .let, type: t1)], output: t2))
+      let t1 = s.demand(MachineType.ptr).erased
+      return s.demand(Arrow(inputs: [.init(label: "of", access: .let, type: t0)], output: t1))
 
     case .markUninitialized:
       let t0 = s.fresh().erased

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -43,11 +43,6 @@ public enum BuiltinFunction: Hashable, Sendable {
   /// measures may be needed to keep the argument alive during the pointer's use.
   case addressOf
 
-  /// `Builtin.mark_uninitialized<T>(_ v: sink T) -> Void`
-  ///
-  /// Marks `v` as being uninitialized.
-  case markUninitialized
-
   // MARK: Functions with a counterpart LLVM instruction.
 
   case add(OverflowBehavior, MachineType.ID)
@@ -406,10 +401,6 @@ extension BuiltinFunction {
       let t1 = s.demand(MachineType.ptr).erased
       return s.demand(Arrow(inputs: [.init(label: "of", access: .let, type: t0)], output: t1))
 
-    case .markUninitialized:
-      let t0 = s.fresh().erased
-      return s.demand(Arrow(inputs: [.init(label: nil, access: .sink, type: t0)], output: .void))
-
     case .add(_, let t):
       return s.demand(Arrow(t, t, to: t))
     case .sub(_, let t):
@@ -752,8 +743,6 @@ extension BuiltinFunction: Showable {
       return "trap"
     case .addressOf:
       return "address"
-    case .markUninitialized:
-      return "mark_uninitialized"
     case .add(let p, let t):
       return printer.format((p != .ignore) ? "add_\(p)_%T" : "add_%T", [t.erased])
     case .sub(let p, let t):
@@ -1098,15 +1087,6 @@ extension BuiltinFunction {
     case "address":
       if !tokens.isEmpty { return nil }
       self = .addressOf
-    case "mark":
-      if tokens != ["uninitialized"] { return nil }
-      self = .markUninitialized
-
-    //    case "advanced":
-    //      guard let ((_, _), t) = (exactly("by") + exactly("bytes") + machineType)(&tokens)
-    //      else { return nil }
-    //      self = .advancedByBytes(byteOffset: t)
-
     case "add":
       guard let (p, t) = integerArithmeticTail(&tokens) else { return nil }
       self = .add(p, s.demand(t))

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -30,18 +30,27 @@ public enum BuiltinFunction: Hashable, Sendable {
 
   // MARK: Functions unique to Hylo
 
-  /// Stops the execution of the program.
+  /// `Builtin.trap() -> Never`
   ///
-  /// This function abstracts over the `trap` instruction of the target.
+  /// Stops the execution of the program by executing the `trap` instruction of the target.
   case trap
 
-  /// `Builtin.address<T>(of v: T) -> Builtin.ptr`
+  /// `Builtin.address<T>(of v: let T) -> Builtin.ptr`
   ///
   /// Returns a pointer to the storage of the argument.
   ///
   /// The resulting pointer is dereferenceable only for the lifetime of the argument; additional
   /// measures may be needed to keep the argument alive during the pointer's use.
   case addressOf
+
+  /// `Builtin.assume_[un]initialized<T>(x: auto T) -> Void
+  ///
+  /// Unsafely treats `x` as having been initialized or uninitialized.
+  ///
+  /// Applications of this function translate directly to an `assume_state` instruction. No access
+  /// is formed on the argument, meaning that no precondition is checked on the initialization
+  /// state of `x` before the instruction is applied.
+  case assumeInitialized(Bool)
 
   // MARK: Functions with a counterpart LLVM instruction.
 
@@ -401,6 +410,10 @@ extension BuiltinFunction {
       let t1 = s.demand(MachineType.ptr).erased
       return s.demand(Arrow(inputs: [.init(label: "of", access: .let, type: t0)], output: t1))
 
+    case .assumeInitialized:
+      let t0 = s.fresh().erased
+      return s.demand(Arrow(inputs: [.init(label: nil, access: .auto, type: t0)], output: .void))
+
     case .add(_, let t):
       return s.demand(Arrow(t, t, to: t))
     case .sub(_, let t):
@@ -743,6 +756,8 @@ extension BuiltinFunction: Showable {
       return "trap"
     case .addressOf:
       return "address"
+    case .assumeInitialized(let b):
+      return "assume_\(b ? "" : "un")initialized"
     case .add(let p, let t):
       return printer.format((p != .ignore) ? "add_\(p)_%T" : "add_%T", [t.erased])
     case .sub(let p, let t):
@@ -1087,6 +1102,10 @@ extension BuiltinFunction {
     case "address":
       if !tokens.isEmpty { return nil }
       self = .addressOf
+    case "assume" where tokens.first == "initialized":
+      self = .assumeInitialized(true)
+    case "assume" where tokens.first == "uninitialized":
+      self = .assumeInitialized(false)
     case "add":
       guard let (p, t) = integerArithmeticTail(&tokens) else { return nil }
       self = .add(p, s.demand(t))

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -2161,20 +2161,31 @@ public struct Typer {
         inferredType(of: program[e].source, in: &ctx)
       }
 
+      let sourceSite = program.spanForDiagnostic(about: program[e].source)
+      let targetSite = program.spanForDiagnostic(about: program[e].target)
+      let operatorSite = program[e].semantics.site
+
       switch program[e].semantics.value {
       case .up:
-        let s = program.spanForDiagnostic(about: program[e].source)
-        context.obligations.assume(WideningConstraint(lhs: lhs, rhs: rhs, site: s))
+        context.obligations.assume(WideningConstraint(lhs: lhs, rhs: rhs, site: sourceSite))
+        return context.obligations.assume(e, hasType: rhs, at: operatorSite)
+
       case .down:
-        let s = program.spanForDiagnostic(about: program[e].target)
-        context.obligations.assume(WideningConstraint(lhs: rhs, rhs: lhs, site: s))
+        context.obligations.assume(WideningConstraint(lhs: rhs, rhs: lhs, site: targetSite))
+        return context.obligations.assume(e, hasType: rhs, at: operatorSite)
+
       case .pointer:
-        if program.types.tag(of: rhs) != RemoteType.self {
-          fatalError()
+        let p = program.types.demand(MachineType.ptr)
+        context.obligations.assume(EqualityConstraint(lhs: lhs, rhs: p.erased, site: sourceSite))
+
+        if let t = program.types.cast(rhs, to: RemoteType.self) {
+          let u = program.types[t].projectee
+          return context.obligations.assume(e, hasType: u, at: operatorSite)
+        } else {
+          report(.init(.error, "expected remote type", at: targetSite))
+          return context.obligations.assume(e, hasType: .error, at: operatorSite)
         }
       }
-
-      return context.obligations.assume(e, hasType: rhs, at: program[e].site)
     }
 
     // Inference failed on the right-hand side.

--- a/Sources/FrontEnd/Types/Arrow.swift
+++ b/Sources/FrontEnd/Types/Arrow.swift
@@ -35,8 +35,8 @@ public struct Arrow: TypeTree {
     self.output = output
   }
 
-  /// Creates an instance from `inputs`, which denote unlabeled `let` parameters, to `output`,
-  /// having no environment and the `let` effect.
+  /// Creates the type of a built-in function accepting `inputs`, which are the types of unlabeled
+  /// `let` parameters, and returning an instance of `output`.
   public init<T: TypeIdentity>(_ inputs: MachineType.ID..., to output: T) {
     self.init(
       inputs: inputs.map({ (i) in .init(access: .let, type: i.erased) }),

--- a/Tests/CompilerTests/CompilerTests.swift
+++ b/Tests/CompilerTests/CompilerTests.swift
@@ -239,7 +239,11 @@ final class CompilerTests: XCTestCase {
       if input.manifest.stage == .execution {
         let e = try XCTUnwrap(r.artifacts.executable)
         let x = try Process.execute(e)
-        assertExitStatus(x, describedBy: input)
+        if input.manifest.shouldTrap {
+          XCTAssert(x.terminationReason == .uncaughtSignal, "program did not trap")
+        } else {
+          assertExitStatus(x, describedBy: input)
+        }
       }
 
       if testFailed || alwaysSaveArtifacts { try r.artifacts.save(into: input) }

--- a/Tests/CompilerTests/Manifest.swift
+++ b/Tests/CompilerTests/Manifest.swift
@@ -23,7 +23,7 @@ struct Manifest {
     case execution
 
     /// The position of `self` in the pipeline.
-    var order: Int {
+    private var order: Int {
       switch self {
       case .parsing: 0
       case .typing: 1
@@ -60,8 +60,11 @@ struct Manifest {
   /// The optimizer configuration with which the input should be compiled.
   private(set) var optimizations: Optimizations = .none
 
-  /// The expected exit status of the input, if executed.
+  /// The expected exit status of the compiled input, if executed.
   private(set) var exitStatus: Int32 = 0
+
+  /// `true` iff the compiled input should trap when executed.
+  private(set) var shouldTrap: Bool = false
 
   /// The expected textual artifacts of the test run, asserted when present.
   private(set) var artifactExpectations = SortedDictionary<CompilerTests.ArtifactTag, String>()
@@ -145,6 +148,8 @@ struct Manifest {
       optimizations = try parse(v, for: k, with: Optimizations.init(rawValue:))
     case "exit-status":
       exitStatus = try parse(v, for: k, with: Int32.init(_:))
+    case "trap":
+      shouldTrap = true
     default:
       throw ManifestError.unknownOption
     }

--- a/Tests/CompilerTests/README.md
+++ b/Tests/CompilerTests/README.md
@@ -7,28 +7,47 @@ A use case is either a single Hylo source file or a directory representing a pac
 A single-file test is compiled to a binary executable, just as if it was passed as an argument to `hc`.
 A package test is built according to the configuration specified by its manifest.
 
+## Test attributes
 
-## Testing without the standard library
+Tests can be configured with various flags and option, called *test attributes*.
+For a single-file test, these settings are written on the first line, prefixed by `//!`.
+For instance, the following test will compile the program, execute it, and check that the exit status is `42`.
 
-You can add `//! no-std` on the first line of a single-file test to disable the loading of the standard library. We encourage using `no-std` when possible, as it makes the test significantly faster.
+```hylo
+//! exit-status:42
 
-## Stopping after a compilation stage
+public fun main() -> Int32 { 42 }
+```
 
-Add `//! stage:stage_name` to stop the driver after a specific compilation stage. Valid stages are:
+For a package test, settings are written by adding an `options` entry to the manifest, whole value is an array of flags and options expressed as character strings. 
+
+### Testing without the standard library
+
+Add the test attribute `no-std` on the first line of a single-file test to disable the loading of the standard library.
+We encourage using `no-std` when possible, as it makes the test significantly faster.
+
+### Stopping after a compilation stage
+
+Add the test attribute `stage:stage_name` to stop the driver after a specific compilation stage.
+Valid stages are:
+
 - `stage:parsing`
 - `stage:typing`
 - `stage:lowering`
 - `stage:llvm`
 - `stage:execution` (default); applicable only in positive tests.
 
-## Expectation types
+### Termination
 
-### Exit status
+Add the test attribute `exit-status:n` to specify the expected expected exit status of the compiled program.
+`0` is expected by default.
 
-Specify an expected exit code by `exit-status:42` manifest attribute. `0` is expected by default.
-Asserted when `stage` is set to `execution` (default). 
+Add the test attribute `trap` to specify that the compiled program is expected to trap (e.g., by calling `fatal_error()`).
 
-### Textual Artifact Expectations
+These two test attributes are mutually exclusive.
+Both of them are applicable only in combination with `stage:execution`.
+
+## Textual Artifact Expectations
 
 Add a `test-case.<artifact-tag>.expected` file besides your `test-case.hylo` to assert the contents of a compilation artifact. Valid artifacts are:
 - `*.raw-ir.expected`

--- a/Tests/CompilerTests/negative/invalid-builtin-dereference.diagnostics.expected
+++ b/Tests/CompilerTests/negative/invalid-builtin-dereference.diagnostics.expected
@@ -1,0 +1,3 @@
+negative/invalid-builtin-dereference.hylo:5.17-21: error: expected remote type
+  let q = p as* Void
+                ~~~~

--- a/Tests/CompilerTests/negative/invalid-builtin-dereference.hylo
+++ b/Tests/CompilerTests/negative/invalid-builtin-dereference.hylo
@@ -1,0 +1,10 @@
+//! no-std
+
+fun use(x: Void) {
+  let p = Builtin.address(of: x)
+  let q = p as* Void
+}
+
+public fun main() {
+  use(())
+}

--- a/Tests/CompilerTests/positive/pointer-place-roundtrip.hylo
+++ b/Tests/CompilerTests/positive/pointer-place-roundtrip.hylo
@@ -1,8 +1,13 @@
 //! exit-status:23
 
+subscript pointer(to_sink x: sink Int32) sink -> Builtin.ptr {
+  yield Builtin.address(of: x)
+  Builtin.assume_uninitialized(x)
+}
+
 public fun main() -> Int32 {
   var x = 23 as Int32
-  var y: Builtin.ptr = Builtin.address(of: x)
-  var z: Int32 = y as* (sink Int32)
-  return z
+  let p = pointer[to_sink: x]
+  var y: Int32 = p as* (sink Int32)
+  return y
 }

--- a/Tests/CompilerTests/positive/pointer-place-roundtrip.hylo
+++ b/Tests/CompilerTests/positive/pointer-place-roundtrip.hylo
@@ -1,0 +1,8 @@
+//! exit-status:23
+
+public fun main() -> Int32 {
+  var x = 23 as Int32
+  var y: Builtin.ptr = Builtin.address(of: x)
+  var z: Int32 = y as* (sink Int32)
+  return z
+}

--- a/Tests/CompilerTests/positive/trap.hylo
+++ b/Tests/CompilerTests/positive/trap.hylo
@@ -1,0 +1,5 @@
+//! trap
+
+public fun main() {
+  Builtin.trap()
+}


### PR DESCRIPTION
~The test `pointer-place-roundtrip.hylo` is only a temporary measure. It is most likely UB.~