### PR TITLE
Fix formatting injection

### DIFF
--- a/Sources/FrontEnd/Diagnostic.swift
+++ b/Sources/FrontEnd/Diagnostic.swift
@@ -123,7 +123,7 @@ extension Program {
     _ f: AnyTypeIdentity, mutably isAppliedMutably: Bool, at site: SourceSpan
   ) -> Diagnostic {
     let x = isAppliedMutably ? "mutably" : "immutably"
-    let m = format("cannot call bundle of type '%T' \(x)", [f])
+    let m = format("cannot call bundle of type '%T' %S", [f, x])
     return .init(.error, m, at: site)
   }
 
@@ -273,9 +273,9 @@ extension Program {
     let message: String = {
       if let u = t {
         if let m = types[u] as? Metatype {
-          return format("type '%T' has no static member '\(n)'", [m.inhabitant])
+          return format("type '%T' has no static member '%S'", [m.inhabitant, n])
         } else {
-          return format("type '%T' has no member '\(n)'", [u])
+          return format("type '%T' has no member '%S'", [u, n])
         }
       } else {
         return "undefined symbol '\(n)'"

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1679,7 +1679,7 @@ public struct Program: Sendable {
 
       case let c:
         let s = c.map(String.init(_:)) ?? ""
-        fatalError("invalid placeholder '%\(s)'", file: file, line: line)
+        fatalError("invalid placeholder '%\(s)' in message: \(message)", file: file, line: line)
       }
     }
 

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -759,11 +759,11 @@ extension BuiltinFunction: Showable {
     case .assumeInitialized(let b):
       return "assume_\(b ? "" : "un")initialized"
     case .add(let p, let t):
-      return printer.format((p != .ignore) ? "add_\(p)_%T" : "add_%T", [t.erased])
+      return printer.format((p != .ignore) ? "add_%S_%T" : "add_%T", [p, t.erased])
     case .sub(let p, let t):
-      return printer.format((p != .ignore) ? "sub_\(p)_%T" : "sub_%T", [t.erased])
+      return printer.format((p != .ignore) ? "sub_%S_%T" : "sub_%T", [p, t.erased])
     case .mul(let p, let t):
-      return printer.format((p != .ignore) ? "mul_\(p)_%T" : "mul_%T", [t.erased])
+      return printer.format((p != .ignore) ? "mul_%S_%T" : "mul_%T", [p, t.erased])
     //    case .shl(let p, let t):
     //      return (p != .ignore) ? "shl_\(p)_\(t)" : "shl_\(t)"
     //    case .udiv(let e, let t):
@@ -797,7 +797,7 @@ extension BuiltinFunction: Showable {
     case .unsignedMultiplicationWithOverflow(let t):
       return printer.format("umul_with_overflow_%T", [t.erased])
     case .icmp(let p, let t):
-      return printer.format("icmp_\(p)_%T", [t.erased])
+      return printer.format("icmp_%S_%T", [p, t.erased])
     //    case .trunc(let l, let r):
     //      return "trunc_\(l)_\(r)"
     //    case .zext(let l, let r):


### PR DESCRIPTION
Fixes #297 

The problem was that some string was interpolated into the formatting string, which ended up becoming parsed by `Program.format` and failed. We should never use raw string interpolation except if we are sure the injected string won't contain `%`.