### PR TITLE
Implement basic cross-module inlining

### DIFF
--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -256,7 +256,7 @@ extension Program {
     if case .function(let n, _) = s.callee {
       let f = demandFunction(named: n, in: &ctx.module)
       let x = insertArguments(s.arguments, mappedWith: f.prototype.mapping, in: &ctx)
-      insertCall(applying: f, to: x, writingResultTo: s.result, in: &ctx)
+      insertCall(f, with: x, writingResultTo: s.result, in: &ctx)
     }
 
     // Is the call indirect?
@@ -265,7 +265,7 @@ extension Program {
       let a = types.seenAsTermAbstraction(ctx.ir.result(of: s.callee)!.type)!
       let p = prototype(types[a], in: &ctx.module)
       let x = insertArguments(s.arguments, mappedWith: p.mapping, in: &ctx)
-      insertCall(applying: f, describedBy: p, to: x, writingResultTo: s.result, in: &ctx)
+      insertCall(f, describedBy: p, with: x, writingResultTo: s.result, in: &ctx)
     }
 
     return ctx.ir.instruction(after: i.erased)
@@ -276,12 +276,33 @@ extension Program {
     _ i: IRApplyBuiltin.ID, in ctx: inout FunctionGenerationContext
   ) -> AnyInstructionIdentity? {
     let s = ctx.ir.at(i)
+    let v = FrontEnd.IRValue.register(i.erased)
 
     switch s.callee {
     case .trap:
       insertTrap(in: &ctx)
     case .addressOf:
-      ctx.value[.register(i.erased)] = ctx.value[s.arguments[0]]!
+      ctx.value[v] = ctx.value[s.arguments[0]]!
+
+    case .sdiv(let e, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertSignedDiv(
+        exact: e, xs[0], xs[1], at: ctx.insertionPoint!).v
+
+    case .signedAdditionWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.sadd.with.overflow, for: t, with: s.arguments, in: &ctx)
+    case .signedSubtractionWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.ssub.with.overflow, for: t, with: s.arguments, in: &ctx)
+    case .signedMultiplicationWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.smul.with.overflow, for: t, with: s.arguments, in: &ctx)
+
+    case .icmp(let p, let t):
+      ctx.value[v] = insertCallBuiltinPredicate(
+        p, for: t, with: s.arguments, in: &ctx)
+
     default:
       unimplemented(String(describing: s.callee))
     }
@@ -956,6 +977,19 @@ extension Program {
     return w
   }
 
+  /// Returns the LLVM values corresponding to `xs`, which are instances of `t`, loaded in memory.
+  ///
+  /// `xs` is an array of IR values denoting places of type `t`, which are defined in the current
+  /// context. This method inserts a load for each of these values in the compiled function.
+  private mutating func insertLoad(
+    _ xs: [FrontEnd.IRValue], of t: MachineType.ID, in ctx: inout FunctionGenerationContext
+  ) -> [LLVMValue] {
+    let m = metadata(of: t, in: &ctx.module)
+    let lhs = ctx.module.llvm.insertLoad(m.llvm, from: ctx.value[xs[0]]!, at: ctx.insertionPoint!)
+    let rhs = ctx.module.llvm.insertLoad(m.llvm, from: ctx.value[xs[1]]!, at: ctx.insertionPoint!)
+    return [lhs.v, rhs.v]
+  }
+
   /// Returns the representations of `arguments`, which are passed to `callee`, in LLVM IR.
   ///
   /// The result contains a LLVM IR value for each non-erased parameter of the callee, computed
@@ -982,22 +1016,22 @@ extension Program {
     return actual
   }
 
-  /// Generates the LLVM IR code for applying `callee` to `xs`, writing the result of the call to
-  /// the storage represented by `result`.
+  /// Generates LLVM IR code for applying `callee` to `xs`, writing the result of the call to the
+  /// storage represented by `result`.
   private mutating func insertCall(
-    applying callee: FunctionMetadata, to xs: consuming [LLVMValue],
+    _ callee: FunctionMetadata, with xs: consuming [LLVMValue],
     writingResultTo result: FrontEnd.IRValue,
     in ctx: inout FunctionGenerationContext
   ) {
     insertCall(
-      applying: callee.value, describedBy: callee.prototype, to: xs,
+      callee.value, describedBy: callee.prototype, with: xs,
       writingResultTo: result, in: &ctx)
   }
 
