### PR TITLE
Avoid creating fresh type variables when lowering built-in applications

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -738,7 +738,7 @@ internal struct IREmitter {
       } else {
         let t = program.type(assignedTo: program[e].callee, assuming: Arrow.self)
         lowering(e) { (me) in
-          let x0 = me._emitApply(builtin: f, typed: t, to: me.program[e].arguments)
+          let x0 = me._emitApply(builtin: f, ofType: t, to: me.program[e].arguments)
           me._emitInitialize(target, with: x0)
         }
       }
@@ -2639,18 +2639,20 @@ internal struct IREmitter {
     _ = _apply_builtin(.trap, ofType: u, to: [])
   }
 
-  /// Generates IR for applying `callee` to `arguments`.
+  /// Calls `f(arguments...)` where `f` is a builtin function of type `t`
+  /// other than `assume_[un]initialized`.
   ///
-  /// `callee` is any built-in function but `assume_[un]initialized`.
+  /// - Note: Calls to `Builtin.assume_[un]initialized` are lowered directly to `assume_state`
+  ///   instructions rather than function applications.
   private mutating func _emitApply(
-    builtin callee: BuiltinFunction, typed calleeType: Arrow.ID,
+    builtin f: BuiltinFunction, ofType t: Arrow.ID,
     to arguments: [LabeledExpression],
   ) -> IRValue {
-    let xs = zip(program.types[calleeType].inputs, arguments).map { (p, a) in
+    let xs = zip(program.types[t].inputs, arguments).map { (p, a) in
       let x0 = lowered(lvalue: a.value)
       return _access([p.access], from: x0)
     }
-    return _apply_builtin(callee, ofType: calleeType, to: xs)
+    return _apply_builtin(f, ofType: t, to: xs)
   }
 
   /// Generates IR for defining a place projecting `source` as a place of type `target` with

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -736,8 +736,9 @@ internal struct IREmitter {
           me._assume_state(target, initialized: true)
         }
       } else {
+        let t = program.type(assignedTo: program[e].callee, assuming: Arrow.self)
         lowering(e) { (me) in
-          let x0 = me._emitApply(builtin: f, to: me.program[e].arguments)
+          let x0 = me._emitApply(builtin: f, typed: t, to: me.program[e].arguments)
           me._emitInitialize(target, with: x0)
         }
       }
