### PR TITLE
Redefine IRLoad across yield point

### DIFF
--- a/Sources/BackEnd/SubscriptDecomposition.swift
+++ b/Sources/BackEnd/SubscriptDecomposition.swift
@@ -587,11 +587,14 @@ extension IRFunction {
     case
       IRAccess.self,
       IRCase.self,
+      IREnumTag.self,  // Safe to redefine assuming MVS.
       IRGlobalAccess.self,
+      IRLoad.self,  // Safe to redefine assuming MVS.
       IRPlaceCast.self,
       IRPointerToPlace.self,
       IRProperty.self,
-      IRSubfield.self:
+      IRSubfield.self,
+      IRWitnessTable.self:
       return .redefined
 
     default:

--- a/Tests/CompilerTests/positive/subscript-load-across-yieldpoint.hylo
+++ b/Tests/CompilerTests/positive/subscript-load-across-yieldpoint.hylo
@@ -1,0 +1,19 @@
+public struct BoxAddress is Deinitializable {
+
+  public var value: Builtin.ptr
+
+  public memberwise init
+
+  public subscript unsafe() let -> UInt32 {
+    let v = self.value as* let UInt32
+    yield v
+    precondition(v == (42 as UInt32))
+  }
+
+}
+
+public fun main() {
+  let x = 42 as UInt32
+  let b = BoxAddress(value: Builtin.address(of: x))
+  precondition(b.unsafe[] == (42 as UInt32))
+}


### PR DESCRIPTION
IRLoad was defaulting to be ignored when going through a yield boundary. As long as MVS is upheld, we can assume that when we reload from memory, it will have the same contents (since we have let access to something we load) - so it should be safe to redefine in the slide instead of capturing the value. @dabrahams @RishabhRD Could you check if my reasoning is correct?

This fixes #346 = #350 