-  /// Generates the LLVM IR code for applying `callee`, which is described by `shape`, to `xs`,
-  /// writing the result of the call to the storage represented by `result`.
+  /// Generates LLVM IR code for applying `callee`, which is described by `shape`, to `xs`, writing
+  /// the result of the call to the storage represented by `result`.
   private mutating func insertCall<F: SwiftyLLVM.IRValue>(
-    applying callee: F.UnsafeReference, describedBy shape: Prototype, to xs: consuming [LLVMValue],
+    _ callee: F.UnsafeReference, describedBy shape: Prototype, with xs: consuming [LLVMValue],
     writingResultTo result: FrontEnd.IRValue,
     in ctx: inout FunctionGenerationContext
   ) {
@@ -1019,6 +1053,46 @@ extension Program {
       _ = ctx.module.llvm.insertCall(
         callee.v, typed: shape.signature.t, on: xs, at: ctx.insertionPoint!)
     }
+  }
+
+  /// Generates LLVM IR code for applying `callee`, which is an integer predicate, to `xs`.
+  private mutating func insertCallBuiltinPredicate(
+    _ callee: FrontEnd.IntegerPredicate, for integer: MachineType.ID, with xs: [FrontEnd.IRValue],
+    in ctx: inout FunctionGenerationContext
+  ) -> LLVMValue {
+    let loaded = insertLoad(xs, of: integer, in: &ctx)
+    let result = ctx.module.llvm.insertIntegerComparison(
+      .init(callee), loaded[0], loaded[1], at: ctx.insertionPoint!)
+    return result.v
+  }
+
+  /// Generates the LLVM IR code for applying `callee`, which is the name of a function in the
+  /// family of `llvm.x.with.overflow`, to `xs`.
+  private mutating func insertCallBuiltinBinaryWithOverflow(
+    _ callee: IntrinsicFunction.Name, for integer: MachineType.ID, with xs: [FrontEnd.IRValue],
+    in ctx: inout FunctionGenerationContext
+  ) -> LLVMValue {
+    let bool = types.demand(MachineType.i(1))
+    let pair = types.tuple(of: [integer.erased, bool.erased])
+
+    let m = metadata(of: integer, in: &ctx.module)
+    let n = metadata(of: pair, in: &ctx.module)
+    let f = ctx.module.llvm.intrinsic(named: callee, for: [m.llvm])!
+
+    // Apply the intrinsic.
+    let loaded = insertLoad(xs, of: integer, in: &ctx)
+    let result = ctx.module.llvm.insertCall(f, on: loaded, at: ctx.insertionPoint!)
+
+    // Unpack the tuple returned by the intrinsic and re-pack it with Hylo's layout.
+    var adapted = ctx.module.llvm.poisonValue(of: n.llvm).v
+    let x0 = ctx.module.llvm.insertExtractValue(from: result, at: 0, at: ctx.insertionPoint!)
+    adapted = ctx.module.llvm.insertInsertValue(
+      x0, at: n.layout.propertyToField[0], into: adapted, at: ctx.insertionPoint!).v
+    let x1 = ctx.module.llvm.insertExtractValue(from: result, at: 1, at: ctx.insertionPoint!)
+    adapted = ctx.module.llvm.insertInsertValue(
+      x1, at: n.layout.propertyToField[1], into: adapted, at: ctx.insertionPoint!).v
+
+    return adapted
   }
 
   /// Generates the LLVM IR code for returning from the function being compiled.
