### PR TITLE
Enable cross-module optimization in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@ jobs:
         include:
           - { os: ubuntu-24.04,     target: linux-x64 }
           - { os: ubuntu-24.04-arm, target: linux-arm64 }
-          - { os: macos-15,         target: macos-arm64 }
-          - { os: macos-15-intel,   target: macos-x64 }
+          - { os: macos-26,         target: macos-arm64 }
+          - { os: macos-26-intel,   target: macos-x64 }
           - { os: windows-2025,     target: windows-x64 }
           - { os: windows-11-arm,   target: windows-arm64 }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,14 +79,14 @@ jobs:
           #       See also: https://github.com/swiftlang/swift/issues/88237
 
       - name: Build distributable
-        run: swift build -c release --verbose --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY
+        run: swift build -c release --verbose --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY -Xswiftc -cross-module-optimization
         shell: pwsh
 
       - name: Locate distributable
         id: locate-distributable
         run: |
           $ErrorActionPreference = 'Stop'
-          $binPath = (swift build -c release --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY --show-bin-path).Trim()
+          $binPath = (swift build -c release --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY -Xswiftc -cross-module-optimization --show-bin-path).Trim()
           $binaryName = if ($env:RUNNER_OS -eq 'Windows') { 'hc.exe' } else { 'hc' }
           "bin_path=$binPath" >> $env:GITHUB_OUTPUT
           "binary_path=$(Join-Path $binPath $binaryName)" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
Currently, this fails Windows builds because of a Swift compiler bug.

 https://github.com/swiftlang/swift/issues/90661

I patched SwiftyLLVM temporarily to make the private property `initializeHost` public.