### PR TITLE
Fix bugs in SortedSet

### DIFF
--- a/Sources/Utilities/SortedSet.swift
+++ b/Sources/Utilities/SortedSet.swift
@@ -161,10 +161,10 @@ extension SortedSet: SetAlgebra {
   public mutating func update(with e: consuming Element) -> Element? {
     let (inserted, k) = index(insertingIfAbsent: e)
     if inserted {
+      return nil
+    } else {
       swap(&e, &elements[k])
       return e
-    } else {
-      return nil
     }
   }
 
@@ -177,29 +177,46 @@ extension SortedSet: SetAlgebra {
     self = union(other)
   }
 
+  /// Returns all elements that are in `self` or `other`.
+  /// 
+  /// - Complexity: O(self.count + other.count)
   public func union(_ other: SortedSet) -> SortedSet {
-    var lhs = self.elements
-    var rhs = other.elements
-
-    // Insert into the largest container to minimize the number of lookups.
-    if lhs.count < rhs.count { swap(&lhs, &rhs) }
-
-    var i = 0
-    for j in rhs.indices {
-      let e = rhs[j]
-      let k = lhs[i...].partitioningIndex(where: { (x) in e <= x })
-
-      if k >= lhs.count {
-        lhs.append(contentsOf: other.elements[j...])
-        break
-      } else if self.elements[k] != e {
-        lhs.insert(e, at: k)
-      }
-
-      i = k + 1
+    if self.isEmpty {
+      return other
+    } else if other.isEmpty {
+      return self
     }
 
-    return .init(sorted: lhs)
+    var result: ContiguousArray<Element> = []
+    result.reserveCapacity(Swift.max(self.count, other.count))
+    var i = 0
+    var j = 0
+
+    while true {
+      if i == self.count {
+        result.append(contentsOf: other.elements[j...])
+        return .init(sorted: result)
+      }
+      if j == other.count {
+        result.append(contentsOf: self.elements[i...])
+        return .init(sorted: result)
+      }
+
+      let a = self.elements[i]
+      let b = other.elements[j]
+
+      if a == b {
+        result.append(a)
+        i += 1
+        j += 1
+      } else if a < b {
+        result.append(a)
+        i += 1
+      } else {
+        result.append(b)
+        j += 1
+      }
+    }
   }
 
   public mutating func formIntersection(_ other: Self) {
@@ -243,7 +260,14 @@ extension SortedSet: SetAlgebra {
     var i = 0
     var j = 0
 
-    while (i < self.elements.count) && (j < other.elements.count) {
+    while true {
+      if i == self.elements.count {
+        result.append(contentsOf: other.elements[j...])
+        return .init(sorted: result)
+      } else if j == other.elements.count {
+        result.append(contentsOf: self.elements[i...])
+        return .init(sorted: result)
+      }
       let a = self.elements[i]
       let b = other.elements[j]
       if a == b {
@@ -257,8 +281,6 @@ extension SortedSet: SetAlgebra {
         j += 1
       }
     }
-
-    return .init(sorted: result)
   }
 
 }

--- a/Tests/UtilitiesTests/SeedableRandomNumberGenerator.swift
+++ b/Tests/UtilitiesTests/SeedableRandomNumberGenerator.swift
@@ -1,0 +1,22 @@
+/// A deterministic, seedable pseudo-random number generator for reproducible tests.
+///
+/// Uses the [Splitmix64](https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64) algorithm.
+struct SeedableRandomNumberGenerator: RandomNumberGenerator {
+
+  private var state: UInt64
+
+  /// Creates an instance with the given seed.
+  init(seed: UInt64) {
+    self.state = seed
+  }
+
+  /// Calculates and returns the next random number.
+  mutating func next() -> UInt64 {
+    state &+= 0x9E37_79B9_7F4A_7C15
+    var z = state
+    z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+    z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+    return z ^ (z >> 31)
+  }
+
+}

--- a/Tests/UtilitiesTests/SortedSetTests.swift
+++ b/Tests/UtilitiesTests/SortedSetTests.swift
@@ -143,4 +143,224 @@ final class SortedSetTests: XCTestCase {
     XCTAssertEqual(s.description, "[1, 2, 3]")
   }
 
+  func testUnion() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      let observed = a.union(b)
+      let expected = Set(a).union(Set(b)).sorted()
+      XCTAssert(
+        observed.elementsEqual(expected),
+        "\(Array(a)) U \(Array(b)) == \(Array(observed)); expected \(expected)")
+
+      // The union is commutative.
+      XCTAssertEqual(observed, b.union(a), "\(Array(a)) U \(Array(b))")
+
+      // `formUnion` agrees with `union`.
+      var c = a
+      c.formUnion(b)
+      XCTAssertEqual(c, observed, "\(Array(a)) U \(Array(b))")
+    }
+  }
+
+  func testIntersection() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      let observed = a.intersection(b)
+      let expected = Set(a).intersection(Set(b)).sorted()
+      XCTAssert(
+        observed.elementsEqual(expected),
+        "\(Array(a)) n \(Array(b)) == \(Array(observed)); expected \(expected)")
+
+      // The intersection is commutative.
+      XCTAssertEqual(observed, b.intersection(a), "\(Array(a)) n \(Array(b))")
+
+      // `formIntersection` agrees with `intersection`.
+      var c = a
+      c.formIntersection(b)
+      XCTAssertEqual(c, observed, "\(Array(a)) n \(Array(b))")
+    }
+  }
+
+  func testSymmetricDifferenceOracle() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      // The result matches the oracle implementation.
+      let observed = a.symmetricDifference(b)
+      let expected = Set(a).symmetricDifference(Set(b)).sorted()
+      XCTAssert(
+        observed.elementsEqual(expected),
+        "\(Array(a)) ∆ \(Array(b)) == \(Array(observed)); expected \(expected)")
+    }
+  }
+
+  func testSymmetricDifferenceCommutative() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      // Symmetric difference is commutative.
+      let observed = a.symmetricDifference(b)
+      XCTAssertEqual(observed, b.symmetricDifference(a), "\(Array(a)) ∆ \(Array(b))")
+    }
+  }
+
+  func testSymmetricDifferenceUnion() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      let observed = a.symmetricDifference(b)
+      // A ∆ B == (A \ B) U (B \ A)
+      XCTAssertEqual(
+        observed, a.subtracting(b).union(b.subtracting(a)), "\(Array(a)) ∆ \(Array(b))")
+    }
+  }
+
+  func testFormSymmetricDifference() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      // `formSymmetricDifference` agrees with `symmetricDifference`.
+      var c = a
+      c.formSymmetricDifference(b)
+      XCTAssertEqual(c, a.symmetricDifference(b), "\(Array(a)) ∆ \(Array(b))")
+    }
+  }
+
+  func testSubtractingOracle() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      let observed = a.subtracting(b)
+      let expected = Set(a).subtracting(Set(b)).sorted()
+      XCTAssert(
+        observed.elementsEqual(expected),
+        "\(Array(a)) \\ \(Array(b)) == \(Array(observed)); expected \(expected)")
+
+      // `subtract` agrees with `subtracting`.
+      var c = a
+      c.subtract(b)
+      XCTAssertEqual(c, observed, "\(Array(a)) \\ \(Array(b))")
+    }
+  }
+
+  func testInitCombiningOracle() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for sources in g.randomSetLists() {
+      let observed = SortedSet(combining: sources)
+      let expected = sources.reduce(into: Set<Int>(), { (s, x) in s.formUnion(x) }).sorted()
+      XCTAssert(
+        observed.elementsEqual(expected),
+        "combining \(sources.map(Array.init)) == \(Array(observed)); expected \(expected)")
+    }
+  }
+
+  func testInclusionPredicates() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      let x = Set(a)
+      let y = Set(b)
+      let m = "\(Array(a)) vs \(Array(b))"
+      XCTAssertEqual(a.isSubset(of: b), x.isSubset(of: y), m)
+      XCTAssertEqual(a.isSuperset(of: b), x.isSuperset(of: y), m)
+      XCTAssertEqual(a.isStrictSubset(of: b), x.isStrictSubset(of: y), m)
+      XCTAssertEqual(a.isStrictSuperset(of: b), x.isStrictSuperset(of: y), m)
+      XCTAssertEqual(a.isDisjoint(with: b), x.isDisjoint(with: y), m)
+
+      // A set is a subset of its union with any other set and a superset of its intersection.
+      XCTAssert(a.isSubset(of: a.union(b)), m)
+      XCTAssert(a.isSuperset(of: a.intersection(b)), m)
+    }
+  }
+
+  func testIndexInsertingIfAbsent() {
+    var g = SeedableRandomNumberGenerator(seed: 0)
+    for (a, b) in g.randomSetPairs() {
+      for e in b {
+        var s = a
+        let m = "inserting \(e) in \(Array(a))"
+        let (inserted, k) = s.index(insertingIfAbsent: e)
+        XCTAssertEqual(inserted, !a.contains(e), m)
+        XCTAssertEqual(s[k], e, m)
+        XCTAssertEqual(s.firstIndex(of: e), k, m)
+        XCTAssertEqual(s, a.union([e]), m)
+      }
+    }
+  }
+
+  func testInsertReturnsMemberAlreadyPresent() {
+    var s: SortedSet<Keyed> = [.init(key: 1, payload: "a")]
+
+    let p0 = s.insert(.init(key: 2, payload: "b"))
+    XCTAssert(p0.inserted)
+    XCTAssertEqual(p0.memberAfterInsert.payload, "b")
+
+    // The member already in the set is returned, not the one passed as an argument.
+    let p1 = s.insert(.init(key: 1, payload: "z"))
+    XCTAssertFalse(p1.inserted)
+    XCTAssertEqual(p1.memberAfterInsert.payload, "a")
+    XCTAssertEqual(s[0].payload, "a")
+  }
+
+  func testUpdateWith() {
+    var s: SortedSet<Keyed> = [.init(key: 1, payload: "a"), .init(key: 3, payload: "c")]
+
+    // Updating with an absent member inserts it and returns `nil`.
+    XCTAssertNil(s.update(with: .init(key: 2, payload: "b")))
+    XCTAssertEqual(s.map(\.payload), ["a", "b", "c"])
+
+    // Updating with a present member replaces it and returns the member it replaced.
+    XCTAssertEqual(s.update(with: .init(key: 1, payload: "z"))?.payload, "a")
+    XCTAssertEqual(s.map(\.payload), ["z", "b", "c"])
+  }
+
+  /// An element whose equality and ordering are defined by `key` alone, ignoring `payload`.
+  ///
+  /// Used for distinguishing between which instance is returned upon updates.
+  private struct Keyed: Comparable, Hashable {
+
+    /// The value defining the identity of `self`.
+    let key: Int
+
+    /// A value that takes no part in equality or ordering.
+    let payload: String
+
+    static func < (l: Self, r: Self) -> Bool {
+      l.key < r.key
+    }
+
+    static func == (l: Self, r: Self) -> Bool {
+      l.key == r.key
+    }
+
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(key)
+    }
+
+  }
+
+}
+
+extension RandomNumberGenerator {
+
+  /// Returns lists of pseudo-random sets to combine, covering a range of lengths, sizes, and
+  /// overlaps, drawn from `g`.
+  fileprivate mutating func randomSetLists() -> [[SortedSet<Int>]] {
+    (0..<300).map { (_) in
+      let bound = Int.random(in: 1...24, using: &self)
+      return (0..<Int.random(in: 0...5, using: &self)).map { (_) in
+        randomSet(maxCount: Int.random(in: 0...8, using: &self), bound: bound)
+      }
+    }
+  }
+
+  /// Returns pairs of pseudo-random sets covering a range of sizes and overlaps, drawn from `g`.
+  fileprivate mutating func randomSetPairs() -> [(SortedSet<Int>, SortedSet<Int>)] {
+    (0..<100).map { (_) in
+      let bound = Int.random(in: 1...24, using: &self)
+      let a = randomSet(maxCount: Int.random(in: 0...16, using: &self), bound: bound)
+      let b = randomSet(maxCount: Int.random(in: 0...16, using: &self), bound: bound)
+      return (a, b)
+    }
+  }
+
+  /// Returns a set of at most `maxCount` elements drawn from `0 ..< bound` using `g`.
+  fileprivate mutating func randomSet(maxCount: Int, bound: Int) -> SortedSet<Int> {
+    SortedSet((0..<maxCount).map({ (_) in Int.random(in: 0..<bound, using: &self) }))
+  }
+
 }


### PR DESCRIPTION
- `union` was O(n^2) instead of O(n+m)
- `update` had its nil-returning semantics opposite to what the [protocol required](https://developer.apple.com/documentation/swift/setalgebra/update(with:)).
- `union` and `symmetricDifference` didn't include the rest of the elements when one side was emptied