### PR TITLE
Report out-of-bounds integer literals

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1446,20 +1446,47 @@ internal struct IREmitter {
   ) -> IRValue {
     let value = BigInt(hyloLiteral: program[source].value)!
 
+    let specification: (width: Int, isSigned: Bool, storage: MachineType, name: String)
     switch target {
-    case program.standardLibraryType(.int), program.standardLibraryType(.uint):
-      return .integer(value, program.types.demand(MachineType.word))
-    case program.standardLibraryType(.int8), program.standardLibraryType(.uint8):
-      return .integer(value, program.types.demand(MachineType.i(8)))
-    case program.standardLibraryType(.int16), program.standardLibraryType(.uint16):
-      return .integer(value, program.types.demand(MachineType.i(16)))
-    case program.standardLibraryType(.int32), program.standardLibraryType(.uint32):
-      return .integer(value, program.types.demand(MachineType.i(32)))
-    case program.standardLibraryType(.int64), program.standardLibraryType(.uint64):
-      return .integer(value, program.types.demand(MachineType.i(64)))
+    // Keep word-sized integer bounds in sync with the generated standard library.
+    case program.standardLibraryType(.int):
+      specification = (64, true, .word, "Int")
+    case program.standardLibraryType(.uint):
+      specification = (64, false, .word, "UInt")
+    case program.standardLibraryType(.int8):
+      specification = (8, true, .i(8), "Int8")
+    case program.standardLibraryType(.uint8):
+      specification = (8, false, .i(8), "UInt8")
+    case program.standardLibraryType(.int16):
+      specification = (16, true, .i(16), "Int16")
+    case program.standardLibraryType(.uint16):
+      specification = (16, false, .i(16), "UInt16")
+    case program.standardLibraryType(.int32):
+      specification = (32, true, .i(32), "Int32")
+    case program.standardLibraryType(.uint32):
+      specification = (32, false, .i(32), "UInt32")
+    case program.standardLibraryType(.int64):
+      specification = (64, true, .i(64), "Int64")
+    case program.standardLibraryType(.uint64):
+      specification = (64, false, .i(64), "UInt64")
     default:
       program.unexpected(target)
     }
+
+    let unit = BigInt(1)
+    let minimum = specification.isSigned ? -(unit << (specification.width - 1)) : 0
+    let maximum =
+      specification.isSigned
+      ? (unit << (specification.width - 1)) - 1
+      : (unit << specification.width) - 1
+    if !(minimum...maximum).contains(value) {
+      let message =
+        "integer literal '\(program[source].value)' is out of bounds for "
+        + "'\(specification.name)'"
+      report(.error, message, about: source)
+    }
+
+    return .integer(value, program.types.demand(specification.storage))
   }
 
   /// Returns the value denoted by `source` interpreted as the floating point

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1446,47 +1446,20 @@ internal struct IREmitter {
   ) -> IRValue {
     let value = BigInt(hyloLiteral: program[source].value)!
 
-    let specification: (width: Int, isSigned: Bool, storage: MachineType, name: String)
     switch target {
-    // Keep word-sized integer bounds in sync with the generated standard library.
-    case program.standardLibraryType(.int):
-      specification = (64, true, .word, "Int")
-    case program.standardLibraryType(.uint):
-      specification = (64, false, .word, "UInt")
-    case program.standardLibraryType(.int8):
-      specification = (8, true, .i(8), "Int8")
-    case program.standardLibraryType(.uint8):
-      specification = (8, false, .i(8), "UInt8")
-    case program.standardLibraryType(.int16):
-      specification = (16, true, .i(16), "Int16")
-    case program.standardLibraryType(.uint16):
-      specification = (16, false, .i(16), "UInt16")
-    case program.standardLibraryType(.int32):
-      specification = (32, true, .i(32), "Int32")
-    case program.standardLibraryType(.uint32):
-      specification = (32, false, .i(32), "UInt32")
-    case program.standardLibraryType(.int64):
-      specification = (64, true, .i(64), "Int64")
-    case program.standardLibraryType(.uint64):
-      specification = (64, false, .i(64), "UInt64")
+    case program.standardLibraryType(.int), program.standardLibraryType(.uint):
+      return .integer(value, program.types.demand(MachineType.word))
+    case program.standardLibraryType(.int8), program.standardLibraryType(.uint8):
+      return .integer(value, program.types.demand(MachineType.i(8)))
+    case program.standardLibraryType(.int16), program.standardLibraryType(.uint16):
+      return .integer(value, program.types.demand(MachineType.i(16)))
+    case program.standardLibraryType(.int32), program.standardLibraryType(.uint32):
+      return .integer(value, program.types.demand(MachineType.i(32)))
+    case program.standardLibraryType(.int64), program.standardLibraryType(.uint64):
+      return .integer(value, program.types.demand(MachineType.i(64)))
     default:
       program.unexpected(target)
     }
-
-    let unit = BigInt(1)
-    let minimum = specification.isSigned ? -(unit << (specification.width - 1)) : 0
-    let maximum =
-      specification.isSigned
-      ? (unit << (specification.width - 1)) - 1
-      : (unit << specification.width) - 1
-    if !(minimum...maximum).contains(value) {
-      let message =
-        "integer literal '\(program[source].value)' is out of bounds for "
-        + "'\(specification.name)'"
-      report(.error, message, about: source)
-    }
-
-    return .integer(value, program.types.demand(specification.storage))
   }
 
   /// Returns the value denoted by `source` interpreted as the floating point

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -1,4 +1,5 @@
 import Algorithms
