### PR TITLE
Lower type witness as value

### DIFF
--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -914,37 +914,51 @@ extension Program {
     switch g.name {
     case .lowered:
       fatalError("TODO: global bindings")
-
     case .witness(let t):
-      // TODO: type arguments/parameters
-      // TODO: witnesses of opaque types
-
-      // Declare the symbol.
-      let storage = ctx.llvm.structType(ctx.typeWitnessHeader)
-      let symbol = ctx.llvm.declareGlobalVariable(name, storage)
-      ctx.llvm.setLinkage(.private, for: symbol)
-
-      // The symbol is defined iff the layout of the type is fixed, so that it may be inlined in
-      // the module. Otherwise, the witness is for a type whose layout is defined externally.
-      let m = metadata(of: t, in: &ctx)
-      guard let s = m.layout.size.fixed else { return symbol }
-
-      let fields: [LLVMValue] = [
-        demandGlobalString(show(t), in: &ctx).v,
-        ctx.llvm.i32.unsafe[].constant(s).v,
-        ctx.llvm.i16.unsafe[].constant(m.layout.alignment).v,
-        ctx.llvm.i16.unsafe[].zero.v,
-      ]
-
-      let alignment = ctx.llvm.layout.preferredAlignment(of: storage)
-      ctx.llvm.setAlignment(alignment, for: symbol)
-
-      let initializer = ctx.llvm.structConstant(of: storage, aggregating: fields)
-      ctx.llvm.setInitializer(initializer, for: symbol)
-      ctx.llvm.setGlobalConstant(true, for: symbol)
-
-      return symbol
+      return demandGlobalTypeWitness(of: t, in: &ctx)
     }
+  }
+
+  /// Returns the global LLVM variable containing the type witness of `t`, declaring it if
+  /// necessary.
+  ///
+  /// - Requires: `t` is dealiased.
+  private mutating func demandGlobalTypeWitness(
+    of t: AnyTypeIdentity, in ctx: inout ModuleGenerationContext
+  ) -> SwiftyLLVM.GlobalVariable.UnsafeReference {
+    // TODO: type arguments/parameters
+    // TODO: witnesses of opaque types
+
+    let name = llvmName(global: .witness(t))
+    if let existing = ctx.llvm.global(named: name) {
+      return existing
+    }
+
+    // Declare the symbol.
+    let storage = ctx.llvm.structType(ctx.typeWitnessHeader)
+    let symbol = ctx.llvm.declareGlobalVariable(name, storage)
+    ctx.llvm.setLinkage(.private, for: symbol)
+
+    // The symbol is defined iff the layout of the type is fixed, so that it may be inlined in
+    // the module. Otherwise, the witness is for a type whose layout is defined externally.
+    let m = metadata(of: t, in: &ctx)
+    guard let s = m.layout.size.fixed else { return symbol }
+
+    let fields: [LLVMValue] = [
+      demandGlobalString(show(t), in: &ctx).v,
+      ctx.llvm.i32.unsafe[].constant(s).v,
+      ctx.llvm.i16.unsafe[].constant(m.layout.alignment).v,
+      ctx.llvm.i16.unsafe[].zero.v,
+    ]
+
+    let alignment = ctx.llvm.layout.preferredAlignment(of: storage)
+    ctx.llvm.setAlignment(alignment, for: symbol)
+
+    let initializer = ctx.llvm.structConstant(of: storage, aggregating: fields)
+    ctx.llvm.setInitializer(initializer, for: symbol)
+    ctx.llvm.setGlobalConstant(true, for: symbol)
+
+    return symbol
   }
 
   private func demandGlobalString(
@@ -1247,6 +1261,10 @@ extension Program {
       return codegen(integer: n, instanceOf: t, in: &ctx.module)
     case .function(let n, _):
       return demandFunction(named: n, in: &ctx.module).value.v
+    case .type(let t, _):
+      // A type witness is represented by the address of its global metadata (for now).
+      // Runtime type witnesses are not yet supported.
+      return demandGlobalTypeWitness(of: t, in: &ctx.module).v
     default:
       fatalError("no LLVM representation of the Hylo value '\(show(v))'")
     }

--- a/Tests/CompilerTests/positive/metatype-address.hylo
+++ b/Tests/CompilerTests/positive/metatype-address.hylo
@@ -1,0 +1,25 @@
+public struct TypeWitnessHeader {
+  public memberwise init
+
+  let description: Pointer<UInt8>
+  let size: UInt32
+  let alignment: UInt16
+  let type_argument_or_parameter_count: UInt16
+}
+
+public struct Victim {
+  public memberwise init
+  let a: UInt32
+  let b: UInt16
+}
+
+public fun main() -> Int32 {
+  // The address of a metatype value is the address of a pointer to the type's witness header.
+  let h = Builtin.address(of: Victim) as* (let Pointer<TypeWitnessHeader>)
+
+  // Access as value (`.unsafe[]`).
+  let w = h.value as* (let TypeWitnessHeader)
+
+  // `Victim` occupies 6 bytes, so this exits with 0.
+  return Int32(value: w.size.value) - (6 as Int32)
+}


### PR DESCRIPTION
Previously, type witnesses were only lowered as global variables, but referencing them through a lowered IRValue was not possible.