### PR TITLE
Fix crash when using erased parameter in slide (#352)

### DIFF
--- a/Sources/BackEnd/SubscriptDecomposition.swift
+++ b/Sources/BackEnd/SubscriptDecomposition.swift
@@ -106,7 +106,7 @@ extension FunctionGenerationContext {
     let u = module.llvm.arrayType(captures.count, module.llvm.ptr).t
     let v = module.llvm.structType([t, u])
     return .init(
-      boundary: y, inputs: result.prototype.mapping.inputs, definitions: definitions,
+      boundary: y, inputs: prototype.mapping.inputs, definitions: definitions,
       captures: captures, captureFrame: v)
   }
 

--- a/Tests/CompilerTests/positive/subscript-use-erased-parameter-in-slide.hylo
+++ b/Tests/CompilerTests/positive/subscript-use-erased-parameter-in-slide.hylo
@@ -1,0 +1,11 @@
+subscript s0(x: Void) -> Int { 42 }
+
+// The parameter is erased and it's accessed after the yield.
+subscript s1(x: Void) -> Int {
+  yield 1
+  precondition(s0[x] == 42)
+}
+
+fun main() {
+  precondition(s1[()] == 1)
+}


### PR DESCRIPTION
We used the wrong function's prototype - we should use the one where erasing has been applied already.
Fixes #352 