### PR TITLE
Fix reallocation and insertion bugs in StableDictionary

### DIFF
--- a/Sources/StableCollections/StableDictionary.swift
+++ b/Sources/StableCollections/StableDictionary.swift
@@ -376,7 +376,7 @@ public struct StableDictionary<Key: Hashable, Value> {
     // Zero-initialize the additional storage.
     newContents.withUnsafeMutablePointers { (head, target) in
       let o = head.pointee.offsets
-      for i in count ..< newCapacity {
+      for i in capacity ..< newCapacity {
         Bucket.withMaybeUninitializedHash(of: target.advanced(by: i), offsets: o) { (h) in
           h.initialize(to: 0)
         }

--- a/Sources/StableCollections/StableDictionary.swift
+++ b/Sources/StableCollections/StableDictionary.swift
@@ -423,8 +423,8 @@ public struct StableDictionary<Key: Hashable, Value> {
 
   /// Inserts the given key/value pair at `p`.
   private mutating func insert(key: Key, value: Value, at p: Int) {
-    reserveCapacity(Swift.max(count + 1, p))
     ensureUnique()
+    reserveCapacity(Swift.max(count + 1, p + 1))
     contents!.withUnsafeMutablePointers { (head, body) in
       let hash = key.hashValue
       head.pointee.assign(position: p, in: body, forHash: hash)

--- a/Tests/StableCollectionsTests/StableDictionaryTests.swift
+++ b/Tests/StableCollectionsTests/StableDictionaryTests.swift
@@ -221,4 +221,50 @@ final class StableDictionaryTests: XCTestCase {
     XCTAssertEqual(t.description, m)
   }
 
+  func testCopyOnWriteReallocationPreservesLiveBucketsPastCount() {
+    var subject = StableDictionary<DistinctlyHashed, Int>()
+
+    let a = DistinctlyHashed(as: 0)
+    subject.assignValue(10, forKey: a)
+
+    let b = DistinctlyHashed(as: 1)
+    subject.assignValue(11, forKey: b)
+
+    let c = DistinctlyHashed(as: 2)
+    subject.assignValue(12, forKey: c)
+
+    subject.removeValue(forKey: a)  // count == 2, live bucket `c` is at position 2.
+
+    // Share the buffer, then mutate to force a copy-on-write reallocation.
+    let held = subject
+    subject.assignValue(110, forKey: b)
+    withExtendedLifetime(held) {}
+
+    // `c` at position 2 must survive the reallocation.
+    XCTAssertEqual(subject.count, 2)
+    XCTAssertEqual(subject[c], 12, "reallocation clobbered a live bucket at position >= count")
+    XCTAssertEqual(subject[b], 110)
+  }
+}
+
+/// A key whose hash is fixed by the caller, so bucket placement is fully deterministic.
+///
+/// `StableDictionary` only ever reads `key.hashValue` (never `hash(into:)`) to place and look up
+/// buckets, so overriding `hashValue` gives complete control over where each key lands.
+private struct DistinctlyHashed: Hashable {
+  
+  /// The hash of `self`.
+  let hashValue: Int
+
+  /// Creates an instance that hashes as `hashValue`. 
+  init(as hashValue: Int) {
+    self.hashValue = hashValue
+  }
+
+  /// Hashesh `self` according to the supplied hash value `id`.
+  func hash(into hasher: inout Hasher) { hasher.combine(hashValue) }
+
+  /// Returns `true` iff the `l` and `r` hash to the same value.
+  static func == (l: Self, r: Self) -> Bool { l.hashValue == r.hashValue }
+
 }

--- a/Tests/StableCollectionsTests/StableDictionaryTests.swift
+++ b/Tests/StableCollectionsTests/StableDictionaryTests.swift
@@ -234,9 +234,7 @@ final class StableDictionaryTests: XCTestCase {
 
     // Remove position 0, leaving a tombstone; count (3) is now below end (4).
     xs.removeValue(forKey: a)
-
     xs.assignValue(99, forKey: DistinctlyHashed(as: 4))
-
     XCTAssertGreaterThanOrEqual(xs.capacity, xs.endIndex, "insert wrote one bucket past the buffer")
   }
 
@@ -264,6 +262,7 @@ final class StableDictionaryTests: XCTestCase {
     XCTAssertEqual(subject[c], 12, "reallocation clobbered a live bucket at position >= count")
     XCTAssertEqual(subject[b], 110)
   }
+
 }
 
 /// A key whose hash is fixed by the caller, so bucket placement is fully deterministic.

--- a/Tests/StableCollectionsTests/StableDictionaryTests.swift
+++ b/Tests/StableCollectionsTests/StableDictionaryTests.swift
@@ -221,6 +221,25 @@ final class StableDictionaryTests: XCTestCase {
     XCTAssertEqual(t.description, m)
   }
 
+  func testInsertAtCapacityBound() {
+    var xs = StableDictionary<DistinctlyHashed, Int>()
+
+    // Append four keys hashing to distinct buckets/slots: capacity grows to 4 with end == 4.
+    let a = DistinctlyHashed(as: 0)
+    let b = DistinctlyHashed(as: 1)
+    let c = DistinctlyHashed(as: 2)
+    let d = DistinctlyHashed(as: 3)
+    for (i, k) in [a, b, c, d].enumerated() { xs.assignValue(i, forKey: k) }
+    XCTAssertEqual(xs.capacity, xs.endIndex)  // capacity == end == 4
+
+    // Remove position 0, leaving a tombstone; count (3) is now below end (4).
+    xs.removeValue(forKey: a)
+
+    xs.assignValue(99, forKey: DistinctlyHashed(as: 4))
+
+    XCTAssertGreaterThanOrEqual(xs.capacity, xs.endIndex, "insert wrote one bucket past the buffer")
+  }
+
   func testCopyOnWriteReallocationPreservesLiveBucketsPastCount() {
     var subject = StableDictionary<DistinctlyHashed, Int>()
 


### PR DESCRIPTION
## Bug 1: insufficient capacity reserved in `insert`
For accommodating index `p`, we need `p + 1` capacity.

## Bug 2: clobbering existing data on reallocation
The first loop already copied elements up until `capacity`, but the next loop that aimed at zero-initializing the rest of the storage started from `count`, which may be a smaller number than `capacity`. In effect, some buckets near capacity were overwritten.