### PR TITLE
Add Hylo-demangle tool

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
   ],
   products: [
     .executable(name: "hc", targets: ["hc"]),
+    .executable(name: "hylo-demangle", targets: ["hylo-demangle"]),
     .library(name: "HyloStandardLibrary", targets: ["StandardLibrary"]),
     .library(name: "HyloFrontEnd", targets: ["FrontEnd"]),
   ],
@@ -56,6 +57,14 @@ let package = Package(
       name: "hc-tests",
       dependencies: [
         .product(name: "ArgumentParser", package: "swift-argument-parser")
+      ],
+      swiftSettings: commonSwiftSettings),
+
+    .executableTarget(
+      name: "hylo-demangle",
+      dependencies: [
+        .target(name: "FrontEnd"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       swiftSettings: commonSwiftSettings),
 

--- a/Sources/FrontEnd/IR/Mangling/DemangledSymbol.swift
+++ b/Sources/FrontEnd/IR/Mangling/DemangledSymbol.swift
@@ -3,7 +3,8 @@ internal indirect enum DemangledSymbol: Hashable, Sendable {
 
   /// Creates an instance decoding the symbol mangled in `s`.
   ///
-  /// `self` is assigned to an error if `s` is malformed.
+  /// `self` is assigned to `.notMangled` if `s` doesn't start with the mangling prefix, or to
+  /// `.error` if `s` is malformed.
   internal init(_ s: String) {
     guard s.starts(with: ManglingEncoding.manglingPrefix) else {
       self = .notMangled

--- a/Sources/FrontEnd/IR/Mangling/DemangledSymbol.swift
+++ b/Sources/FrontEnd/IR/Mangling/DemangledSymbol.swift
@@ -5,7 +5,13 @@ internal indirect enum DemangledSymbol: Hashable, Sendable {
   ///
   /// `self` is assigned to an error if `s` is malformed.
   internal init(_ s: String) {
-    if let x = String(assemblySanitized: s) {
+    guard s.starts(with: ManglingEncoding.manglingPrefix) else {
+      self = .notMangled
+      return
+    }
+
+    let m = String(s.dropFirst(ManglingEncoding.manglingPrefix.count))
+    if let x = String(assemblySanitized: m) {
       var source = DemanglingContext(stream: x[...])
       self = ManglingEncoding.demangle(from: &source)
     } else {
@@ -27,6 +33,9 @@ internal indirect enum DemangledSymbol: Hashable, Sendable {
   /// The payload captures what we could demangle until we encountered the error, if any, and the
   /// characters still remaining to be parsed.
   case error(DemangledSymbol?, remaining: String)
+
+  /// Indication that the symbol doesn't appear to be mangled at all.
+  case notMangled
 
   /// An instance decoding a reserved symbol identifier.
   internal init(reserved: ReservedSymbol) {
@@ -57,6 +66,8 @@ internal indirect enum DemangledSymbol: Hashable, Sendable {
       return "witness table"
     case .error:
       return "error"
+    case .notMangled:
+      return "not mangled"
     }
   }
 
@@ -78,6 +89,8 @@ extension DemangledSymbol: CustomStringConvertible {
       } else {
         return "#! (remaining: \(r))"
       }
+    case .notMangled:
+      return "#! not mangled"
     }
   }
 
@@ -439,6 +452,19 @@ extension DemangledType.Parameter: CustomStringConvertible {
     } else {
       return "\(type)"
     }
+  }
+
+}
+
+extension String {
+
+  /// Returns the demangled representation of `self` or `nil` if it is not a mangled symbol.
+  public func demangled() -> String? {
+    let d = DemangledSymbol(self)
+    if case .notMangled = d {
+      return nil
+    }
+    return d.description
   }
 
 }

--- a/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
@@ -1308,6 +1308,13 @@ internal struct ManglingEncoding: Sendable {
 
 }
 
+extension ManglingEncoding {
+
+  /// Prefix of all mangled Hylo symbols.
+  internal static let manglingPrefix = "$h"
+
+}
+
 extension ScopeIdentity {
 
   /// The mangling symbol corresponding to `self`.

--- a/Sources/FrontEnd/IR/Mangling/Program+Mangling.swift
+++ b/Sources/FrontEnd/IR/Mangling/Program+Mangling.swift
@@ -32,7 +32,7 @@ extension Program {
     var m = ManglingEncoding(self)
     var o = ManglingContext(self)
     mangle(s, &m, &o)
-    return o.output.assemblySanitized
+    return ManglingEncoding.manglingPrefix + o.output.assemblySanitized
   }
 
 }

--- a/Sources/hylo-demangle/CommandLine.swift
+++ b/Sources/hylo-demangle/CommandLine.swift
@@ -1,0 +1,101 @@
+import ArgumentParser
+import Foundation
+import FrontEnd
+
+/// Demangles Hylo mangled symbols found in input text.
+@main struct CommandLine: ParsableCommand {
+
+  /// Configuration for this command.
+  public static let configuration = CommandConfiguration(
+    commandName: "hylo-demangle", abstract: "Demangle Hylo mangled symbols found in input text.")
+
+  /// Whether to print a symbol-by-symbol listing instead of rewriting the input text.
+  @Flag(
+    name: [.customLong("list")],
+    help: "Print each demangled symbol on its own line.")
+  private var listOnly: Bool = false
+
+  /// Input text to scan. If empty, the command reads stdin.
+  @Argument(help: "Input text to scan. Reads stdin when omitted.")
+  private var inputText: [String] = []
+
+  /// Creates a new instance with default options.
+  public init() {}
+
+  /// Executes the command.
+  public func run() throws {
+    let input = try sourceText()
+
+    if listOnly {
+      input.enumerateTokens { (token) in
+        if let demangled = String(token).demangled() {
+          print("\(token) => \(demangled)")
+        }
+      }
+      return
+    }
+
+    printRewritten(input)
+  }
+
+  /// Returns the text to scan, from arguments or stdin.
+  private func sourceText() throws -> String {
+    if !inputText.isEmpty {
+      return inputText.joined(separator: " ")
+    }
+
+    let data = FileHandle.standardInput.readDataToEndOfFile()
+    guard let text = String(data: data, encoding: .utf8) else {
+      throw ValidationError("stdin is not valid UTF-8")
+    }
+    return text
+  }
+
+  /// Prints `input` with each matched mangled symbol replaced by its demangled form.
+  private func printRewritten(_ input: String) {
+    var lastIndex = input.startIndex
+    input.enumerateTokens { (token) in
+      if lastIndex < token.startIndex {
+        print(input[lastIndex..<token.startIndex], terminator: "")
+      }
+      if let demangled = String(token).demangled() {
+        print(demangled, terminator: "")
+      }
+      else {
+        print(token, terminator: "")
+      }
+      lastIndex = token.endIndex
+    }
+    if lastIndex < input.endIndex {
+      print(input[lastIndex..<input.endIndex], terminator: "")
+    }
+  }
+
+}
+
+extension String {
+
+  /// Enumerates candidate mangled symbols in `self`.
+  ///
+  /// A candidate starts at `$` and continues while characters remain valid mangling symbols.
+  fileprivate func enumerateTokens(_ action: (Substring) -> Void) {
+    var remaining = self[...]
+    while let start = remaining.firstIndex(of: "$") {
+      let token = remaining[start...]
+      let end = token.firstIndex(where: { (c) in !c.isValidManglingSymbol() }) ?? token.endIndex
+      action(token[..<end])
+      remaining = token[end...]
+    }
+  }
+
+}
+
+extension Character {
+
+  /// Returns `true` iff `self` is a valid symbol in a mangled Hylo symbol.
+  fileprivate func isValidManglingSymbol() -> Bool {
+    isASCII && (isLetter || isNumber || self == "_" || self == "." || self == "$")
+  }
+  
+}
+

--- a/Sources/hylo-demangle/CommandLine.swift
+++ b/Sources/hylo-demangle/CommandLine.swift
@@ -67,7 +67,7 @@ import FrontEnd
     }
   }
 
-  /// Prints the demangled form of each matched mangled symbol om `input`.
+  /// Prints the demangled form of each matched mangled symbol in `input`.
   private func printDemangled(_ input: String) {
     input.enumerateTokens { (token) in
       if let demangled = String(token).demangled() {

--- a/Sources/hylo-demangle/CommandLine.swift
+++ b/Sources/hylo-demangle/CommandLine.swift
@@ -27,15 +27,12 @@ import FrontEnd
     let input = try sourceText()
 
     if listOnly {
-      input.enumerateTokens { (token) in
-        if let demangled = String(token).demangled() {
-          print("\(token) => \(demangled)")
-        }
-      }
-      return
+      printDemangled(input)
+    }
+    else {
+      printRewritten(input)
     }
 
-    printRewritten(input)
   }
 
   /// Returns the text to scan, from arguments or stdin.
@@ -60,14 +57,22 @@ import FrontEnd
       }
       if let demangled = String(token).demangled() {
         print(demangled, terminator: "")
-      }
-      else {
+      } else {
         print(token, terminator: "")
       }
       lastIndex = token.endIndex
     }
     if lastIndex < input.endIndex {
       print(input[lastIndex..<input.endIndex], terminator: "")
+    }
+  }
+
+  /// Prints the demangled form of each matched mangled symbol om `input`.
+  private func printDemangled(_ input: String) {
+    input.enumerateTokens { (token) in
+      if let demangled = String(token).demangled() {
+        print("\(token) => \(demangled)")
+      }
     }
   }
 
@@ -96,6 +101,5 @@ extension Character {
   fileprivate func isValidManglingSymbol() -> Bool {
     isASCII && (isLetter || isNumber || self == "_" || self == "." || self == "$")
   }
-  
-}
 
+}

--- a/Tests/BackEndTests/SimpleFunctionEmitterTest.swift
+++ b/Tests/BackEndTests/SimpleFunctionEmitterTest.swift
@@ -31,7 +31,7 @@ final class SimpleFunctionEmitterTest: XCTestCase {
     XCTAssert(
       llvmIR.containsOnce(
         """
-        define private void @"M6testvUpvirtualu6rky9fkv9x3F06mainlT01tR50tR5$gP71L1L1L"() {
+        define private void @"$hM6testvUpvirtualu6rky9fkv9x3F06mainlT01tR50tR5$gP71L1L1L"() {
           %1 = alloca {}, align 8
           ret void
         }
@@ -42,7 +42,7 @@ final class SimpleFunctionEmitterTest: XCTestCase {
       llvmIR.containsOnce(
         """
         define i32 @main() {
-          call void @"M6testvUpvirtualu6rky9fkv9x3F06mainlT01tR50tR5$gP71L1L1L"()
+          call void @"$hM6testvUpvirtualu6rky9fkv9x3F06mainlT01tR50tR5$gP71L1L1L"()
           ret i32 0
         }
         """))


### PR DESCRIPTION
The tool parses the input and replaces the symbols that look like Hylo mangled symbols with their demangled string, keeping everything else the same.

Add "$h" as a prefix for Hylo mangled names.