### PR TITLE
Print nicer error message when a runtime witness table couldn't be lowered

### DIFF
--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -662,6 +662,16 @@ extension Program {
     }
 
     let tableType = metadata(of: s.witnessType, in: &ctx.module)
+
+    assert(entries.allSatisfy(\.unsafe[].isConstant), """
+      Runtime-defined IRWitnessTable operands are not yet supported.
+      See https://github.com/hylo-lang/hylo-new/issues/342
+
+      Problem occurred during LLVM lowering of:
+      \(show(ctx.ir))
+
+      """)
+
     let table = ctx.module.llvm.structConstant(
       of: StructType.UnsafeReference(tableType.llvm)!, aggregating: entries)
 


### PR DESCRIPTION
Masking the hard-to-diagnose LLVM assertion failure with something easier to understand while working with the compiler.