+import BigInt
 import OrderedCollections
 import Utilities
 
@@ -2019,7 +2020,8 @@ public struct Typer {
     case IntegerLiteral.self:
       return inferredType(of: castUnchecked(e, to: IntegerLiteral.self), in: &context)
     case FloatingPointLiteral.self:
-      return inferredType(of: castUnchecked(e, to: FloatingPointLiteral.self), in: &context)
+      return inferredType(
+        ofPrimitiveLiteral: castUnchecked(e, to: FloatingPointLiteral.self), in: &context)
     case Lambda.self:
       return inferredType(of: castUnchecked(e, to: Lambda.self), in: &context)
     case NameExpression.self:
@@ -2315,10 +2317,21 @@ public struct Typer {
     return context.obligations.assume(e, hasType: t, at: program[e].site)
   }
 
+  /// Returns the inferred type of the integer literal `e`.
+  private mutating func inferredType(
+    of e: IntegerLiteral.ID, in context: inout InferenceContext
+  ) -> AnyTypeIdentity {
+    if program[e.module].type(assignedTo: e) == nil {
+      let t = context.expectedType ?? standardLibraryType(IntegerLiteral.defaultType)
+      checkIntegerLiteral(e, representableBy: t)
+    }
+    return inferredType(ofPrimitiveLiteral: e, in: &context)
+  }
+
   /// Returns the inferred type of a primitive literal `e`, ensuring `e` is elaborated to a call
   /// to `.new(x: e)`, where `x` is the constructor label of `T`.
   private mutating func inferredType<T: LiteralExpression>(
-    of e: T.ID, in context: inout InferenceContext
+    ofPrimitiveLiteral e: T.ID, in context: inout InferenceContext
   ) -> AnyTypeIdentity {
     // Did we already elaborate this expression?
     if let t = program[e.module].type(assignedTo: e) {
@@ -4712,12 +4725,77 @@ public struct Typer {
 
   // MARK: Standard library
 
+  /// The value ranges of standard library integer types.
+  private static let standardLibraryIntegerBounds:
+    [Program.StandardLibraryEntity: ClosedRange<BigInt>] = {
+      let one = BigInt(1)
+
+      func signed(_ width: Int) -> ClosedRange<BigInt> {
+        let magnitude = one << (width - 1)
+        return -magnitude...(magnitude - one)
+      }
+
+      func unsigned(_ width: Int) -> ClosedRange<BigInt> {
+        0...((one << width) - one)
+      }
+
+      let signed64 = signed(64)
+      let unsigned64 = unsigned(64)
+      return [
+        .int: signed64,
+        .uint: unsigned64,
+        .int8: signed(8),
+        .uint8: unsigned(8),
+        .int16: signed(16),
+        .uint16: unsigned(16),
+        .int32: signed(32),
+        .uint32: unsigned(32),
+        .int64: signed64,
+        .uint64: unsigned64,
+      ]
+    }()
+
+  /// Reports an error iff `e` is not representable by `t`.
+  private mutating func checkIntegerLiteral(
+    _ e: IntegerLiteral.ID, representableBy t: AnyTypeIdentity
+  ) {
+    guard
+      let bounds = standardLibraryIntegerBounds(of: t),
+      let value = BigInt(hyloLiteral: program[e].value),
+      !bounds.contains(value)
+    else { return }
+
+    report(
+      .error,
+      "integer literal '\(program.show(e))' is out of bounds for '\(program.show(t))'",
+      about: e)
+  }
+
+  /// Returns the value range of `t` iff it is a standard library integer type.
+  private mutating func standardLibraryIntegerBounds(
+    of t: AnyTypeIdentity
+  ) -> ClosedRange<BigInt>? {
+    guard let e = standardLibraryIntegerEntity(of: t) else { return nil }
+    return Self.standardLibraryIntegerBounds[e]
+  }
+
+  /// Returns the standard library entity denoted by integer type `t`.
+  private mutating func standardLibraryIntegerEntity(
+    of t: AnyTypeIdentity
+  ) -> Program.StandardLibraryEntity? {
+    guard program.containsStandardLibrary else { return nil }
+
+    let u = program.types.dealiased(t)
+    return Program.StandardLibraryEntity.allIntegerTypes.first(
+      where: { (e) in standardLibraryType(e) == u })
+  }
+
   /// Returns `true` iff `t` is a standard library integer type (e.g., `Hylo.Int`).
   ///
   /// The module containing the standard library must have been loaded in the `self.program`, or
   /// `self.module` is the standard library.
   private mutating func isStandardLibraryIntegerType(_ t: AnyTypeIdentity) -> Bool {
-    isStandardLibraryType(t, in: Program.StandardLibraryEntity.allIntegerTypes)
+    standardLibraryIntegerEntity(of: t) != nil
   }
 
   /// Returns `true` iff `t` is a standard library floating point type (e.g., `Hylo.Float32`).

--- a/Tests/CompilerTests/negative/integer-literal-bounds.diagnostics.expected
+++ b/Tests/CompilerTests/negative/integer-literal-bounds.diagnostics.expected
@@ -7,8 +7,8 @@ negative/integer-literal-bounds.hylo:5.18-21: error: integer literal '128' is ou
 negative/integer-literal-bounds.hylo:6.19-21: error: integer literal '-1' is out of bounds for 'UInt8'
   let a3: UInt8 = -1
                   ~~
-negative/integer-literal-bounds.hylo:7.19-22: error: integer literal '300' is out of bounds for 'UInt8'
-  let a4: UInt8 = 300
+negative/integer-literal-bounds.hylo:7.19-22: error: integer literal '256' is out of bounds for 'UInt8'
+  let a4: UInt8 = 256
                   ~~~
 negative/integer-literal-bounds.hylo:9.19-25: error: integer literal '-32769' is out of bounds for 'Int16'
   let a5: Int16 = -32769

--- a/Tests/CompilerTests/negative/integer-literal-bounds.diagnostics.expected
+++ b/Tests/CompilerTests/negative/integer-literal-bounds.diagnostics.expected
@@ -1,0 +1,60 @@
+negative/integer-literal-bounds.hylo:4.18-22: error: integer literal '-129' is out of bounds for 'Int8'
+  let a1: Int8 = -129
+                 ~~~~
+negative/integer-literal-bounds.hylo:5.18-21: error: integer literal '128' is out of bounds for 'Int8'
+  let a2: Int8 = 128
+                 ~~~
+negative/integer-literal-bounds.hylo:6.19-21: error: integer literal '-1' is out of bounds for 'UInt8'
+  let a3: UInt8 = -1
+                  ~~
+negative/integer-literal-bounds.hylo:7.19-22: error: integer literal '300' is out of bounds for 'UInt8'
+  let a4: UInt8 = 300
+                  ~~~
+negative/integer-literal-bounds.hylo:9.19-25: error: integer literal '-32769' is out of bounds for 'Int16'
+  let a5: Int16 = -32769
+                  ~~~~~~
+negative/integer-literal-bounds.hylo:10.19-24: error: integer literal '32768' is out of bounds for 'Int16'
+  let a6: Int16 = 32768
+                  ~~~~~
+negative/integer-literal-bounds.hylo:11.20-22: error: integer literal '-1' is out of bounds for 'UInt16'
+  let a7: UInt16 = -1
+                   ~~
+negative/integer-literal-bounds.hylo:12.20-25: error: integer literal '65536' is out of bounds for 'UInt16'
+  let a8: UInt16 = 65536
+                   ~~~~~
+negative/integer-literal-bounds.hylo:14.19-30: error: integer literal '-2147483649' is out of bounds for 'Int32'
+  let a9: Int32 = -2147483649
+                  ~~~~~~~~~~~
+negative/integer-literal-bounds.hylo:15.20-30: error: integer literal '2147483648' is out of bounds for 'Int32'
+  let a10: Int32 = 2147483648
+                   ~~~~~~~~~~
+negative/integer-literal-bounds.hylo:16.21-23: error: integer literal '-1' is out of bounds for 'UInt32'
+  let a11: UInt32 = -1
+                    ~~
+negative/integer-literal-bounds.hylo:17.21-31: error: integer literal '4294967296' is out of bounds for 'UInt32'
+  let a12: UInt32 = 4294967296
+                    ~~~~~~~~~~
+negative/integer-literal-bounds.hylo:19.20-40: error: integer literal '-9223372036854775809' is out of bounds for 'Int64'
+  let a13: Int64 = -9223372036854775809
+                   ~~~~~~~~~~~~~~~~~~~~
+negative/integer-literal-bounds.hylo:20.20-39: error: integer literal '9223372036854775808' is out of bounds for 'Int64'
+  let a14: Int64 = 9223372036854775808
+                   ~~~~~~~~~~~~~~~~~~~
+negative/integer-literal-bounds.hylo:21.21-23: error: integer literal '-1' is out of bounds for 'UInt64'
+  let a15: UInt64 = -1
+                    ~~
+negative/integer-literal-bounds.hylo:22.21-41: error: integer literal '18446744073709551616' is out of bounds for 'UInt64'
+  let a16: UInt64 = 18446744073709551616
+                    ~~~~~~~~~~~~~~~~~~~~
+negative/integer-literal-bounds.hylo:24.18-38: error: integer literal '-9223372036854775809' is out of bounds for 'Int'
+  let a17: Int = -9223372036854775809
+                 ~~~~~~~~~~~~~~~~~~~~
+negative/integer-literal-bounds.hylo:25.18-37: error: integer literal '9223372036854775808' is out of bounds for 'Int'
+  let a18: Int = 9223372036854775808
+                 ~~~~~~~~~~~~~~~~~~~
+negative/integer-literal-bounds.hylo:26.19-21: error: integer literal '-1' is out of bounds for 'UInt'
+  let a19: UInt = -1
+                  ~~
+negative/integer-literal-bounds.hylo:27.19-39: error: integer literal '18446744073709551616' is out of bounds for 'UInt'
+  let a20: UInt = 18446744073709551616
+                  ~~~~~~~~~~~~~~~~~~~~

--- a/Tests/CompilerTests/negative/integer-literal-bounds.hylo
+++ b/Tests/CompilerTests/negative/integer-literal-bounds.hylo
@@ -1,0 +1,28 @@
+//! stage:lowering
+
+fun integer_literal_bounds() {
+  let a1: Int8 = -129
+  let a2: Int8 = 128
+  let a3: UInt8 = -1
+  let a4: UInt8 = 300
+
+  let a5: Int16 = -32769
+  let a6: Int16 = 32768
+  let a7: UInt16 = -1
+  let a8: UInt16 = 65536
+
+  let a9: Int32 = -2147483649
+  let a10: Int32 = 2147483648
+  let a11: UInt32 = -1
+  let a12: UInt32 = 4294967296
+
+  let a13: Int64 = -9223372036854775809
+  let a14: Int64 = 9223372036854775808
+  let a15: UInt64 = -1
+  let a16: UInt64 = 18446744073709551616
+
+  let a17: Int = -9223372036854775809
+  let a18: Int = 9223372036854775808
+  let a19: UInt = -1
+  let a20: UInt = 18446744073709551616
+}

--- a/Tests/CompilerTests/negative/integer-literal-bounds.hylo
+++ b/Tests/CompilerTests/negative/integer-literal-bounds.hylo
@@ -1,10 +1,10 @@
-//! stage:lowering
+//! stage:typing
 
 fun integer_literal_bounds() {
   let a1: Int8 = -129
   let a2: Int8 = 128
   let a3: UInt8 = -1
-  let a4: UInt8 = 300
+  let a4: UInt8 = 256
 
   let a5: Int16 = -32769
   let a6: Int16 = 32768

--- a/Tests/CompilerTests/positive/integer-literals.hylo
+++ b/Tests/CompilerTests/positive/integer-literals.hylo
@@ -1,18 +1,28 @@
 //! stage:lowering
 
 fun integer_literal_conversions() {
-  let a1: Int8 = 1
-  let a2: UInt8 = 1
+  let a1: Int8 = -128
+  let a2: Int8 = 127
+  let a3: UInt8 = 0
+  let a4: UInt8 = 255
 
-  let a3: Int16 = 1
-  let a4: UInt16 = 1
+  let a5: Int16 = -32768
+  let a6: Int16 = 32767
+  let a7: UInt16 = 0
+  let a8: UInt16 = 65535
 
-  let a5: Int32 = 1
-  let a6: UInt32 = 1
+  let a9: Int32 = -2147483648
+  let a10: Int32 = 2147483647
+  let a11: UInt32 = 0
+  let a12: UInt32 = 4294967295
 
-  let a7: Int64 = 1
-  let a8: UInt64 = 1
+  let a13: Int64 = -9223372036854775808
+  let a14: Int64 = 9223372036854775807
+  let a15: UInt64 = 0
+  let a16: UInt64 = 18446744073709551615
 
-  let a9: Int = 1
-  let a10: UInt = 1
+  let a17: Int = -9223372036854775808
+  let a18: Int = 9223372036854775807
+  let a19: UInt = 0
+  let a20: UInt = 18446744073709551615
 }


### PR DESCRIPTION
## Summary
- validate integer literals against the exact signed or unsigned range of their standard-library target type during lowering
- report an error at the literal while continuing lowering so multiple invalid literals are diagnosed in one pass
- cover the issue reproduction (`let x: UInt8 = 300`), every standard integer type, and accepted min/max boundaries

`Int` and `UInt` use 64-bit bounds to match the standard library generator’s current `Builtin.word` model and its existing issue #331 TODO.

## Verification
- focused positive/negative compiler tests: 2/2
- full `swift test` with the repository-pinned LLVM 20.1.6 toolchain: 437/437
- max Swift line length: 100 characters
- `git diff --check`

Closes #335