@@ -1218,6 +1292,8 @@ extension Program {
       metadata(of: types.castUnchecked(t, to: TypeApplication.self), in: &ctx)
     case TypeWitness.self:
       metadata(of: types.castUnchecked(t, to: TypeWitness.self), in: &ctx)
+    case UniversalType.self:
+      metadata(of: types.castUnchecked(t, to: UniversalType.self), in: &ctx)
     default:
       unimplemented("no LLVM representation of the type '\(show(t))'")
     }
@@ -1328,7 +1404,7 @@ extension Program {
       } else if let properties = program.fields(of: t.erased, visibleFrom: ctx.hylo) {
         return program.metadata(record: n, fields: properties, in: &ctx)
       } else {
-        fatalError("no LLVM metadata representation of the type '\(program.show(t))'")
+        unimplemented("no LLVM representation of the type '\(program.show(t))'")
       }
     }
   }
@@ -1339,6 +1415,19 @@ extension Program {
   ) -> TypeMetadata {
     let p = types.demand(MachineType.ptr)
     return metadata(of: p, in: &ctx)
+  }
+
+  /// Returns the LLVM type representation of the Hylo type `t`.
+  private mutating func metadata(
+    of t: UniversalType.ID, in ctx: inout ModuleGenerationContext
+  ) -> TypeMetadata {
+    metadata(of: t, in: &ctx) { (program, ctx, t, n) in
+      if t.erased == .never {
+        return program.metadata(record: n, fields: [], in: &ctx)
+      } else {
+        unimplemented("no LLVM representation of the type '\(program.show(t))'")
+      }
+    }
   }
 
   /// Returns the LLVM type representation of a record type having the given name and fields.
