### PR TITLE
Add hc --version option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Embed release version
         run: |
           $version = $env:RELEASE_TAG -replace '^v', ''
-          "let hyloVersion = `"$version`"" | Set-Content Sources/hc/Version.swift
+          "internal let hyloVersion = `"$version`"" | Set-Content Sources/hc/Version.swift
         shell: pwsh
 
       - name: Download Recent Visual Studio and Windows SDK
@@ -147,7 +147,6 @@ jobs:
 
           $binaryName = if ($env:RUNNER_OS -eq 'Windows') { 'hc.exe' } else { 'hc' }
           $binary = Join-Path $extractDir $binaryName
-          & $binary --help
           $expectedVersion = $env:RELEASE_TAG -replace '^v', ''
           $actualVersion = (& $binary --version).Trim()
           if ($actualVersion -ne $expectedVersion) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env: &distributable-env
       ARTIFACT_NAME: hylo-${{ github.ref_name }}-${{ matrix.target }}
+      RELEASE_TAG: ${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@v7
@@ -68,6 +69,12 @@ jobs:
           llvmBuildConfig: MinSizeRel
           addToPkgConfigPath: true
           addToPath: true
+
+      - name: Embed release version
+        run: |
+          $version = $env:RELEASE_TAG -replace '^v', ''
+          "let hyloVersion = `"$version`"" | Set-Content Sources/hc/Version.swift
+        shell: pwsh
 
       - name: Download Recent Visual Studio and Windows SDK
         uses: compnerd/gha-setup-vsdevenv@main
@@ -141,6 +148,11 @@ jobs:
           $binaryName = if ($env:RUNNER_OS -eq 'Windows') { 'hc.exe' } else { 'hc' }
           $binary = Join-Path $extractDir $binaryName
           & $binary --help
+          $expectedVersion = $env:RELEASE_TAG -replace '^v', ''
+          $actualVersion = (& $binary --version).Trim()
+          if ($actualVersion -ne $expectedVersion) {
+            throw "Expected version '$expectedVersion', got '$actualVersion'"
+          }
         shell: pwsh
 
       - name: Upload distributable to draft release

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -12,9 +12,7 @@ private typealias Module = FrontEnd.Module
 @main struct CommandLine: AsyncParsableCommand {
 
   /// Configuration for this command.
-  public static let configuration = CommandConfiguration(
-    commandName: "hc",
-    version: hyloVersion)
+  public static let configuration = CommandConfiguration(commandName: "hc", version: hyloVersion)
 
   /// The paths at which libraries may be found.
   @Option(

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -12,7 +12,9 @@ private typealias Module = FrontEnd.Module
 @main struct CommandLine: AsyncParsableCommand {
 
   /// Configuration for this command.
-  public static let configuration = CommandConfiguration(commandName: "hc")
+  public static let configuration = CommandConfiguration(
+    commandName: "hc",
+    version: hyloVersion)
 
   /// The paths at which libraries may be found.
   @Option(

--- a/Sources/hc/Version.swift
+++ b/Sources/hc/Version.swift
@@ -1,0 +1,1 @@
+let hyloVersion = "development"

--- a/Sources/hc/Version.swift
+++ b/Sources/hc/Version.swift
@@ -1,1 +1,1 @@
-let hyloVersion = "development"
+internal let hyloVersion = "development"


### PR DESCRIPTION
## Summary

Closes #316.

Adds a built-in `hc --version` option and embeds the release tag into every
published distributable.

## Changes

- adds `Sources/hc/Version.swift` with `development` as the local-build value
- wires that value into `ArgumentParser`'s command configuration
- replaces the source value from `github.ref_name` before release builds
- verifies the unpacked distributable reports the expected tag-derived version
  on every release matrix target

The release workflow strips only the conventional leading `v`, so a tag such
as `v0.2.0-test-lsp` produces `hc --version` output of `0.2.0-test-lsp`.

## Testing

- parsed `.github/workflows/release.yml` with PyYAML
- built `hc` locally with Swift 6.3 and LLVM 20.1.8
- verified the default binary reports `development`
- temporarily embedded `1.2.3-test`, rebuilt, and verified the binary reports
  exactly `1.2.3-test`
- ran `git diff --check`

`swift test` reaches test-target compilation but cannot import `XCTest` because
this machine has Apple Command Line Tools rather than `Xcode.app`. The `hc`
product itself builds successfully; the repository CI runs the full test suite
with its configured Swift and LLVM environment.
