### PR TITLE
Run dealiasing until a fixed point

### DIFF
--- a/Sources/FrontEnd/Types/TypeStore.swift
+++ b/Sources/FrontEnd/Types/TypeStore.swift
@@ -800,15 +800,17 @@ public struct TypeStore: Sendable {
   /// Returns `n` without any type alias.
   public mutating func dealiased(_ n: AnyTypeIdentity) -> AnyTypeIdentity {
     self.map(n) { (s, t) in
-      if !t[.hasAliases] {
-        return .stepOver(t)
-      } else if let a = s[t] as? TypeAlias {
-        return .stepInto(a.aliasee)
-      } else if let a = s[t] as? TypeApplication, let f = s[a.abstraction] as? TypeAlias {
-        return .stepInto(s.substitute(a.arguments, in: f.aliasee))
-      } else {
-        return .stepInto(t)
+      var u = t
+      while u[.hasAliases] {
+        if let a = s[u] as? TypeAlias {
+          u = a.aliasee
+        } else if let a = s[u] as? TypeApplication, let f = s[a.abstraction] as? TypeAlias {
+          u = s.substitute(a.arguments, in: f.aliasee)
+        } else {
+          return .stepInto(u)
+        }
       }
+      return .stepOver(u)
     }
   }
 

--- a/Tests/CompilerTests/positive/chained-type-aliases.hylo
+++ b/Tests/CompilerTests/positive/chained-type-aliases.hylo
@@ -1,0 +1,13 @@
+//! stage:typing no-std
+
+type A = {Void,Void}
+type B = A
+type C = B
+
+fun f(x: sink B) -> A {
+  x
+}
+
+public fun g() -> C {
+  return f(((), ()))
+}


### PR DESCRIPTION
The dealiasing returned `.stepInto(m)` where `m` itself may have been a type alias. The `map` algorithm only steps into the children of `m`, and doesn't evaluate the action on `m` itself. The fix is to run dealiasing within the action until a point where we are sure the returned value is not a type alias.