@@ -1461,6 +1550,26 @@ extension Program {
 
     default:
       return nil
+    }
+  }
+
+}
+
+extension SwiftyLLVM.IntegerPredicate {
+
+  /// Creates an instance representing the same predicate as `other`.
+  fileprivate init(_ other: FrontEnd.IntegerPredicate) {
+    switch other {
+    case .eq: self = .eq
+    case .ne: self = .ne
+    case .ugt: self = .ugt
+    case .uge: self = .uge
+    case .ult: self = .ult
+    case .ule: self = .ule
+    case .slt: self = .slt
+    case .sge: self = .sge
+    case .sgt: self = .sgt
+    case .sle: self = .sle
     }
   }
 

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -985,9 +985,9 @@ extension Program {
     _ xs: [FrontEnd.IRValue], of t: MachineType.ID, in ctx: inout FunctionGenerationContext
   ) -> [LLVMValue] {
     let m = metadata(of: t, in: &ctx.module)
-    let lhs = ctx.module.llvm.insertLoad(m.llvm, from: ctx.value[xs[0]]!, at: ctx.insertionPoint!)
-    let rhs = ctx.module.llvm.insertLoad(m.llvm, from: ctx.value[xs[1]]!, at: ctx.insertionPoint!)
-    return [lhs.v, rhs.v]
+    return xs.map { (x) in
+      ctx.module.llvm.insertLoad(m.llvm, from: ctx.value[x]!, at: ctx.insertionPoint!).v
+    }
   }
 
   /// Returns the representations of `arguments`, which are passed to `callee`, in LLVM IR.

--- a/Sources/FrontEnd/IR/Anchor.swift
+++ b/Sources/FrontEnd/IR/Anchor.swift
@@ -41,7 +41,7 @@ extension Program {
 
   /// Creates an anchor attached to `site`, which is the same file as `scope`.
   public func anchor(at site: SourceSpan, in scope: ScopeIdentity) -> Anchor {
-    assert(modules.values[scope.module][scope.file].source == site.source)
+    assert(self[scope.module][scope.file].source == site.source)
     return .init(site: site, scope: scope)
   }
 
@@ -72,7 +72,7 @@ extension Program {
 
   /// Returns the region of text to which `anchor` is attached.
   public func span(_ anchor: Anchor) -> SourceSpan {
-    let source = modules.values[anchor.scope.module][anchor.scope.file].source
+    let source = self[anchor.scope.module][anchor.scope.file].source
     let x0 = source.index(line: anchor.start.line, utf16Offset: anchor.start.offset)
     let x1 = source.index(line: anchor.end.line, utf16Offset: anchor.end.offset)
     return .init(x0 ..< x1, in: source)

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2299,8 +2299,7 @@ internal struct IREmitter {
     properties[source.entry!] = target.block(defining: boundary)
 
     // Where control flow will jump on return.
-    let after: IRBlock.ID? =
-      (source.blocks.count > 1) ? target.split(before: boundary) : nil
+    let after: IRBlock.ID = target.split(before: boundary)
 
     // Initialize the insertion context.
     var formerContext = InsertionContext(function: target.move())
@@ -2324,10 +2323,8 @@ internal struct IREmitter {
         // If next instruction returns, then jump to the "after" block if it's been defined or
         // simply ignore the instruction otherwise.
         if source.tag(of: i) == IRReturn.self {
-          if let a = after {
-            insertionContext.anchor = properties.anchor(source.at(i))
-            _br(a)
-          }
+          insertionContext.anchor = properties.anchor(source.at(i))
+          _br(after)
         } else {
           _clone(i, from: source, substitutingOperandsWith: &properties)
         }

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -104,7 +104,7 @@ public struct IRFunction: Sendable {
   }
 
   /// The types of an IR function's parameters and return value.
-  public struct Signature: Sendable {
+  public struct Signature: Equatable, Sendable {
 
     /// The generic type parameters that the function accepts.
     public let context: [GenericParameter.ID]

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+Inlining.swift
@@ -21,40 +21,52 @@ extension IRFunction {
     return success
   }
 
-  /// Inlines the contents of the callees in `self` that have been resolved statically to a
-  /// declaration annotated with `@inline(always)`.
+  /// Inlines the contents of the callees in `self` that were resolved statically to a declaration
+  /// annotated with `@inline(always)`, and whose definition is visible from `m`.
   internal mutating func inlineSimpleCallees(emittingInto m: Module.ID, using typer: inout Typer) {
     var work = Array(blocks)
     while let b = work.popLast() {
       // Nothing to do if the block's empty.
-      guard var i = b.first else { continue }
+      guard var j = b.last else { continue }
 
-      // Look for calls to inline.
-      while i != b.last {
-        var j = instruction(after: i)!
+      // Look for calls to inline. `j` ranges over the identities of the block in reverse order so
+      // that we can set `i` to the instruction immediately before any split necessary to inline
+      // the contents of another function.
+      while j != b.first {
+        var i = instruction(before: j)!
+        defer { swap(&i, &j) }
 
-        if let s = at(i) as? IRApply, case .function(let f, _) = s.callee {
+        // TODO: Subscripts
+        if let s = at(j) as? IRApply, case .function(let f, _) = s.callee {
           // Should the callee be inlined?
-          let callee = typer.program[m].ir.functions[f]!
-          if !callee.isDefined || !typer.program.shouldInline(callee.name) { break }
+          let callee = typer.program[m].ir.functions[f]!.name
+          if !typer.program.shouldInline(callee) { continue }
+
+          // Can we access the callee's definition.
+          guard let (n, source) = typer.program.definition(of: callee, visibleFrom: m) else {
+            continue
+          }
+
+          for k in source.instructions() {
+            for case .function(let f, _) in source.at(k).operands {
+              typer.program[m].ir.declare(typer.program[n].ir.functions[f]!)
+            }
+          }
 
           // Construct a table mapping each parameter to its argument.
           var table = IRSubstitutionTable()
-          table[callee.returnRegister!] = s.result
+          table[source.returnRegister!] = s.result
           for (p, a) in s.arguments.enumerated() {
             table[.parameter(p)] = a
           }
 
           // Replace the call with the contents of the callee.
-          remove(i)
           typer.program.withEmitter(insertingIn: m) { (emitter) in
             emitter.insert(
-              contentsOf: callee, before: j, in: &self,
-              substitutingOperandsWith: table)
+              contentsOf: source, before: j, in: &self, substitutingOperandsWith: table)
           }
+          remove(j)
         }
-
-        swap(&i, &j)
       }
     }
   }

--- a/Sources/FrontEnd/Module.swift
+++ b/Sources/FrontEnd/Module.swift
@@ -184,6 +184,27 @@ public struct Module: Sendable {
       functions.index(forKey: name)
     }
 
+    /// Declares `f` in this module.
+    ///
+    /// Either `f` is not declared in `self` or the function named `f.name` in `self` has the same
+    /// signature as that of `f`. In either case, the definition of `f` (if any) is not copied.
+    @discardableResult
+    internal mutating func declare(_ f: IRFunction) -> (inserted: Bool, identity: IRFunction.ID) {
+      let inserted = modify(&functions[f.name]) { (slot) in
+        if let g = slot {
+          assert(f.signature() == g.signature())
+          return false
+        } else {
+          let g = IRFunction(
+            name: f.name, anchor: f.anchor, output: f.output,
+            typeParameters: f.typeParameters, termParameters: f.termParameters)
+          slot = .some(g)
+          return true
+        }
+      }
+      return (inserted, functions.index(forKey: f.name)!)
+    }
+
     /// Adds `f` to this module.
     ///
     /// - Requires: `self` contains no IR function having the name of `f`.

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1552,6 +1552,37 @@ public struct Program: Sendable {
     }
   }
 
+  /// Returns the definition of `f` iff such definition is visible from `m`.
+  ///
+  /// The result is the first definition of `f` found by inspecting `m` and then its dependencies,
+  /// in an arbitrary order. The method assumes all possible definitions of `f` to be equivalent,
+  /// which corresponds to LLVM's `linkonce` linkage type.
+  ///
+  /// - Requires: `f` is declared (possibly without a definition) in `m`.
+  public func definition(
+    of f: IRFunction.Name, visibleFrom m: Module.ID
+  ) -> (Module.ID, IRFunction)? {
+    guard let i = self[m].ir.identity(function: f) else {
+      preconditionFailure("'\(show(f))' not declared in module '\(self[m].name)'")
+    }
+
+    // Is `f` defined in `m`?
+    if self[m].ir[i].isDefined {
+      return (m, self[m].ir[i])
+    }
+
+    // Is `f` defined in a dependency?
+    for d in self[m].dependencies {
+      guard let n = self.identity(module: d) else { continue }
+      if let j = self[n].ir.identity(function: f), self[n].ir[j].isDefined {
+        return (n, self[n].ir[j])
+      }
+    }
+
+    // No definition available.
+    return nil
+  }
+
   /// Reports that `n` was not expected in the current execution path and exits the program.
   public func unexpected<T: SyntaxIdentity>(
     _ n: T, file: StaticString = #file, line: UInt = #line

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -63,9 +63,9 @@ public enum BuiltinFunction: Hashable, Sendable {
   //  case shl(OverflowBehavior, MachineType.ID)
   //
   //  case udiv(exact: Bool, MachineType.ID)
-  //
-  //  case sdiv(exact: Bool, MachineType.ID)
-  //
+
+  case sdiv(exact: Bool, MachineType.ID)
+
   //  case lshr(exact: Bool, MachineType.ID)
   //
   //  case ashr(exact: Bool, MachineType.ID)
@@ -424,8 +424,8 @@ extension BuiltinFunction {
     //      return .init(^t, ^t, to: ^t)
     //    case .udiv(_, let t):
     //      return .init(^t, ^t, to: ^t)
-    //    case .sdiv(_, let t):
-    //      return .init(^t, ^t, to: ^t)
+      case .sdiv(_, let t):
+      return s.demand(Arrow(t, t, to: t))
     //    case .lshr(_, let t):
     //      return .init(^t, ^t, to: ^t)
     //    case .ashr(_, let t):
@@ -768,8 +768,8 @@ extension BuiltinFunction: Showable {
     //      return (p != .ignore) ? "shl_\(p)_\(t)" : "shl_\(t)"
     //    case .udiv(let e, let t):
     //      return e ? "udiv_exact_\(t)" : "udiv_\(t)"
-    //    case .sdiv(let e, let t):
-    //      return e ? "sdiv_exact_\(t)" : "sdiv_\(t)"
+    case .sdiv(let e, let t):
+      return printer.format(e ? "sdiv_exact_\(t)" : "sdiv_\(t)", [t.erased])
     //    case .lshr(let e, let t):
     //      return e ? "lshr_exact_\(t)" : "lshr_\(t)"
     //    case .ashr(let e, let t):
@@ -1123,11 +1123,10 @@ extension BuiltinFunction {
     //    case "udiv":
     //      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
     //      self = .udiv(exact: p != nil, t)
-    //
-    //    case "sdiv":
-    //      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
-    //      self = .sdiv(exact: p != nil, t)
-    //
+    case "sdiv":
+      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
+      self = .sdiv(exact: p != nil, s.demand(t))
+
     //    case "lshr":
     //      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
     //      self = .lshr(exact: p != nil, t)

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -769,7 +769,7 @@ extension BuiltinFunction: Showable {
     //    case .udiv(let e, let t):
     //      return e ? "udiv_exact_\(t)" : "udiv_\(t)"
     case .sdiv(let e, let t):
-      return printer.format(e ? "sdiv_exact_\(t)" : "sdiv_\(t)", [t.erased])
+      return printer.format(e ? "sdiv_exact_%T" : "sdiv_%T", [t.erased])
     //    case .lshr(let e, let t):
     //      return e ? "lshr_exact_\(t)" : "lshr_\(t)"
     //    case .ashr(let e, let t):

--- a/Sources/FrontEnd/Types/MachineType.swift
+++ b/Sources/FrontEnd/Types/MachineType.swift
@@ -49,8 +49,8 @@ extension MachineType: CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case .i(let bitWidth):
-      return "i\(bitWidth)"
+    case .i(let width):
+      return "i\(width)"
     case .word:
       return "word"
     case .float16:

--- a/StandardLibrary/Sources/Core/Numbers/Int32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Int32.hylo
@@ -13,6 +13,94 @@ public struct Int32 is Deinitializable {
     &self.value = Builtin.zeroinitializer_i32()
   }
 
+  /// Returns the sum of `self` and `other`.
+  ///
+  /// - Requires: The result is representable in `Self`.
+  @inline(always)
+  public fun infix+ (other: Self) -> Self {
+    let (result, overflow) = Builtin.sadd_with_overflow_i32(self.value, other.value)
+    if Bool(value: overflow) {
+      Builtin.trap()
+    } else {
+      return .new(value: result)
+    }
+  }
+
+  /// Returns the result of `other` subtracted from `self`.
+  ///
+  /// - Requires: The result is representable in `Self`.
+  @inline(always)
+  public fun infix- (other: Self) -> Self {
+    let (result, overflow) = Builtin.ssub_with_overflow_i32(self.value, other.value)
+    if Bool(value: overflow) {
+      Builtin.trap()
+    } else {
+      return .new(value: result)
+    }
+  }
+
+  /// Returns the result of `self` multiplied by `other`.
+  ///
+  /// - Requires: The result is representable in `Self`.
+  @inline(always)
+  public fun infix* (other: Self) -> Self {
+    let (result, overflow) = Builtin.smul_with_overflow_i32(self.value, other.value)
+    if Bool(value: overflow) {
+      Builtin.trap()
+    } else {
+      return .new(value: result)
+    }
+  }
+
+  /// Returns the result of `self` divided by `other`.
+  ///
+  /// - Requires: `other` is different from zero.
+  @inline(always)
+  public fun infix/ (other: Self) -> Self {
+    if other == (0 as Self) {
+      Builtin.trap()
+    } else {
+      return .new(value: Builtin.sdiv_i32(self.value, other.value))
+    }
+  }
+
+
+  /// Returns `true` iff `self` is equal to `other`.
+  @inline(always)
+  public fun infix== (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_eq_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is not equal to `other`.
+  @inline(always)
+  public fun infix!= (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_ne_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is less than `other`.
+  @inline(always)
+  public fun infix< (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_slt_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is less than or equal to `other`.
+  @inline(always)
+  public fun infix<= (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_sle_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is greater than `other`.
+  @inline(always)
+  public fun infix> (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_sgt_i32(self.value, other.value))
+  }
+
+  /// Returns `true` iff `self` is greater than or equal to `other`.
+  @inline(always)
+  public fun infix>= (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_sge_i32(self.value, other.value))
+  }
+
 }
 
 public given Int32 is ExpressibleByIntegerLiteral { /* built-in */ }

--- a/Tests/CompilerTests/positive/factorial.hylo
+++ b/Tests/CompilerTests/positive/factorial.hylo
@@ -1,0 +1,14 @@
+//! exit-status:24 optimizations:all
+
+fun factorial(n: sink Int32) -> Int32 {
+  var m: Int32 = 1
+  while n > (0 as Int32) {
+    &m = m * n
+    &n = n - (1 as Int32)
+  }
+  return m
+}
+
+public fun main() -> Int32 {
+  factorial(4 as Int32)
+}

--- a/Tests/CompilerTests/positive/fibonacci.hylo
+++ b/Tests/CompilerTests/positive/fibonacci.hylo
@@ -1,0 +1,13 @@
+//! exit-status:21
+
+fun fibonacci(n: sink Int32) -> Int32 {
+  if n > (1 as Int32) {
+    fibonacci(n - (1 as Int32)) + fibonacci(n - (2 as Int32))
+  } else {
+    n
+  }
+}
+
+public fun main() -> Int32 {
+  fibonacci(8 as Int32)
+}

--- a/Tests/CompilerTests/positive/inlining.hylo
+++ b/Tests/CompilerTests/positive/inlining.hylo
@@ -1,10 +1,14 @@
 //! stage:lowering
 
+@inline(never)
+fun one() -> Int32 { 1 }
+
 @inline
 fun two(c: Bool) -> Int32 {
-  if c { 2 } else { 3 }
+  if c { 2 } else { one() }
 }
 
 public fun main() -> Int32 {
+  // `two` is inlined but `one` isn't.
   two(true)
 }

--- a/Tests/CompilerTests/positive/inlining.refined-ir.expected
+++ b/Tests/CompilerTests/positive/inlining.refined-ir.expected
@@ -1,0 +1,35 @@
+fun main(set %p0: Int32) {
+%b0:
+  %r0 = alloca Bool, #preferred
+  %r1 = subfield %r0 at 0 as i1
+  %r2 = access [set] %r1
+  %r3 = store i1 1 to %r2
+  %r4 = end %r2
+  %r5 = access [let] %r0
+  %r6 = access [set] %p0
+  %r14 = subfield %r5 at 0 as i1
+  %r15 = access [let] %r14
+  %r16 = load %r15
+  %r17 = end %r15
+  %r18 = condbr %r16, %b4, %b2
+%b1:
+  %r10 = end %r6
+  %r9 = end %r5
+  %r11 = access [sink] %r0
+  %r12 = assume_state %r11 uninitialized
+  %r13 = end %r11
+  %r8 = return
+%b2:
+  %r25 = access [set] %r6
+  %r26 = apply one() => %r25
+  %r27 = end %r25
+  %r28 = br %b3
+%b3:
+  %r24 = br %b1
+%b4:
+  %r19 = subfield %r6 at 0 as i32
+  %r20 = access [set] %r19
+  %r21 = store i32 2 to %r20
+  %r22 = end %r20
+  %r23 = br %b3
+}


### PR DESCRIPTION
This patch implements basic cross-module inlining for functions marked with `@inline(always)`, which mandates inlining.

Inlining is not yet guaranteed to apply recursively on all `@inline(always)` functions as this patch does not implement any call-graph analysis. However, the change is sufficient to support the compilation of user-programs using basic functions from the standard library, without compiling the standard library into its own object file.

See `factorial.hylo` for a demonstration.