### PR TITLE
Modify the representation of IR anchors

### DIFF
--- a/Sources/FrontEnd/Diagnostic.swift
+++ b/Sources/FrontEnd/Diagnostic.swift
@@ -140,6 +140,33 @@ extension Program {
     .init(.error, "expression does not denote a type", at: spanForDiagnostic(about: e))
   }
 
+  /// Returns an error indicating that `second` yields after `first` already did.
+  internal func extraneousYield(
+    _ second: IRYield.ID, first: IRYield.ID, in source: IRFunction
+  ) -> Diagnostic {
+    let a = span(source.at(first).anchor)
+    let b = span(source.at(second).anchor)
+    let n = Diagnostic(.note, "value already projected here", at: .empty(at: a.start))
+    return .init(
+      .error, "subscript cannot project more than once", at: .empty(at: b.start),
+      notes: [n])
+  }
+
+  /// Returns an error indicating that a yield statement is missing.
+  internal func missingYield(_ anchor: Anchor) -> Diagnostic {
+    .init(.error, "subscript must yield before returning", at: span(anchor))
+  }
+
+  /// Returns an error diagnosing an invalid access on some lvalue.
+  internal func illegalAccess(_ k: AccessEffect, at anchor: Anchor) -> Diagnostic {
+    .init(.error, "illegal '\(k)' access", at: span(anchor))
+  }
+
+  /// Returns an error diagnosing an invalid relocation.
+  internal func illegalMove(at anchor: Anchor) -> Diagnostic {
+    .init(.error, "illegal move", at: span(anchor))
+  }
+
   /// Returns an error diagnosing an illegal non-empty capture list.
   internal func illegalCaptureList(at site: SourceSpan) -> Diagnostic {
     .init(.error, "declaration cannot have a non-empty capture list", at: site)
@@ -278,56 +305,18 @@ extension Program {
     .init(level, format("unused value of type '%T'", [t]), at: site)
   }
 
-}
-
-extension IRFunction {
-
-  /// Returns an error indicating that `second` yields after `first` already did.
-  internal func extraneousYield(
-    _ second: AnyInstructionIdentity, first: AnyInstructionIdentity
-  ) -> Diagnostic {
-    let n = Diagnostic(
-      .note, "value already projected here", at: .empty(at: at(first).anchor.site.start))
-    return .init(
-      .error, "subscript cannot project more than once",
-      at: .empty(at: at(second).anchor.site.start),
-      notes: [n])
-  }
-
-  /// Returns an error indicating that a yield statement is missing.
-  internal func missingYield(at site: SourceSpan) -> Diagnostic {
-    .init(.error, "subscript must yield before returning", at: site)
-  }
-
-}
-
-extension Diagnostic {
-
-  internal static func illegalConsumption(_ k: AccessEffect, at site: SourceSpan) -> Diagnostic {
-    .init(.error, "cannot consume '\(k)' projection", at: site)
-  }
-
-  internal static func illegalAccess(_ k: AccessEffect, at site: SourceSpan) -> Diagnostic {
-    .init(.error, "illegal '\(k)' access", at: site)
-  }
-
-  internal static func illegalMove(at site: SourceSpan) -> Diagnostic {
-    .init(.error, "illegal move", at: site)
-  }
-
-  internal static func uninitializedObject(at site: SourceSpan) -> Diagnostic {
-    .init(.error, "uninitialized object", at: site)
-  }
-
-  internal static func useOfConsumedObject(at site: SourceSpan) -> Diagnostic {
+  /// Returns an error reporting the illegal use of a consumed object.
+  internal func useOfConsumedObject(at site: SourceSpan) -> Diagnostic {
     .init(.error, "use of consumed object", at: site)
   }
 
-  internal static func useOfPartialObject(at site: SourceSpan) -> Diagnostic {
+  /// Returns an error reporting the illegal use of a partially initialized object.
+  internal func useOfPartialObject(at site: SourceSpan) -> Diagnostic {
     .init(.error, "use of partially initialized object", at: site)
   }
 
-  internal static func useOfUninitializedObject(at site: SourceSpan) -> Diagnostic {
+  /// Returns an error reporting the illegal use of an uninitialized object.
+  internal func useOfUninitializedObject(at site: SourceSpan) -> Diagnostic {
     .init(.error, "use of uninitialized object", at: site)
   }
 

--- a/Sources/FrontEnd/Files/SourceFile.swift
+++ b/Sources/FrontEnd/Files/SourceFile.swift
@@ -158,10 +158,10 @@ public struct SourceFile: Hashable, Sendable {
   ///
   /// - Complexity: O(log N) + O(C) where N is the number of lines in `self` and C is the returned
   ///   offset.
-  func lineAndUTF16Offset(_ i: Index) -> (line: Int, offset: Int) {
+  func lineAndUTF16Offset(_ i: Index) -> LineAndUTF16Offset {
     let lineNumber = line(containing: i).index
     let offset = text.utf16.distance(from: properties.lineStarts[lineNumber], to: i)
-    return (lineNumber, offset)
+    return LineAndUTF16Offset(line: lineNumber, offset: offset)
   }
 
   /// Returns the index in `text` corresponding to the 0-based `line` and `offset`.
@@ -190,8 +190,8 @@ public struct SourceFile: Hashable, Sendable {
     let lineStart = properties.lineStarts[line]
     let utf16Line = text[lineStart...].utf16
 
-    return utf16Line.index(utf16Line.startIndex, offsetBy: utf16Offset, limitedBy: endIndex)
-      ?? endIndex
+    let e = utf16Line.index(utf16Line.startIndex, offsetBy: utf16Offset, limitedBy: endIndex)
+    return e ?? endIndex
   }
 
   /// Calls `action` on each source file URL in `directory` having the extension `pathExtension`.
@@ -258,5 +258,29 @@ extension SourceFile: Archivable {
     try archive.write(name)
     try archive.write(text)
   }
+
+}
+
+/// A 0-based line index and 0-based UTF-16 column offset in that line.
+@Archivable
+public struct LineAndUTF16Offset: Hashable, Sendable {
+
+  /// Internal representation of `self`.
+  private let _line: UInt32
+
+  /// The 0-based offset in the line.
+  private let _offset: UInt32
+
+  /// Creates an instance with the given properties.
+  fileprivate init(line: Int, offset: Int) {
+    self._line = UInt32(line)
+    self._offset = UInt32(offset)
+  }
+
+  /// Internal representation of `self`.
+  public var line: Int { Int(_line) }
+
+  /// The 0-based offset in the line.
+  public var offset: Int { Int(_offset) }
 
 }

--- a/Sources/FrontEnd/Files/SourcePosition.swift
+++ b/Sources/FrontEnd/Files/SourcePosition.swift
@@ -22,9 +22,8 @@ public struct SourcePosition: Hashable {
   }
 
   /// The 0-based line and 0-based UTF-16 offset of this position.
-  public var lineAndUTF16Offset: (line: Int, offset: Int) {
-    let r = source.lineAndUTF16Offset(index)
-    return (r.line, r.offset)
+  public var lineAndUTF16Offset: LineAndUTF16Offset {
+    source.lineAndUTF16Offset(index)
   }
 
 }

--- a/Sources/FrontEnd/IR/Anchor.swift
+++ b/Sources/FrontEnd/IR/Anchor.swift
@@ -1,11 +1,15 @@
 import Archivist
+import Utilities
 
 /// A region of the source code to which IR can be associated.
 @Archivable
 public struct Anchor: Hashable, Sendable {
 
-  /// The site of `self`.
-  public let site: SourceSpan
+  /// The position at the start of the region covered by `self`.
+  public let start: LineAndUTF16Offset
+
+  /// The position immediately after the end of the region covered by `self`.
+  public let end: LineAndUTF16Offset
 
   /// The lexical scope that notionally contains this anchor.
   ///
@@ -13,15 +17,33 @@ public struct Anchor: Hashable, Sendable {
   /// expression from which the IR was lowered.
   public let scope: ScopeIdentity
 
-  /// Creates an instance with the given properties.
-  public init(site: SourceSpan, scope: ScopeIdentity) {
-    self.site = site
+  fileprivate init(start: LineAndUTF16Offset, end: LineAndUTF16Offset, scope: ScopeIdentity) {
+    self.start = start
+    self.end = end
     self.scope = scope
+  }
+
+  /// Creates an instance with the given properties.
+  fileprivate init(site: SourceSpan, scope: ScopeIdentity) {
+    self.start = site.start.lineAndUTF16Offset
+    self.end = site.end.lineAndUTF16Offset
+    self.scope = scope
+  }
+
+  /// Returns an anchor attached to the end of the region to which `self` is attached.
+  public var emptyAtEnd: Anchor {
+    .init(start: end, end: end, scope: scope)
   }
 
 }
 
 extension Program {
+
+  /// Creates an anchor attached to `site`, which is the same file as `scope`.
+  public func anchor(at site: SourceSpan, in scope: ScopeIdentity) -> Anchor {
+    assert(modules.values[scope.module][scope.file].source == site.source)
+    return .init(site: site, scope: scope)
+  }
 
   /// Creates an anchor attached to `d`'s introducer.
   public func anchor(introducerOf d: BindingDeclaration.ID) -> Anchor {
@@ -41,6 +63,19 @@ extension Program {
   /// Creates an anchor attached to `d`'s introducer.
   public func anchor(introducerOf d: VariantDeclaration.ID) -> Anchor {
     .init(site: self[d].effect.site, scope: .init(node: d))
+  }
+
+  /// Returns an anchor suitable to generate debug information related to `n` as a whole.s
+  public func anchorForDiagnostics<T: SyntaxIdentity>(about n: T) -> Anchor {
+    .init(site: spanForDiagnostic(about: n), scope: parent(containing: n))
+  }
+
+  /// Returns the region of text to which `anchor` is attached.
+  public func span(_ anchor: Anchor) -> SourceSpan {
+    let source = modules.values[anchor.scope.module][anchor.scope.file].source
+    let x0 = source.index(line: anchor.start.line, utf16Offset: anchor.start.offset)
+    let x1 = source.index(line: anchor.end.line, utf16Offset: anchor.end.offset)
+    return .init(x0 ..< x1, in: source)
   }
 
 }

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -261,7 +261,7 @@ internal struct IREmitter {
   /// Generates the IR of the subscript that projects the witness declared by `d`, assuming the
   /// insertion context is configured to generate IR into its lowered form.
   private mutating func lowerDefinition(_ d: ConformanceDeclaration.ID) {
-    insertionContext.anchor = .init(site: program[d].introducer.site, scope: .init(node: d))
+    insertionContext.anchor = program.anchor(introducerOf: d)
     let (_, w, _) = currentFunction.output.remote!
 
     // If the conformance is a nested given, we can simply extract the witness from the parameter
@@ -1006,10 +1006,9 @@ internal struct IREmitter {
     _ e: NameExpression.ID, output r: IRValue, markedForMutationBy mutationMarker: Token?,
   ) -> LoweredCallee {
     let d = program.declaration(referredToBy: e)
-    let a = Anchor(site: program[e].site, scope: program.parent(containing: e))
     return loweredCallee(
       d, qualifiedBy: program[e].qualification, markedForMutationBy: mutationMarker,
-      output: r, at: a)
+      output: r, at: program.anchorForDiagnostics(about: e))
   }
 
   /// Generates the IR using `d` as a callee that is optionally qualified by `qualification`,
@@ -1036,7 +1035,7 @@ internal struct IREmitter {
 
       // The qualification may define type arguments.
       if let ts = qualification.flatMap({ (e) in argumentsFromStaticQualification(e) }) {
-        let g = lowering(at: anchor.site, in: anchor.scope, { $0._type_apply(f.value, to: ts) })
+        let g = lowering(at: anchor, { $0._type_apply(f.value, to: ts) })
         return f.substituting(value: g)
       } else {
         return f
@@ -1052,7 +1051,7 @@ internal struct IREmitter {
       // the receiver's expression.
       let r = currentFunction.result(of: receiver)!.type
       if let ts = program.types.select(r, \TypeApplication.arguments) {
-        let g = lowering(at: anchor.site, in: anchor.scope, { $0._type_apply(f.value, to: ts) })
+        let g = lowering(at: anchor, { $0._type_apply(f.value, to: ts) })
         return f.substituting(value: g)
       } else {
         return f
@@ -1067,7 +1066,7 @@ internal struct IREmitter {
         let target = loweredCallee(
           referringTo: m, boundTo: receiver, markedForMutationBy: mutationMarker, output: result)
 
-        return lowering(at: anchor.site, in: anchor.scope) { (me) in
+        return lowering(at: anchor) { (me) in
           // References to members in extensions are expressed using a witness representing the
           // type and term arguments passed to parameters declared on the extension itself.
           let (e, ts, xs) = me._emit(decompose: w)
@@ -1084,7 +1083,7 @@ internal struct IREmitter {
           tp.typeOfImplementation(satisfying: m, in: w)
         }
 
-        return lowering(at: anchor.site, in: anchor.scope) { (me) in
+        return lowering(at: anchor) { (me) in
           let x0 = me._emit(witness: w)
           let x1 = me._property(m, of: x0, withType: typeOfImplementation)
           return LoweredCallee(value: x1, arguments: Array(contentsOf: receiver), result: result)
@@ -1517,7 +1516,7 @@ internal struct IREmitter {
     if let i = program[module].ir.functions.index(forKey: name) {
       return i
     } else {
-      let anchor = program.anchorForDiagnostics(about: .init(conformance))
+      let anchor = program.anchorForDiagnostics(about: conformance)
       let (terms, output) = prototype(functionOrConformance: requirement, applying: arguments)
       return program[module].ir.addFunction(
         IRFunction(
@@ -1552,7 +1551,7 @@ internal struct IREmitter {
     let o = program.types.dealiased(program.types[e].inhabitant)
     ps.append(.init(type: o, access: .set, declaration: nil))
 
-    let anchor = program.anchorForDiagnostics(about: .init(d))
+    let anchor = program.anchorForDiagnostics(about: d)
     return program[module].ir.addFunction(
       IRFunction(
         name: name, anchor: anchor, output: .indirect, typeParameters: ts, termParameters: ps))
@@ -1574,9 +1573,9 @@ internal struct IREmitter {
     // Declare the global's initializer.
     let t = program.types.dealiased(program.type(assignedTo: d))
     let o = IRParameter(type: t, access: .set, declaration: nil)
-    let a = program.anchorForDiagnostics(about: .init(d))
     let i = IRFunction(
-      name: .initializer(d), anchor: a, output: .indirect, typeParameters: [], termParameters: [o])
+      name: .initializer(d), anchor: program.anchorForDiagnostics(about: d),
+      output: .indirect, typeParameters: [], termParameters: [o])
     let f = program[module].ir.addFunction(i)
 
     // Declare the global itself.
@@ -1789,7 +1788,18 @@ internal struct IREmitter {
   private mutating func lowering<R>(
     at site: SourceSpan, in scope: ScopeIdentity, _ action: (inout Self) -> R
   ) -> R {
-    var a = Anchor(site: site, scope: scope) as Optional
+    var a = program.anchor(at: site, in: scope) as Optional
+    swap(&a, &insertionContext.anchor)
+    let r = action(&self)
+    swap(&a, &insertionContext.anchor)
+    return r
+  }
+
+  /// Returns the result of calling `action` on `self` with the given insertion anchor.
+  private mutating func lowering<R>(
+    at anchor: Anchor, _ action: (inout Self) -> R
+  ) -> R {
+    var a = anchor as Optional
     swap(&a, &insertionContext.anchor)
     let r = action(&self)
     swap(&a, &insertionContext.anchor)
@@ -2375,7 +2385,7 @@ internal struct IREmitter {
       // Is `d` referring to a local variable that is not yet in scope?
       if let v = program.cast(d, to: VariableDeclaration.self) {
         // The only way to get here is if `v` has not been defined yet.
-        let s = insertionContext.anchor!.site
+        let s = program.span(insertionContext.anchor!)
         report(.init(.error, "use of '\(program[v].identifier)' before its declaration", at: s))
         return .poison(program.types.ir(place: t))
       }
@@ -2760,7 +2770,7 @@ internal struct IREmitter {
               implicit deinitialization of instances of '\(program.show(t))' causes infinite \
               recursion in this context
               """
-            report(.init(.error, m, at: currentAnchor.site))
+            report(.init(.error, m, at: program.span(currentAnchor)))
             _emitTrap()
             return false
           }
@@ -3119,7 +3129,8 @@ internal struct IREmitter {
     if let pick = candidates.uniqueElement {
       return pick.witness
     } else {
-      report(program.noUniqueGivenInstance(of: goal, found: candidates, at: currentAnchor.site))
+      let s = program.span(currentAnchor)
+      report(program.noUniqueGivenInstance(of: goal, found: candidates, at: s))
       return nil
     }
   }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+DeadCodeElimination.swift
@@ -9,7 +9,7 @@ extension IRFunction {
         removeAll(after: i)
 
         let a = at(i).anchor
-        let s = IRUnreachable(anchor: .init(site: .empty(at: a.site.end), scope: a.scope))
+        let s = IRUnreachable(anchor: a.emptyAtEnd)
         append(s, to: b)
       }
     }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -159,14 +159,14 @@ private struct Transfer: AbstractTransferFunction {
 
     let s = f.reborrowedSource(i)
     let a = context.locals[access.source]!.place!
-    let d = context.withObject(at: a, computingLayoutWith: &typer) { (o, _) -> Diagnostic? in
+    let d = context.withObject(at: a, computingLayoutWith: &typer) { (o, tp) -> Diagnostic? in
       switch k {
       case .let:
         if f.isValidImmutableAccess(reborrowingFrom: s, sharedBy: borrowers(o.value)) {
           insertBorrower(i, into: &o.value)
           return nil
         } else {
-          return .illegalAccess(.let, at: access.anchor.site)
+          return tp.program.illegalAccess(.let, at: access.anchor)
         }
 
       case .inout, .set, .sink:
@@ -175,7 +175,7 @@ private struct Transfer: AbstractTransferFunction {
           insertBorrower(i, into: &o.value)
           return nil
         } else {
-          return .illegalAccess(k, at: access.anchor.site)
+          return tp.program.illegalAccess(k, at: access.anchor)
         }
 
       case .auto:

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
@@ -10,8 +10,8 @@ extension IRFunction {
     for i in instructions() {
       if let s = at(i) as? IRApply, case .function(let f, _) = s.callee {
         if typer.program.isPrivate(f, in: m) {
-          let d = Diagnostic(
-            .error, "use of non-exposed function in inlined function", at: s.anchor.site)
+          let a = typer.program.span(s.anchor)
+          let d = Diagnostic(.error, "use of non-exposed function in inlined function", at: a)
           typer.program[m].addDiagnostic(d)
           success = false
         }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -237,13 +237,13 @@ private struct Transfer: AbstractTransferFunction {
     // skip further changes to the context to avoid cascading diagnostics.
     let isLegal = (k == .let) || !f.isBoundImmutably(access.source)
     if !isLegal {
-      report(.illegalAccess(k, at: access.anchor.site))
+      report(program.illegalAccess(k, at: access.anchor))
     }
 
     switch k {
     case .let, .inout, .sink:
       if isLegal {
-        checkInitialized(place: access.source, in: f, at: access.anchor.site)
+        checkInitialized(place: access.source, in: f, at: program.span(access.anchor))
         if k == .sink { consume(place: access.source, with: i.erased, in: f) }
       }
       context.declare(i, from: f, initially: .initialized)
@@ -271,7 +271,7 @@ private struct Transfer: AbstractTransferFunction {
     let k = opener.capabilities.uniqueElement!
     switch k {
     case .let, .set, .inout:
-      checkInitialized(place: f.at(i).start, in: f, at: f.at(i).anchor.site)
+      checkInitialized(place: f.at(i).start, in: f, at: program.span(f.at(i).anchor))
 
       // Assume the postcondition moving forward.
       let a = context.locals[opener.source]!.place!
@@ -398,7 +398,7 @@ private struct Transfer: AbstractTransferFunction {
     _ i: IREnumTag.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
     let s = f.at(i)
-    checkInitialized(place: s.source, in: f, at: s.anchor.site)
+    checkInitialized(place: s.source, in: f, at: program.span(s.anchor))
     context.declare(i.erased, from: f, initially: .initialized)
     return f.instruction(after: i.erased)
   }
@@ -559,7 +559,7 @@ private struct Transfer: AbstractTransferFunction {
 
         // Report potential failures.
         if o.value != .uniform(.initialized) {
-          let s = f.at(i).anchor.site
+          let s = program.span(f.at(i).anchor)
           if v == f.returnRegister {
             report(.init(.error, "missing return value", at: s))
           } else {
@@ -712,11 +712,11 @@ private struct Transfer: AbstractTransferFunction {
     case .uniform(.initialized):
       break
     case .uniform(.uninitialized), .uniform(.phi):
-      report(.useOfUninitializedObject(at: site))
+      report(program.useOfUninitializedObject(at: site))
     case .uniform(.consumed):
-      report(.useOfConsumedObject(at: site))
+      report(program.useOfConsumedObject(at: site))
     case .mixed:
-      report(.useOfPartialObject(at: site))
+      report(program.useOfPartialObject(at: site))
     }
   }
 
@@ -742,15 +742,15 @@ private struct Transfer: AbstractTransferFunction {
     }
 
     let a = context.locals[place]!.place!
-    let d = context.withObject(at: a, computingLayoutWith: &typer) { (o, _) -> Diagnostic? in
+    let d = context.withObject(at: a, computingLayoutWith: &typer) { (o, _) -> Anchor? in
       if o.value == .uniform(.initialized) {
         o.value = .uniform(.consumed( [consumer]))
         return nil
       } else {
-        return .illegalMove(at: f.at(consumer).anchor.site)
+        return f.at(consumer).anchor
       }
     }
-    d.map({ (d) in report(d) })
+    d.map({ (d) in report(program.illegalMove(at: d)) })
   }
 
   /// Updates `object` to mark it consumed by `consumer`, reporting a diagnostic if `object` cannot
@@ -766,17 +766,17 @@ private struct Transfer: AbstractTransferFunction {
       return
     }
 
-    let d = modify(&context.locals[object]!) { (local) -> Diagnostic? in
+    let d = modify(&context.locals[object]!) { (local) -> Anchor? in
       var o = local.object!
       if o.value == .uniform(.initialized) {
         o.value = .uniform(.consumed([consumer]))
         local = .object(o)
         return nil
       } else {
-        return .illegalMove(at: f.at(consumer).anchor.site)
+        return f.at(consumer).anchor
       }
     }
-    d.map({ (d) in report(d) })
+    d.map({ (d) in report(program.illegalMove(at: d)) })
   }
 
   /// Inserts IR to deinitialize the specified `parts` of the object stored at `place` immediately
@@ -857,7 +857,7 @@ private struct Transfer: AbstractTransferFunction {
     case .let, .inout, .sink:
       // All three effects require that the object be fully initialized.
       let a = context.locals[v]!.place!
-      checkInitialized(place: v, in: f, at: f.at(i).anchor.site)
+      checkInitialized(place: v, in: f, at: program.span(f.at(i).anchor))
 
       // A `sink` access consumes its source.
       if k == .sink {
@@ -900,7 +900,7 @@ private struct Transfer: AbstractTransferFunction {
   ) {
     switch k {
     case .let, .set, .inout:
-      checkInitialized(place: v, in: f, at: f.at(e).anchor.site)
+      checkInitialized(place: v, in: f, at: program.span(f.at(e).anchor))
     case .sink:
       ensureDeinitialized(place: v, before: e, in: &f)
     case .auto:

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+YieldCoherence.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+YieldCoherence.swift
@@ -15,10 +15,12 @@ extension IRFunction {
   /// In the second phase, we run another breadth-first search starting from the slides we have
   /// identified and look for illegal yield statements.
   ///
+  /// Errors are reported `typer.program`.
+  ///
   /// - Complexity: O(*n*) where *n* is the number of instructions in the function.
-  internal mutating func checkYieldCoherence(reportingDiagnosticsTo log: inout DiagnosticSet) {
+  internal mutating func checkYieldCoherence(using typer: inout Typer) -> Bool {
     // Nothing to do if the function isn't a subscript or isn't defined.
-    if !isSubscript || !isDefined { return }
+    if !isSubscript || !isDefined { return true }
 
     /// A work list with the basic blocks to process.
     var work: [IRBlock.ID] = .init(minimumCapacity: blocks.count)
@@ -37,8 +39,8 @@ extension IRFunction {
         // Make sure there isn't another yield in the same block.
         for i in instructions(after: y) {
           if tag(of: i) == IRYield.self {
-            log.insert(extraneousYield(i, first: y))
-            return
+            typer.program.reportExtraneousYield(i, first: y, in: self)
+            return false
           }
         }
 
@@ -56,8 +58,8 @@ extension IRFunction {
 
       // Otherwise, complain that there isn't any yield statement.
       else {
-        log.insert(missingYield(at: .empty(at: at(blocks[b].last!).anchor.site.end)))
-        return
+        typer.program.reportMissingYield(endOf: b, in: self)
+        return false
       }
     }
 
@@ -70,8 +72,8 @@ extension IRFunction {
       // Make sure there isn't another yield in the block.
       let y = slide[b]!
       if let i = instructions(in: b).first(where: { (s) in tag(of: s) == IRYield.self }) {
-        log.insert(extraneousYield(i, first: y))
-        return
+        typer.program.reportExtraneousYield(i, first: y, in: self)
+        return false
       }
 
       // Collect the next blocks to visit.
@@ -80,6 +82,28 @@ extension IRFunction {
         work.append(s)
       }
     }
+
+    return true
+  }
+
+}
+
+extension Program {
+
+  /// Reports an error diagnosing that `extra` is an extraneous yield instruction occurring after,
+  /// which is another yield instruction in `f`.
+  fileprivate mutating func reportExtraneousYield(
+    _ extra: AnyInstructionIdentity, first: AnyInstructionIdentity, in f: IRFunction
+  ) {
+    let a = f.castUnchecked(extra, to: IRYield.self)
+    let b = f.castUnchecked(first, to: IRYield.self)
+    self[f.anchor.scope.module].addDiagnostic(extraneousYield(a, first: b, in: f))
+  }
+
+  /// Reports an error diagnosing that there is a missing yield statement at the end of `b`, which
+  /// is an exit point of `f`.
+  fileprivate mutating func reportMissingYield(endOf b: IRBlock.ID, in f: IRFunction) {
+    self[f.anchor.scope.module].addDiagnostic(missingYield(f.at(f.blocks[b].last!).anchor))
   }
 
 }

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -135,11 +135,7 @@ public struct Program: Sendable {
         work[i].function.closeOpenEndedRegions()
 
         // The following passes may fail.
-        var ds = DiagnosticSet()
-        work[i].function.checkYieldCoherence(reportingDiagnosticsTo: &ds)
-        typer.program[m].addDiagnostics(ds)
-        if ds.containsError { continue }
-
+        if !work[i].function.checkYieldCoherence(using: &typer) { continue }
         if !work[i].function.normalizeLifetimes(emittingInto: m, using: &typer) { continue }
         if !work[i].function.upholdExclusivity(emittingInto: m, using: &typer) { continue }
         if !work[i].function.upholdInliningRequirements(in: m, using: &typer) { continue }
@@ -1627,11 +1623,6 @@ public struct Program: Sendable {
     } else {
       return spanForDiagnostic(about: self[n].value)
     }
-  }
-
-  /// Returns an anchor suitable to generate debug information related to `d` as a whole.
-  public func anchorForDiagnostics(about d: DeclarationIdentity) -> Anchor {
-    .init(site: spanForDiagnostic(about: d), scope: parent(containing: d))
   }
 
   /// Returns `message` with placeholders replaced by their corresponding values in `arguments`.


### PR DESCRIPTION
This patch modifies the internal representation of anchors in the IR, so that an anchor referring to code in some module can be archived in a different module.