@@ -2072,12 +2073,12 @@ internal struct IREmitter {
 
   /// Inserts a `apply_builtin` instruction.
   internal mutating func _apply_builtin(
-    _ callee: BuiltinFunction, typed f: Arrow.ID, to arguments: [IRValue]
+    _ callee: BuiltinFunction, typed calleeType: Arrow.ID, to arguments: [IRValue]
   ) -> IRValue {
-    assert(program.types[f].inputs.count == arguments.count)
-    let p = program.types[f].inputs.map(\.access)
+    assert(program.types[calleeType].inputs.count == arguments.count)
+    let p = program.types[calleeType].inputs.map(\.access)
     let s = IRApplyBuiltin(
-      callee: callee, inputs: p, output: program.types[f].output, arguments: arguments,
+      callee: callee, inputs: p, output: program.types[calleeType].output, arguments: arguments,
       anchor: currentAnchor)
     return insert(s)!
   }
@@ -2633,22 +2634,23 @@ internal struct IREmitter {
 
   /// Generates IR for calling `Builtin.trap`.
   internal mutating func _emitTrap() {
-    let f = BuiltinFunction.trap.type(uniquingTypesWith: &program.types)
-    _ = _apply_builtin(.trap, typed: f, to: [])
+    let t = BuiltinFunction.trap.type(uniquingTypesWith: &program.types)
+    let u = program.types.castUnchecked(t, to: Arrow.self)
+    _ = _apply_builtin(.trap, typed: u, to: [])
   }
 
   /// Generates IR for applying `callee` to `arguments`.
   ///
   /// `callee` is any built-in function but `assume_[un]initialized`.
   private mutating func _emitApply(
-    builtin callee: BuiltinFunction, to arguments: [LabeledExpression],
+    builtin callee: BuiltinFunction, typed calleeType: Arrow.ID,
+    to arguments: [LabeledExpression],
   ) -> IRValue {
-    let t = callee.type(uniquingTypesWith: &program.types)
-    let xs = zip(program.types[t].inputs, arguments).map { (p, a) in
+    let xs = zip(program.types[calleeType].inputs, arguments).map { (p, a) in
       let x0 = lowered(lvalue: a.value)
       return _access([p.access], from: x0)
     }
-    return _apply_builtin(callee, typed: t, to: xs)
+    return _apply_builtin(callee, typed: calleeType, to: xs)
   }
 
   /// Generates IR for defining a place projecting `source` as a place of type `target` with

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2071,14 +2071,14 @@ internal struct IREmitter {
     return result
   }
 
-  /// Inserts a `apply_builtin` instruction.
+  /// Calls `f(arguments...)`, where `f` has type `t`.
   internal mutating func _apply_builtin(
-    _ callee: BuiltinFunction, typed calleeType: Arrow.ID, to arguments: [IRValue]
+    _ callee: BuiltinFunction, ofType t: Arrow.ID, to arguments: [IRValue]
   ) -> IRValue {
-    assert(program.types[calleeType].inputs.count == arguments.count)
-    let p = program.types[calleeType].inputs.map(\.access)
+    assert(program.types[t].inputs.count == arguments.count)
+    let p = program.types[t].inputs.map(\.access)
     let s = IRApplyBuiltin(
-      callee: callee, inputs: p, output: program.types[calleeType].output, arguments: arguments,
+      callee: callee, inputs: p, output: program.types[t].output, arguments: arguments,
       anchor: currentAnchor)
     return insert(s)!
   }
@@ -2636,7 +2636,7 @@ internal struct IREmitter {
   internal mutating func _emitTrap() {
     let t = BuiltinFunction.trap.type(uniquingTypesWith: &program.types)
     let u = program.types.castUnchecked(t, to: Arrow.self)
-    _ = _apply_builtin(.trap, typed: u, to: [])
+    _ = _apply_builtin(.trap, ofType: u, to: [])
   }
 
   /// Generates IR for applying `callee` to `arguments`.
@@ -2650,7 +2650,7 @@ internal struct IREmitter {
       let x0 = lowered(lvalue: a.value)
       return _access([p.access], from: x0)
     }
-    return _apply_builtin(callee, typed: calleeType, to: xs)
+    return _apply_builtin(callee, ofType: calleeType, to: xs)
   }
 
   /// Generates IR for defining a place projecting `source` as a place of type `target` with

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -397,37 +397,42 @@ public enum BuiltinFunction: Hashable, Sendable {
 
 extension BuiltinFunction {
 
-  /// Returns the type of the function, calling `freshVariable` to create fresh type variables.
-  public func type(uniquingTypesWith s: inout TypeStore) -> Arrow.ID {
+  /// Returns the type of the function, using `s` to create unique type identities.
+  public func type(uniquingTypesWith s: inout TypeStore) -> AnyTypeIdentity {
     let i1 = s.demand(MachineType.i(1))
 
     switch self {
     case .trap:
-      return s.demand(Arrow(inputs: [], output: .never))
+      return s.demand(Arrow(inputs: [], output: .never)).erased
 
     case .addressOf:
-      let t0 = s.fresh().erased
+      let t0 = s.demand(GenericParameter.nth(0, .proper))
       let t1 = s.demand(MachineType.ptr).erased
-      return s.demand(Arrow(inputs: [.init(label: "of", access: .let, type: t0)], output: t1))
+      let a = Arrow(inputs: [.init(label: "of", access: .let, type: t0.erased)], output: t1)
+
+      let t2 = s.demand(a).erased
+      let t3 = s.demand(UniversalType(parameters: [t0], head: t2))
+      return t3.erased
 
     case .assumeInitialized:
       let t0 = s.fresh().erased
-      return s.demand(Arrow(inputs: [.init(label: nil, access: .auto, type: t0)], output: .void))
+      let t1 = s.demand(Arrow(inputs: [.init(label: nil, access: .auto, type: t0)], output: .void))
+      return t1.erased
 
     case .add(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .sub(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .mul(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     //    case .shl(_, let t):
     //      return .init(^t, ^t, to: ^t)
     //    case .udiv(_, let t):
     //      return .init(^t, ^t, to: ^t)
     case .udiv(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .sdiv(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     //    case .lshr(_, let t):
     //      return .init(^t, ^t, to: ^t)
     //    case .ashr(_, let t):
@@ -437,31 +442,31 @@ extension BuiltinFunction {
     //    case .srem(let t):
     //      return .init(^t, ^t, to: ^t)
     case .and(let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .or(let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .xor(let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .signedAdditionWithOverflow(let t):
       let u = s.tuple(of: [t.erased, i1.erased])
-      return s.demand(Arrow(t, t, to: u))
+      return s.demand(Arrow(t, t, to: u)).erased
     case .unsignedAdditionWithOverflow(let t):
       let u = s.tuple(of: [t.erased, i1.erased])
-      return s.demand(Arrow(t, t, to: u))
+      return s.demand(Arrow(t, t, to: u)).erased
     case .signedSubtractionWithOverflow(let t):
       let u = s.tuple(of: [t.erased, i1.erased])
-      return s.demand(Arrow(t, t, to: u))
+      return s.demand(Arrow(t, t, to: u)).erased
     case .unsignedSubtractionWithOverflow(let t):
       let u = s.tuple(of: [t.erased, i1.erased])
-      return s.demand(Arrow(t, t, to: u))
+      return s.demand(Arrow(t, t, to: u)).erased
     case .signedMultiplicationWithOverflow(let t):
       let u = s.tuple(of: [t.erased, i1.erased])
-      return s.demand(Arrow(t, t, to: u))
+      return s.demand(Arrow(t, t, to: u)).erased
     case .unsignedMultiplicationWithOverflow(let t):
       let u = s.tuple(of: [t.erased, i1.erased])
-      return s.demand(Arrow(t, t, to: u))
+      return s.demand(Arrow(t, t, to: u)).erased
     case .icmp(_, let t):
-      return s.demand(Arrow(t, t, to: i1))
+      return s.demand(Arrow(t, t, to: i1)).erased
     //    case .trunc(let s, let d):
     //      return .init(^s, to: ^d)
     //    case .zext(let s, let d):
@@ -477,25 +482,25 @@ extension BuiltinFunction {
     //    case .ptrtoint(let t):
     //      return .init(.builtin(.ptr), to: ^t)
     case .fadd(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .fsub(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .fmul(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .fdiv(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .frem(_, let t):
-      return s.demand(Arrow(t, t, to: t))
+      return s.demand(Arrow(t, t, to: t)).erased
     case .fcmp(_, _, let t):
-      return s.demand(Arrow(t, t, to: i1))
+      return s.demand(Arrow(t, t, to: i1)).erased
     case .fptrunc(let f, let d):
-      return s.demand(Arrow(f, to: d))
+      return s.demand(Arrow(f, to: d)).erased
     case .fpext(let f, let d):
-      return s.demand(Arrow(f, to: d))
+      return s.demand(Arrow(f, to: d)).erased
     case .fptoui(let f, let d):
-      return s.demand(Arrow(f, to: d))
+      return s.demand(Arrow(f, to: d)).erased
     case .fptosi(let f, let d):
-      return s.demand(Arrow(f, to: d))
+      return s.demand(Arrow(f, to: d)).erased
     //    case .ctpop(let t):
     //      return .init(^t, to: ^t)
     //    case .ctlz(let t):
@@ -503,7 +508,7 @@ extension BuiltinFunction {
     //    case .cttz(let t):
     //      return .init(^t, to: ^t)
     case .zeroinitializer(let t):
-      return s.demand(Arrow(inputs: [], output: t.erased))
+      return s.demand(Arrow(inputs: [], output: t.erased)).erased
     //    case .advancedByBytes(let byteOffset):
     //      return .init(.builtin(.ptr), ^byteOffset, to: .builtin(.ptr))
     //    case .atomic_store_relaxed(let t):

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -4221,8 +4221,17 @@ public struct Typer {
 
     // Are we selecting a built-in function?
     else if let f = BuiltinFunction(n.identifier, uniquingTypesWith: &program.types) {
+      let r = DeclarationReference.builtin(.function(f))
       let t = f.type(uniquingTypesWith: &program.types)
-      return [.init(reference: .builtin(.function(f)), type: t.erased)]
+
+      // If the built-in function has a generic type, then we replace its type parameters by fresh
+      // variables to avoid elaborating type applications, essentially pretending that there exists
+      // an overload for each possible instantiation.
+      if let u = program.types[t] as? UniversalType {
+        return [.init(reference: r, type: program.types.open(u.parameters, in: u.head))]
+      } else {
+        return [.init(reference: r, type: t)]
+      }
     }
 
     // Nothing that we know.


### PR DESCRIPTION
This patch improves the performance of the emitter by avoiding creating new fresh type variables before lowering `apply_builtin` instructions.

Before the patch, we called `BuiltinFunction.type(uniquingTypesWith:)` in `IREmitter._emitApply(builtin:to:)` in order to get the access effect of each parameter. This call caused the creation of new fresh type variables for the generic built-in functions (e.g., `Builtin.address(of:)`), eventually requiring a reallocation of the type store. This patch fixed that issue by reusing types inferred during typing and by constructing universal types for generic built-in functions, so that the result of `BuiltinFunction.type(uniquingTypesWith:)` is idempotent.