### PR TITLE
Clarify Metatype layout documentation.

### DIFF
--- a/Sources/BackEnd/ModuleGenerationContext.swift
+++ b/Sources/BackEnd/ModuleGenerationContext.swift
@@ -61,7 +61,8 @@ internal struct ModuleGenerationContext: ~Copyable {
 
   /// The header of the structure representing information stored in all type witnesses.
   ///
-  /// A type witness is a 4-tuple optionally followed by a buffer of pointers, containing:
+  /// A type witness is a 4-tuple followed by a tail buffer of zero or more pointers. 
+  /// The tuple contains:
   /// - A string describing the type being witnessed;
   /// - The size of the type, as a 32-bit unsigned integer;
   /// - The alignment of the type, as a 16-bit unsigned ingeter;

--- a/Sources/BackEnd/ModuleGenerationContext.swift
+++ b/Sources/BackEnd/ModuleGenerationContext.swift
@@ -61,7 +61,7 @@ internal struct ModuleGenerationContext: ~Copyable {
 
   /// The header of the structure representing information stored in all type witnesses.
   ///
-  /// A type witness is a 4-tuple optionally followed by a buffer of pointers containing:
+  /// A type witness is a 4-tuple optionally followed by a buffer of pointers, containing:
   /// - A string describing the type being witnessed;
   /// - The size of the type, as a 32-bit unsigned integer;
   /// - The alignment of the type, as a 16-bit unsigned ingeter;


### PR DESCRIPTION
Otherwise, this comment says that the buffer of pointers contains those things.  The first commit clarifies with just a comma.  The second commit goes a bit further.