### PR TITLE
Add more builtin instructions; add Builtin.* tests

### DIFF
--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -299,9 +299,9 @@ extension Program {
       ctx.value[v] = metadata(of: t, in: &ctx.module).llvm.unsafe[].null
     case .advancedByBytes(let t):
       let p = insertLoad([s.arguments[0]], of: types.demand(MachineType.ptr), in: &ctx)[0]
-      let n = insertLoad([s.arguments[1]], of: t, in: &ctx)
+      let offsets = insertLoad([s.arguments[1]], of: t, in: &ctx)
       ctx.value[v] = ctx.module.llvm.insertGetElementPointerInBounds(
-        of: p, typed: ctx.module.llvm.i8, indices: n, at: ctx.insertionPoint!).v
+        of: p, typed: ctx.module.llvm.i8, indices: offsets , at: ctx.insertionPoint!).v
 
     case .add(let o, let t):
       let xs = insertLoad(s.arguments, of: t, in: &ctx)

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -297,6 +297,61 @@ extension Program {
       ctx.value[v] = ctx.value[s.arguments[0]]!
     case .zeroinitializer(let t):
       ctx.value[v] = metadata(of: t, in: &ctx.module).llvm.unsafe[].null
+    case .advancedByBytes(byteOffset: let t):
+      assert(s.arguments.count == 2)
+      let p = insertLoad([s.arguments[0]], of: types.demand(MachineType.ptr), in: &ctx)[0]
+      let offsets = insertLoad([s.arguments[1]], of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertGetElementPointerInBounds(
+        of: p, typed: ctx.module.llvm.i8, indices: offsets, at: ctx.insertionPoint!).v
+
+    case .add(let o, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertAdd(
+        overflow: o.llvm, xs[0].v, xs[1].v, at: ctx.insertionPoint!).v
+    case .signedAdditionWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.sadd.with.overflow, for: t, with: s.arguments, in: &ctx)
+    case .unsignedAdditionWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.uadd.with.overflow, for: t, with: s.arguments, in: &ctx)
+    case .fadd(let f, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      let i = ctx.module.llvm.insertFAdd(xs[0], xs[1], at: ctx.insertionPoint!)
+      ctx.module.llvm.setFastMathFlags(f.llvm, for: i)
+      ctx.value[v] = i.v
+
+    case .sub(let o, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertSub(
+        overflow: o.llvm, xs[0].v, xs[1].v, at: ctx.insertionPoint!).v
+    case .signedSubtractionWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.ssub.with.overflow, for: t, with: s.arguments, in: &ctx)
+    case .unsignedSubtractionWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.usub.with.overflow, for: t, with: s.arguments, in: &ctx)
+    case .fsub(let f, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      let i = ctx.module.llvm.insertFSub(xs[0], xs[1], at: ctx.insertionPoint!)
+      ctx.module.llvm.setFastMathFlags(f.llvm, for: i)
+      ctx.value[v] = i.v
+
+    case .mul(let o, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertMul(
+        overflow: o.llvm, xs[0].v, xs[1].v, at: ctx.insertionPoint!).v
+    case .signedMultiplicationWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.smul.with.overflow, for: t, with: s.arguments, in: &ctx)
+    case .unsignedMultiplicationWithOverflow(let t):
+      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
+        IntrinsicFunction.llvm.umul.with.overflow, for: t, with: s.arguments, in: &ctx)
+    case .fmul(let f, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      let i = ctx.module.llvm.insertFMul(xs[0], xs[1], at: ctx.insertionPoint!)
+      ctx.module.llvm.setFastMathFlags(f.llvm, for: i)
+      ctx.value[v] = i.v
+
     case .udiv(let e, let t):
       let xs = insertLoad(s.arguments, of: t, in: &ctx)
       ctx.value[v] = ctx.module.llvm.insertUnsignedDiv(
@@ -305,49 +360,89 @@ extension Program {
       let xs = insertLoad(s.arguments, of: t, in: &ctx)
       ctx.value[v] = ctx.module.llvm.insertSignedDiv(
         exact: e, xs[0], xs[1], at: ctx.insertionPoint!).v
+    case .fdiv(let f, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      let i = ctx.module.llvm.insertFDiv(xs[0], xs[1], at: ctx.insertionPoint!)
+      ctx.module.llvm.setFastMathFlags(f.llvm, for: i)
+      ctx.value[v] = i.v
+
     case .urem(let t):
       let xs = insertLoad(s.arguments, of: t, in: &ctx)
-      ctx.value[v] = ctx.module.llvm.insertUnsignedRem(
-        xs[0], xs[1], at: ctx.insertionPoint!).v
-    case .signedAdditionWithOverflow(let t):
-      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
-        IntrinsicFunction.llvm.sadd.with.overflow, for: t, with: s.arguments, in: &ctx)
-    case .unsignedAdditionWithOverflow(let t):
-      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
-        IntrinsicFunction.llvm.uadd.with.overflow, for: t, with: s.arguments, in: &ctx)
-    case .signedSubtractionWithOverflow(let t):
-      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
-        IntrinsicFunction.llvm.ssub.with.overflow, for: t, with: s.arguments, in: &ctx)
-    case .unsignedSubtractionWithOverflow(let t):
-      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
-        IntrinsicFunction.llvm.usub.with.overflow, for: t, with: s.arguments, in: &ctx)
-    case .signedMultiplicationWithOverflow(let t):
-      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
-        IntrinsicFunction.llvm.smul.with.overflow, for: t, with: s.arguments, in: &ctx)
-    case .unsignedMultiplicationWithOverflow(let t):
-      ctx.value[v] = insertCallBuiltinBinaryWithOverflow(
-        IntrinsicFunction.llvm.umul.with.overflow, for: t, with: s.arguments, in: &ctx)
-    case .advancedByBytes(byteOffset: let t):
-      assert(s.arguments.count == 2)
-      let p = insertLoad([s.arguments[0]], of: types.demand(MachineType.ptr), in: &ctx)[0]
-      let offsets = insertLoad([s.arguments[1]], of: t, in: &ctx)
-      ctx.value[v] = ctx.module.llvm.insertGetElementPointerInBounds(
-        of: p, typed: ctx.module.llvm.i8, indices: offsets, at: ctx.insertionPoint!).v
-    case .zext(let from, let to):
+      ctx.value[v] = ctx.module.llvm.insertUnsignedRem(xs[0], xs[1], at: ctx.insertionPoint!).v
+    case .srem(let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertSignedRem(xs[0], xs[1], at: ctx.insertionPoint!).v
+    case .frem(let f, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      let i = ctx.module.llvm.insertFRem(xs[0], xs[1], at: ctx.insertionPoint!)
+      ctx.module.llvm.setFastMathFlags(f.llvm, for: i)
+      ctx.value[v] = i.v
+
+    case .icmp(let p, let t):
+      ctx.value[v] = insertCallBuiltinPredicate(p, for: t, with: s.arguments, in: &ctx)
+
+    case .assumeInitialized(_):
+      unreachable("assume_initialized must have been lowered as IRAssumeState.")
+
+    case .and(let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertBitwiseAnd(xs[0].v, xs[1].v, at: ctx.insertionPoint!).v
+    case .or(let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertBitwiseOr(xs[0].v, xs[1].v, at: ctx.insertionPoint!).v
+    case .xor(let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertBitwiseXor(xs[0].v, xs[1].v, at: ctx.insertionPoint!).v
+
+    case .fcmp(let f, let p, let t):
+      let xs = insertLoad(s.arguments, of: t, in: &ctx)
+      let i = ctx.module.llvm.insertFloatingPointComparison(
+        p.llvm, xs[0], xs[1], at: ctx.insertionPoint!)
+      ctx.module.llvm.setFastMathFlags(f.llvm, for: i)
+      ctx.value[v] = i.v
+
+    case .fptrunc(let from, let to):
       let xs = insertLoad(s.arguments, of: from, in: &ctx)
-      let t = metadata(of: to, in: &ctx.module).llvm
-      ctx.value[v] = ctx.module.llvm.insertZeroExtend(
-        xs[0], to: t, at: ctx.insertionPoint!).v
+      ctx.value[v] = ctx.module.llvm.insertFPTrunc(
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
+    case .fpext(let from, let to):
+      let xs = insertLoad(s.arguments, of: from, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertFPExtend(
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
+    case .fptoui(let from, let to):
+      let xs = insertLoad(s.arguments, of: from, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertFPToUI(
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
+    case .fptosi(let from, let to):
+      let xs = insertLoad(s.arguments, of: from, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertFPToSI(
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
+
     case .trunc(let from, let to):
       let xs = insertLoad(s.arguments, of: from, in: &ctx)
-      let t = metadata(of: to, in: &ctx.module).llvm
       ctx.value[v] = ctx.module.llvm.insertTrunc(
-        xs[0], to: t, at: ctx.insertionPoint!).v    case .icmp(let p, let t):
-      ctx.value[v] = insertCallBuiltinPredicate(
-        p, for: t, with: s.arguments, in: &ctx)
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
 
-    default:
-      unimplemented(String(describing: s.callee))
+    case .zext(let from, let to):
+      let xs = insertLoad(s.arguments, of: from, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertZeroExtend(
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
+
+    case .sext(let from, let to):
+      let xs = insertLoad(s.arguments, of: from, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertSignExtend(
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
+
+    case .uitofp(let from, let to):
+      let xs = insertLoad(s.arguments, of: from, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertUIToFP(
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
+
+    case .sitofp(let from, let to):
+      let xs = insertLoad(s.arguments, of: from, in: &ctx)
+      ctx.value[v] = ctx.module.llvm.insertSIToFP(
+        xs[0], to: metadata(of: to, in: &ctx.module).llvm, at: ctx.insertionPoint!).v
+
     }
 
     return ctx.ir.instruction(after: i.erased)
@@ -1151,6 +1246,8 @@ extension Program {
 
   /// Generates the LLVM IR code for applying `callee`, which is the name of a function in the
   /// family of `llvm.x.with.overflow`, to `xs`.
+  ///
+  /// - Requires: `xs` is a list of pointers to the actual operands.
   private mutating func insertCallBuiltinBinaryWithOverflow(
     _ callee: IntrinsicFunction.Name, for integer: MachineType.ID, with xs: [FrontEnd.IRValue],
     in ctx: inout FunctionGenerationContext
@@ -1314,6 +1411,8 @@ extension Program {
       return ctx.value[v]!
     case .integer(let n, let t):
       return codegen(integer: n, instanceOf: t, in: &ctx.module)
+    case .floatingPoint(let literal, let t):
+      return codegen(floatingPoint: literal, instanceOf: t, in: &ctx.module)
     case .function(let n, _):
       return demandFunction(named: n, in: &ctx.module).value.v
     case .type(let t, _):
@@ -1336,6 +1435,17 @@ extension Program {
     } else {
       return t.unsafe[].constant(words: n.words.map(UInt64.init(_:))).v
     }
+  }
+
+  /// Returns a LLVM IR constant equivalent to `literal`, which is the textual representation of
+  /// an instance of a floating-point type `t`.
+  private mutating func codegen(
+    floatingPoint literal: String, instanceOf t: MachineType.ID,
+    in ctx: inout ModuleGenerationContext
+  ) -> LLVMValue {
+    let u = metadata(of: t, in: &ctx)
+    let t = FloatingPointType.UnsafeReference(u.llvm)!
+    return t.unsafe[].constant(parsing: literal).v
   }
 
   /// Returns the LLVM type corresponding to the Hylo type `t`, using `compute` to determine its
@@ -1434,10 +1544,16 @@ extension Program {
         ctx.llvm.integerType(Int(width)).t
       case .word:
         ctx.llvm.iptr.t
+      case .float16:
+        ctx.llvm.half.t
+      case .float32:
+        ctx.llvm.float.t
+      case .float64:
+        ctx.llvm.double.t
+      case .float128:
+        ctx.llvm.fp128.t
       case .ptr:
         ctx.llvm.ptr.t
-      default:
-        unimplemented("no LLVM representation of the type '\(program.show(t))'")
       }
 
       let s = ctx.llvm.layout.storageSize(of: v)
@@ -1657,6 +1773,54 @@ extension SwiftyLLVM.IntegerPredicate {
     case .sge: self = .sge
     case .sgt: self = .sgt
     case .sle: self = .sle
+    }
+  }
+
+}
+
+extension FrontEnd.OverflowBehavior {
+
+  /// The LLVM representation of `self`.
+  var llvm: SwiftyLLVM.OverflowBehavior {
+    switch self {
+    case .ignore: .ignore
+    case .nuw: .nuw
+    case .nsw: .nsw
+    }
+  }
+
+}
+
+extension FrontEnd.MathFlags {
+
+  /// The LLVM representation of `self`.
+  var llvm: SwiftyLLVM.FastMathFlags {
+    .init(rawValue: UInt32(rawValue))
+  }
+
+}
+
+extension FrontEnd.FloatingPointPredicate {
+
+  /// The LLVM representation of `self`.
+  var llvm: SwiftyLLVM.FloatingPointPredicate {
+    switch self {
+    case .alwaysFalse: .alwaysFalse
+    case .alwaysTrue: .alwaysTrue
+    case .oeq: .oeq
+    case .one: .one
+    case .ogt: .ogt
+    case .oge: .oge
+    case .olt: .olt
+    case .ole: .ole
+    case .ord: .ord
+    case .ueq: .ueq
+    case .une: .une
+    case .ugt: .ugt
+    case .uge: .uge
+    case .ult: .ult
+    case .ule: .ule
+    case .uno: .uno
     }
   }
 

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -297,12 +297,11 @@ extension Program {
       ctx.value[v] = ctx.value[s.arguments[0]]!
     case .zeroinitializer(let t):
       ctx.value[v] = metadata(of: t, in: &ctx.module).llvm.unsafe[].null
-    case .advancedByBytes(byteOffset: let t):
-      assert(s.arguments.count == 2)
+    case .advancedByBytes(let t):
       let p = insertLoad([s.arguments[0]], of: types.demand(MachineType.ptr), in: &ctx)[0]
-      let offsets = insertLoad([s.arguments[1]], of: t, in: &ctx)
+      let n = insertLoad([s.arguments[1]], of: t, in: &ctx)
       ctx.value[v] = ctx.module.llvm.insertGetElementPointerInBounds(
-        of: p, typed: ctx.module.llvm.i8, indices: offsets, at: ctx.insertionPoint!).v
+        of: p, typed: ctx.module.llvm.i8, indices: n, at: ctx.insertionPoint!).v
 
     case .add(let o, let t):
       let xs = insertLoad(s.arguments, of: t, in: &ctx)

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -380,6 +380,10 @@ public struct Driver {
       .trimmingCharacters(in: .whitespacesAndNewlines)
     arguments += ["-isysroot", sdk, "-lSystem"]
     #endif
+    #if os(Linux)
+    // Instruction selection may lower some instructions (e.g., `frem`) to libm calls.
+    arguments += ["-lm"]
+    #endif
 
     let clang = try Host.findBinaryExecutable(invokedAs: "clang")
     _ = try Process.executionOutput(clang, arguments: arguments)

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -69,10 +69,10 @@ public enum BuiltinFunction: Hashable, Sendable {
   //  case lshr(exact: Bool, MachineType.ID)
   //
   //  case ashr(exact: Bool, MachineType.ID)
-  //
+
   case urem(MachineType.ID)
-  //
-  //  case srem(MachineType.ID)
+
+  case srem(MachineType.ID)
 
   case and(MachineType.ID)
 
@@ -103,16 +103,16 @@ public enum BuiltinFunction: Hashable, Sendable {
   case trunc(MachineType.ID, MachineType.ID)
 
   case zext(MachineType.ID, MachineType.ID)
-  //
-  //  case sext(MachineType.ID, MachineType.ID)
-  //
-  //  case uitofp(MachineType.ID, MachineType.ID)
-  //
-  //  case sitofp(MachineType.ID, MachineType.ID)
-  //
-  //  case inttoptr(MachineType.ID)
-  //
-  //  case ptrtoint(MachineType.ID)
+
+  case sext(MachineType.ID, MachineType.ID)
+
+  case uitofp(MachineType.ID, MachineType.ID)
+
+  case sitofp(MachineType.ID, MachineType.ID)
+
+//  case inttoptr(MachineType.ID)
+//
+//  case ptrtoint(MachineType.ID)
 
   /// In LLVM: `fadd`.
   case fadd(MathFlags, MachineType.ID)
@@ -429,8 +429,6 @@ extension BuiltinFunction {
       return s.demand(Arrow(t, t, to: t)).erased
     //    case .shl(_, let t):
     //      return .init(^t, ^t, to: ^t)
-    //    case .udiv(_, let t):
-    //      return .init(^t, ^t, to: ^t)
     case .udiv(_, let t):
       return s.demand(Arrow(t, t, to: t)).erased
     case .sdiv(_, let t):
@@ -441,9 +439,8 @@ extension BuiltinFunction {
     //      return .init(^t, ^t, to: ^t)
     case .urem(let t):
       return s.demand(Arrow(t, t, to: t)).erased
-
-    //    case .srem(let t):
-    //      return .init(^t, ^t, to: ^t)
+    case .srem(let t):
+      return s.demand(Arrow(t, t, to: t)).erased
     case .and(let t):
       return s.demand(Arrow(t, t, to: t)).erased
     case .or(let t):
@@ -470,18 +467,16 @@ extension BuiltinFunction {
       return s.demand(Arrow(t, t, to: u)).erased
     case .icmp(_, let t):
       return s.demand(Arrow(t, t, to: i1)).erased
-    case .trunc(let src, let dst):
-      return s.demand(Arrow(src, to: dst)).erased
-    case .zext(let src, let dst):
-      return s.demand(Arrow(src, to: dst)).erased
-
-    //      return .init(^s, to: ^d)
-    //    case .sext(let s, let d):
-    //      return .init(^s, to: ^d)
-    //    case .uitofp(let s, let d):
-    //      return .init(^s, to: ^d)
-    //    case .sitofp(let s, let d):
-    //      return .init(^s, to: ^d)
+    case .trunc(let f, let d):
+      return s.demand(Arrow(f, to: d)).erased
+    case .zext(let f, let d):
+      return s.demand(Arrow(f, to: d)).erased
+    case .sext(let f, let d):
+      return s.demand(Arrow(f, to: d)).erased
+    case .uitofp(let f, let d):
+      return s.demand(Arrow(f, to: d)).erased
+    case .sitofp(let f, let d):
+      return s.demand(Arrow(f, to: d)).erased
     //    case .inttoptr(let t):
     //      return .init(^t, to: .builtin(.ptr))
     //    case .ptrtoint(let t):
@@ -772,11 +767,17 @@ extension BuiltinFunction: Showable {
     case .assumeInitialized(let b):
       return "assume_\(b ? "" : "un")initialized"
     case .add(let p, let t):
-      return printer.format((p != .ignore) ? "add_%S_%T" : "add_%T", [p, t.erased])
+      return (p != .ignore)
+        ? printer.format("add_%S_%T", [p, t.erased])
+        : printer.format("add_%T", [t.erased])
     case .sub(let p, let t):
-      return printer.format((p != .ignore) ? "sub_%S_%T" : "sub_%T", [p, t.erased])
+      return (p != .ignore)
+        ? printer.format("sub_%S_%T", [p, t.erased])
+        : printer.format("sub_%T", [t.erased])
     case .mul(let p, let t):
-      return printer.format((p != .ignore) ? "mul_%S_%T" : "mul_%T", [p, t.erased])
+      return (p != .ignore)
+        ? printer.format("mul_%S_%T", [p, t.erased])
+        : printer.format("mul_%T", [t.erased])
     //    case .shl(let p, let t):
     //      return (p != .ignore) ? "shl_\(p)_\(t)" : "shl_\(t)"
     case .udiv(let e, let t):
@@ -789,9 +790,8 @@ extension BuiltinFunction: Showable {
     //      return e ? "ashr_exact_\(t)" : "ashr_\(t)"
     case .urem(let t):
       return printer.format("urem_%T", [t.erased])
-
-    //    case .srem(let t):
-    //      return "srem_\(t)"
+    case .srem(let t):
+      return printer.format("srem_%T", [t.erased])
     case .and(let t):
       return printer.format("and_%T", [t.erased])
     case .or(let t):
@@ -812,16 +812,16 @@ extension BuiltinFunction: Showable {
       return printer.format("umul_with_overflow_%T", [t.erased])
     case .icmp(let p, let t):
       return printer.format("icmp_%S_%T", [p, t.erased])
-    case .trunc(let s, let d):
-      return printer.format("trunc_%T_%T", [s.erased, d.erased])
-    case .zext(let s, let d):
-      return printer.format("zext_%T_%T", [s.erased, d.erased])
-    //    case .sext(let l, let r):
-    //      return "sext_\(l)_\(r)"
-    //    case .uitofp(let l, let r):
-    //      return "uitofp_\(l)_\(r)"
-    //    case .sitofp(let l, let r):
-    //      return "sitofp_\(l)_\(r)"
+    case .trunc(let l, let r):
+      return printer.format("trunc_%T_%T", [l.erased, r.erased])
+    case .zext(let l, let r):
+      return printer.format("zext_%T_%T", [l.erased, r.erased])
+    case .sext(let l, let r):
+      return printer.format("sext_%T_%T", [l.erased, r.erased])
+    case .uitofp(let l, let r):
+      return printer.format("uitofp_%T_%T", [l.erased, r.erased])
+    case .sitofp(let l, let r):
+      return printer.format("sitofp_%T_%T", [l.erased, r.erased])
     //    case .inttoptr(let t):
     //      return "inttoptr_\(t)"
     //    case .ptrtoint(let t):
@@ -1151,14 +1151,13 @@ extension BuiltinFunction {
     //    case "ashr":
     //      guard let (p, t) = (maybe("exact") + machineType)(&tokens) else { return nil }
     //      self = .ashr(exact: p != nil, t)
-    //
+
     case "urem":
       guard let t = machineType(&tokens) else { return nil }
       self = .urem(s.demand(t))
-
-    //    case "srem":
-    //      guard let t = machineType(&tokens) else { return nil }
-    //      self = .srem(t)
+    case "srem":
+      guard let t = machineType(&tokens) else { return nil }
+      self = .srem(s.demand(t))
 
     case "and":
       guard let t = machineType(&tokens) else { return nil }
@@ -1192,24 +1191,25 @@ extension BuiltinFunction {
       self = .icmp(p, s.demand(t))
 
     case "trunc":
-      guard let (src, dst) = (machineType + machineType)(&tokens) else { return nil }
-      self = .trunc(s.demand(src), s.demand(dst))
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .trunc(s.demand(f), s.demand(d))
+
     case "zext":
-      guard let (src, dst) = (machineType + machineType)(&tokens) else { return nil }
-      self = .zext(s.demand(src), s.demand(dst))
-    //
-    //    case "sext":
-    //      guard let (s, d) = (machineType + machineType)(&tokens) else { return nil }
-    //      self = .sext(s, d)
-    //
-    //    case "uitofp":
-    //      guard let (s, d) = (machineType + machineType)(&tokens) else { return nil }
-    //      self = .uitofp(s, d)
-    //
-    //    case "sitofp":
-    //      guard let (s, d) = (machineType + machineType)(&tokens) else { return nil }
-    //      self = .sitofp(s, d)
-    //
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .zext(s.demand(f), s.demand(d))
+
+    case "sext":
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .sext(s.demand(f), s.demand(d))
+
+    case "uitofp":
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .uitofp(s.demand(f), s.demand(d))
+
+    case "sitofp":
+      guard let (f, d) = (machineType + machineType)(&tokens) else { return nil }
+      self = .sitofp(s.demand(f), s.demand(d))
+
     //    case "inttoptr":
     //      guard let t = machineType(&tokens) else { return nil }
     //      self = .inttoptr(t)

--- a/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/BuiltinFunction.swift
@@ -152,9 +152,9 @@ public enum BuiltinFunction: Hashable, Sendable {
 
   case zeroinitializer(MachineType.ID)
 
-  // Corresponding LLVM instruction: get_elementptr_inbounds.
+  /// In LLVM: `getelementptr inbounds` on a base of type `i8`.
   case advancedByBytes(byteOffset: MachineType.ID)
-  //
+
   //  case atomic_store_relaxed(MachineType.ID)
   //
   //  case atomic_store_release(MachineType.ID)
@@ -509,9 +509,9 @@ extension BuiltinFunction {
     //      return .init(^t, to: ^t)
     case .zeroinitializer(let t):
       return s.demand(Arrow(inputs: [], output: t.erased)).erased
-    case .advancedByBytes(let t):
+    case .advancedByBytes(let byteOffset):
       let p = s.demand(MachineType.ptr)
-      return s.demand(Arrow(p, t, to: p)).erased
+      return s.demand(Arrow(p, byteOffset, to: p)).erased
     //    case .atomic_store_relaxed(let t):
     //      return .init(.builtin(.ptr), ^t, to: .void)
     //    case .atomic_store_release(let t):
@@ -855,7 +855,7 @@ extension BuiltinFunction: Showable {
     case .zeroinitializer(let t):
       return printer.format("zeroinitializer_%T", [t.erased])
     case .advancedByBytes(let t):
-      return "advanced_by_bytes_\(t)"
+      return printer.format("advanced_by_bytes_%T", [t.erased])
     //    case .atomic_store_relaxed(let t):
     //      return "atomic_store_relaxed_\(t)"
     //    case .atomic_store_release(let t):
@@ -1631,6 +1631,7 @@ private func integerArithmeticWithOverflowTail(
   return p(&stream).map(\.1)
 }
 
+/// Parses the parameters and type of `advanced_by_bytes`.
 private let advancedByBytesTail =
   exactly("by") + exactly("bytes") + machineType
 

--- a/Sources/FrontEnd/Syntax/Builtins/MathFlags.swift
+++ b/Sources/FrontEnd/Syntax/Builtins/MathFlags.swift
@@ -2,7 +2,8 @@ import Archivist
 
 /// A set of customizations to the behavior of floating point operations.
 ///
-/// The meaning of each customization is given by the LLVM option of the same name.
+/// The meaning of each customization is given by the LLVM option of the same name. The raw value
+/// of each flag matches its position in `LLVMFastMathFlags` (see llvm-c/Core.h).
 public struct MathFlags: OptionSet, Hashable, Sendable {
 
   public typealias RawValue = UInt8
@@ -13,21 +14,22 @@ public struct MathFlags: OptionSet, Hashable, Sendable {
     self.rawValue = rawValue
   }
 
-  public static let afn = MathFlags(rawValue: 1 << 0)
+  public static let reassoc = MathFlags(rawValue: 1 << 0)
 
-  public static let arcp = MathFlags(rawValue: 1 << 1)
+  public static let nnan = MathFlags(rawValue: 1 << 1)
 
-  public static let contract = MathFlags(rawValue: 1 << 2)
+  public static let ninf = MathFlags(rawValue: 1 << 2)
 
-  public static let fast = MathFlags(rawValue: 1 << 3)
+  public static let nsz = MathFlags(rawValue: 1 << 3)
 
-  public static let ninf = MathFlags(rawValue: 1 << 4)
+  public static let arcp = MathFlags(rawValue: 1 << 4)
 
-  public static let nnan = MathFlags(rawValue: 1 << 5)
+  public static let contract = MathFlags(rawValue: 1 << 5)
 
-  public static let nsz = MathFlags(rawValue: 1 << 6)
+  public static let afn = MathFlags(rawValue: 1 << 6)
 
-  public static let reassoc = MathFlags(rawValue: 1 << 7)
+  /// All flags; implies every other customization, as in LLVM.
+  public static let fast: MathFlags = [.reassoc, .nnan, .ninf, .nsz, .arcp, .contract, .afn]
 
 }
 
@@ -76,11 +78,11 @@ extension MathFlags: LosslessStringConvertible {
 
   /// The contribution this set of flags makes to name of a function in the `Builtin` module.
   public var description: String {
+    if self.contains(.fast) { return "fast" }
     var result: [String] = []
     if self.contains(.afn) { result.append("afn") }
     if self.contains(.arcp) { result.append("arcp") }
     if self.contains(.contract) { result.append("contract") }
-    if self.contains(.fast) { result.append("fast") }
     if self.contains(.ninf) { result.append("ninf") }
     if self.contains(.nnan) { result.append("nnan") }
     if self.contains(.nsz) { result.append("nsz") }

--- a/Sources/hc-tests/CommandLine.swift
+++ b/Sources/hc-tests/CommandLine.swift
@@ -54,7 +54,9 @@ import Foundation
   }
 
   private func testCaseIdentifier(_ testCase: URL) -> String {
-    testCase.deletingPathExtension().lastPathComponent.replacingOccurrences(of: "-", with: "_")
+    testCase.deletingPathExtension().lastPathComponent
+      .replacingOccurrences(of: "-", with: "_")
+      .replacingOccurrences(of: ".", with: "_")
   }
 
   /// Creates a new instance with default options.

--- a/Tests/CompilerTests/positive/Builtin.add.hylo
+++ b/Tests/CompilerTests/positive/Builtin.add.hylo
@@ -1,0 +1,25 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.add_i64((1 as Int64).value, (2 as Int64).value),
+    (3 as Int64).value))
+
+  // `add` wraps around on overflow.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.add_i64(Int64.max().value, (1 as Int64).value),
+    Int64.min().value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.add_i64(Int64.min().value, (-1 as Int64).value),
+    Int64.max().value))
+
+  // `nuw`/`nsw` variants work right at the limits.
+  expect(Builtin.icmp_eq_i8(
+    Builtin.add_nuw_i8((254 as UInt8).value, (1 as UInt8).value),
+    UInt8.max().value))
+  expect(Builtin.icmp_eq_i8(
+    Builtin.add_nsw_i8((-127 as Int8).value, (-1 as Int8).value),
+    Int8.min().value))
+}

--- a/Tests/CompilerTests/positive/Builtin.address.hylo
+++ b/Tests/CompilerTests/positive/Builtin.address.hylo
@@ -1,0 +1,11 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  let x = 42 as Int64
+
+  // The address of a binding's storage is non-null and stable.
+  expect(Builtin.icmp_ne_ptr(Builtin.address(of: x), Builtin.zeroinitializer_ptr()))
+  expect(Builtin.icmp_eq_ptr(Builtin.address(of: x), Builtin.address(of: x)))
+}

--- a/Tests/CompilerTests/positive/Builtin.advanced_by_bytes.hylo
+++ b/Tests/CompilerTests/positive/Builtin.advanced_by_bytes.hylo
@@ -1,0 +1,42 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+/// Four bytes laid out contiguously, since all properties have the same alignment.
+struct Quad is Deinitializable {
+  public memberwise init
+  public var a: UInt8
+  public var b: UInt8
+  public var c: UInt8
+  public var d: UInt8
+}
+
+public fun main() {
+  var q = Quad(a: 1 as UInt8, b: 2 as UInt8, c: 3 as UInt8, d: 4 as UInt8)
+  let p = Builtin.address(of: q)
+
+  // Advancing by zero bytes is the identity.
+  expect(Builtin.icmp_eq_ptr(Builtin.advanced_by_bytes_word(p, (0 as Int).value), p))
+
+  // Offsets are measured in bytes.
+  expect(Builtin.icmp_eq_ptr(
+    Builtin.advanced_by_bytes_word(p, (3 as Int).value), Builtin.address(of: q.d)))
+
+  // Offsets are signed.
+  let e = Builtin.address(of: q.d)
+  expect(Builtin.icmp_eq_ptr(Builtin.advanced_by_bytes_word(e, (-3 as Int).value), p))
+
+  // The offset may have any builtin integer type.
+  expect(Builtin.icmp_eq_ptr(
+    Builtin.advanced_by_bytes_i32(p, (2 as Int32).value), Builtin.address(of: q.c)))
+  expect(Builtin.icmp_eq_ptr(
+    Builtin.advanced_by_bytes_i32(e, (-1 as Int32).value), Builtin.address(of: q.c)))
+
+  // The storage addressed by an advanced address is that of the corresponding property.
+  let x = Builtin.advanced_by_bytes_word(p, (2 as Int).value) as* (let UInt8)
+  precondition(x == (3 as UInt8))
+
+  inout y = Builtin.advanced_by_bytes_word(p, (1 as Int).value) as* (inout UInt8)
+  &y = 7 as UInt8
+  precondition(q.b == (7 as UInt8))
+}

--- a/Tests/CompilerTests/positive/Builtin.and.hylo
+++ b/Tests/CompilerTests/positive/Builtin.and.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.and_i64((12 as Int64).value, (10 as Int64).value),
+    (8 as Int64).value))
+
+  // All-ones is the identity of `and`; zero absorbs.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.and_i64((42 as Int64).value, (-1 as Int64).value),
+    (42 as Int64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.and_i64((42 as Int64).value, (0 as Int64).value),
+    (0 as Int64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.assume_initialized.hylo
+++ b/Tests/CompilerTests/positive/Builtin.assume_initialized.hylo
@@ -1,0 +1,15 @@
+fun s(a: Builtin.ptr) {
+  inout v = a as* (inout Int64)
+  &v = 1334 as Int64
+}
+
+public fun main() {
+  var x = 42 as Int64
+  let a = Builtin.address(of: x)
+  Builtin.assume_uninitialized(x)
+
+  s(a)
+
+  Builtin.assume_initialized(x)
+  precondition(x == (1334 as Int64))
+}

--- a/Tests/CompilerTests/positive/Builtin.fadd.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fadd.hylo
@@ -1,0 +1,19 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fadd_float64((1.5 as Float64).value, (2.25 as Float64).value),
+    (3.75 as Float64).value))
+
+  // Overflow produces infinity, which exceeds every finite value.
+  expect(Builtin.fcmp_ogt_float64(
+    Builtin.fadd_float64((1.0e308 as Float64).value, (1.0e308 as Float64).value),
+    (1.7976931348623157e308 as Float64).value))
+
+  // Fast-math flags do not change exact computations.
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fadd_fast_float64((1.5 as Float64).value, (2.25 as Float64).value),
+    (3.75 as Float64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.fcmp.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fcmp.hylo
@@ -1,0 +1,31 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  let one = (1.0 as Float64).value
+  let two = (2.0 as Float64).value
+  let nan = Builtin.fdiv_float64((0.0 as Float64).value, (0.0 as Float64).value)
+
+  expect(Builtin.fcmp_oeq_float64(one, one))
+  expect(Builtin.fcmp_one_float64(one, two))
+  expect(Builtin.fcmp_olt_float64(one, two))
+  expect(Builtin.fcmp_ole_float64(one, one))
+  expect(Builtin.fcmp_ogt_float64(two, one))
+  expect(Builtin.fcmp_oge_float64(two, two))
+
+  // `ord` holds without NaN; `uno` holds with it.
+  expect(Builtin.fcmp_ord_float64(one, two))
+  expect_not(Builtin.fcmp_ord_float64(nan, one))
+  expect(Builtin.fcmp_uno_float64(nan, one))
+  expect_not(Builtin.fcmp_uno_float64(one, two))
+
+  // NaN is not ordered-equal to anything, including itself.
+  expect_not(Builtin.fcmp_oeq_float64(nan, nan))
+  expect(Builtin.fcmp_ueq_float64(nan, one)) // unordered or equal
+  expect(Builtin.fcmp_une_float64(nan, nan)) // unordered or not equal
+}

--- a/Tests/CompilerTests/positive/Builtin.fdiv.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fdiv.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fdiv_float64((3.0 as Float64).value, (2.0 as Float64).value),
+    (1.5 as Float64).value))
+
+  // Division by zero yields signed infinities.
+  expect(Builtin.fcmp_ogt_float64(
+    Builtin.fdiv_float64((1.0 as Float64).value, (0.0 as Float64).value),
+    (1.7976931348623157e308 as Float64).value))
+  expect(Builtin.fcmp_olt_float64(
+    Builtin.fdiv_float64((-1.0 as Float64).value, (0.0 as Float64).value),
+    (-1.7976931348623157e308 as Float64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.fmul.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fmul.hylo
@@ -1,0 +1,19 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fmul_float64((1.5 as Float64).value, (2.0 as Float64).value),
+    (3.0 as Float64).value))
+
+  // Overflow produces infinity, which exceeds every finite value.
+  expect(Builtin.fcmp_ogt_float64(
+    Builtin.fmul_float64((1.0e308 as Float64).value, (10.0 as Float64).value),
+    (1.7976931348623157e308 as Float64).value))
+
+  // Fast-math flags do not change exact computations.
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fmul_nnan_ninf_float64((1.5 as Float64).value, (2.0 as Float64).value),
+    (3.0 as Float64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.fpext.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fpext.hylo
@@ -1,0 +1,12 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fpext_float32_float64((1.5 as Float32).value),
+    (1.5 as Float64).value))
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fpext_float32_float64((-0.5 as Float32).value),
+    (-0.5 as Float64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.fptosi.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fptosi.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  // `fptosi` truncates towards zero.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.fptosi_float64_i64((4.99 as Float64).value),
+    (4 as Int64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.fptosi_float64_i64((-4.5 as Float64).value),
+    (-4 as Int64).value))
+
+  // The 64-bit minimum is exactly convertible.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.fptosi_float64_i64((-9223372036854775808.0 as Float64).value),
+    Int64.min().value))
+}

--- a/Tests/CompilerTests/positive/Builtin.fptoui.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fptoui.hylo
@@ -1,0 +1,19 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  // `fptoui` truncates towards zero. Negative operands are poison unless the truncated value is
+  // representable, i.e. only above -1.0: truncation makes that 0, whereas rounding down wouldn't.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.fptoui_float64_i64((4.5 as Float64).value),
+    (4 as UInt64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.fptoui_float64_i64((-0.5 as Float64).value),
+    (0 as UInt64).value))
+
+  // The largest double below 2^64 converts at the limit.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.fptoui_float64_i64((18446744073709549568.0 as Float64).value),
+    (18446744073709549568 as UInt64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.fptrunc.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fptrunc.hylo
@@ -1,0 +1,12 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float32(
+    Builtin.fptrunc_float64_float32((1.5 as Float64).value),
+    (1.5 as Float32).value))
+  expect(Builtin.fcmp_oeq_float32(
+    Builtin.fptrunc_float64_float32((-0.5 as Float64).value),
+    (-0.5 as Float32).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.frem.hylo
+++ b/Tests/CompilerTests/positive/Builtin.frem.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.frem_float64((5.5 as Float64).value, (2.0 as Float64).value),
+    (1.5 as Float64).value))
+
+  // `frem` takes the sign of the dividend.
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.frem_float64((-5.5 as Float64).value, (2.0 as Float64).value),
+    (-1.5 as Float64).value))
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.frem_float64((5.5 as Float64).value, (-2.0 as Float64).value),
+    (1.5 as Float64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.fsub.hylo
+++ b/Tests/CompilerTests/positive/Builtin.fsub.hylo
@@ -1,0 +1,12 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fsub_float64((3.75 as Float64).value, (2.25 as Float64).value),
+    (1.5 as Float64).value))
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.fsub_float64((0.0 as Float64).value, (1.5 as Float64).value),
+    (-1.5 as Float64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.icmp.hylo
+++ b/Tests/CompilerTests/positive/Builtin.icmp.hylo
@@ -1,0 +1,30 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  let zero = (0 as Int64).value
+  let minus_one = (-1 as Int64).value
+
+  expect(Builtin.icmp_eq_i64(zero, zero))
+  expect_not(Builtin.icmp_ne_i64(zero, zero))
+  expect(Builtin.icmp_ne_i64(minus_one, zero))
+
+  // Signed: -1 < 0 and min < max.
+  expect(Builtin.icmp_slt_i64(minus_one, zero))
+  expect(Builtin.icmp_sle_i64(minus_one, minus_one))
+  expect(Builtin.icmp_sgt_i64(zero, minus_one))
+  expect(Builtin.icmp_sge_i64(zero, zero))
+  expect(Builtin.icmp_slt_i64(Int64.min().value, Int64.max().value))
+
+  // Unsigned: the same bit patterns order the other way around.
+  expect(Builtin.icmp_ugt_i64(minus_one, zero))
+  expect(Builtin.icmp_uge_i64(minus_one, minus_one))
+  expect(Builtin.icmp_ult_i64(zero, minus_one))
+  expect(Builtin.icmp_ule_i64(zero, zero))
+  expect(Builtin.icmp_ugt_i64(Int64.min().value, Int64.max().value))
+}

--- a/Tests/CompilerTests/positive/Builtin.mul.hylo
+++ b/Tests/CompilerTests/positive/Builtin.mul.hylo
@@ -1,0 +1,25 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.mul_i64((6 as Int64).value, (7 as Int64).value),
+    (42 as Int64).value))
+
+  // `mul` wraps around on overflow.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.mul_i64(Int64.max().value, (2 as Int64).value),
+    (-2 as Int64).value))
+  expect(Builtin.icmp_eq_i8(
+    Builtin.mul_i8((64 as Int8).value, (2 as Int8).value),
+    Int8.min().value))
+
+  // `nuw`/`nsw` variants work right at the limits.
+  expect(Builtin.icmp_eq_i8(
+    Builtin.mul_nuw_i8((85 as UInt8).value, (3 as UInt8).value),
+    UInt8.max().value))
+  expect(Builtin.icmp_eq_i8(
+    Builtin.mul_nsw_i8((-64 as Int8).value, (2 as Int8).value),
+    Int8.min().value))
+}

--- a/Tests/CompilerTests/positive/Builtin.or.hylo
+++ b/Tests/CompilerTests/positive/Builtin.or.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.or_i64((12 as Int64).value, (10 as Int64).value),
+    (14 as Int64).value))
+
+  // Zero is the identity of `or`; all-ones absorbs.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.or_i64((42 as Int64).value, (0 as Int64).value),
+    (42 as Int64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.or_i64((42 as Int64).value, (-1 as Int64).value),
+    (-1 as Int64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.sadd_with_overflow.hylo
+++ b/Tests/CompilerTests/positive/Builtin.sadd_with_overflow.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  let (r0, o0) = Builtin.sadd_with_overflow_i64((1 as Int64).value, (2 as Int64).value)
+  expect(Builtin.icmp_eq_i64(r0, (3 as Int64).value))
+  expect_not(o0)
+
+  // Overflow wraps and is reported.
+  let (r1, o1) = Builtin.sadd_with_overflow_i64(Int64.max().value, (1 as Int64).value)
+  expect(Builtin.icmp_eq_i64(r1, Int64.min().value))
+  expect(o1)
+}

--- a/Tests/CompilerTests/positive/Builtin.sdiv.hylo
+++ b/Tests/CompilerTests/positive/Builtin.sdiv.hylo
@@ -1,0 +1,29 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  // `sdiv` rounds towards zero.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sdiv_i64((7 as Int64).value, (2 as Int64).value),
+    (3 as Int64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sdiv_i64((-7 as Int64).value, (2 as Int64).value),
+    (-3 as Int64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sdiv_i64((7 as Int64).value, (-2 as Int64).value),
+    (-3 as Int64).value))
+
+  // Defined at the limits, except for `min / -1`.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sdiv_i64(Int64.min().value, (1 as Int64).value),
+    Int64.min().value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sdiv_i64(Int64.max().value, (-1 as Int64).value),
+    (-9223372036854775807 as Int64).value))
+
+  // The `exact` variant is defined when there is no remainder.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sdiv_exact_i64((-8 as Int64).value, (2 as Int64).value),
+    (-4 as Int64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.sext.hylo
+++ b/Tests/CompilerTests/positive/Builtin.sext.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sext_i8_i64((127 as Int8).value),
+    (127 as Int64).value))
+
+  // `sext` extends with the sign bit, preserving signed values.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sext_i8_i64((-1 as Int8).value),
+    (-1 as Int64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sext_i8_i64(Int8.min().value),
+    (-128 as Int64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.sitofp.hylo
+++ b/Tests/CompilerTests/positive/Builtin.sitofp.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.sitofp_i64_float64((-3 as Int64).value),
+    (-3.0 as Float64).value))
+  expect(Builtin.fcmp_oeq_float32(
+    Builtin.sitofp_i64_float32((-3 as Int64).value),
+    (-3.0 as Float32).value))
+
+  // The 64-bit minimum is exactly representable as a double.
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.sitofp_i64_float64(Int64.min().value),
+    (-9223372036854775808.0 as Float64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.smul_with_overflow.hylo
+++ b/Tests/CompilerTests/positive/Builtin.smul_with_overflow.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  let (r0, o0) = Builtin.smul_with_overflow_i64((6 as Int64).value, (7 as Int64).value)
+  expect(Builtin.icmp_eq_i64(r0, (42 as Int64).value))
+  expect_not(o0)
+
+  // Overflow wraps and is reported.
+  let (r1, o1) = Builtin.smul_with_overflow_i64(Int64.max().value, (2 as Int64).value)
+  expect(Builtin.icmp_eq_i64(r1, (-2 as Int64).value))
+  expect(o1)
+}

--- a/Tests/CompilerTests/positive/Builtin.srem.hylo
+++ b/Tests/CompilerTests/positive/Builtin.srem.hylo
@@ -1,0 +1,22 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.srem_i64((7 as Int64).value, (2 as Int64).value),
+    (1 as Int64).value))
+
+  // `srem` takes the sign of the dividend.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.srem_i64((-7 as Int64).value, (2 as Int64).value),
+    (-1 as Int64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.srem_i64((7 as Int64).value, (-2 as Int64).value),
+    (1 as Int64).value))
+
+  // Defined at the limits, except for `min % -1`.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.srem_i64(Int64.min().value, (2 as Int64).value),
+    (0 as Int64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.ssub_with_overflow.hylo
+++ b/Tests/CompilerTests/positive/Builtin.ssub_with_overflow.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  let (r0, o0) = Builtin.ssub_with_overflow_i64((3 as Int64).value, (5 as Int64).value)
+  expect(Builtin.icmp_eq_i64(r0, (-2 as Int64).value))
+  expect_not(o0)
+
+  // Overflow wraps and is reported.
+  let (r1, o1) = Builtin.ssub_with_overflow_i64(Int64.min().value, (1 as Int64).value)
+  expect(Builtin.icmp_eq_i64(r1, Int64.max().value))
+  expect(o1)
+}

--- a/Tests/CompilerTests/positive/Builtin.sub.hylo
+++ b/Tests/CompilerTests/positive/Builtin.sub.hylo
@@ -1,0 +1,25 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sub_i64((5 as Int64).value, (3 as Int64).value),
+    (2 as Int64).value))
+
+  // `sub` wraps around on overflow.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sub_i64(Int64.min().value, (1 as Int64).value),
+    Int64.max().value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.sub_i64(Int64.max().value, (-1 as Int64).value),
+    Int64.min().value))
+
+  // `nuw`/`nsw` variants work right at the limits.
+  expect(Builtin.icmp_eq_i8(
+    Builtin.sub_nuw_i8((255 as UInt8).value, (255 as UInt8).value),
+    (0 as UInt8).value))
+  expect(Builtin.icmp_eq_i8(
+    Builtin.sub_nsw_i8(Int8.min().value, (-1 as Int8).value),
+    (-127 as Int8).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.trap.hylo
+++ b/Tests/CompilerTests/positive/Builtin.trap.hylo
@@ -1,0 +1,5 @@
+//! trap
+
+public fun main() {
+  Builtin.trap()
+}

--- a/Tests/CompilerTests/positive/Builtin.trunc.hylo
+++ b/Tests/CompilerTests/positive/Builtin.trunc.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i8(
+    Builtin.trunc_i64_i8((127 as Int64).value),
+    (127 as Int8).value))
+
+  // `trunc` keeps the low bits of its operand.
+  expect(Builtin.icmp_eq_i8(
+    Builtin.trunc_i64_i8((511 as Int64).value),
+    (-1 as Int8).value))
+  expect(Builtin.icmp_eq_i8(
+    Builtin.trunc_i64_i8((257 as Int64).value),
+    (1 as Int8).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.uadd_with_overflow.hylo
+++ b/Tests/CompilerTests/positive/Builtin.uadd_with_overflow.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  let (r0, o0) = Builtin.uadd_with_overflow_i64((5 as UInt64).value, (7 as UInt64).value)
+  expect(Builtin.icmp_eq_i64(r0, (12 as UInt64).value))
+  expect_not(o0)
+
+  // Overflow wraps and is reported.
+  let (r1, o1) = Builtin.uadd_with_overflow_i64(UInt64.max().value, (1 as UInt64).value)
+  expect(Builtin.icmp_eq_i64(r1, (0 as UInt64).value))
+  expect(o1)
+}

--- a/Tests/CompilerTests/positive/Builtin.udiv.hylo
+++ b/Tests/CompilerTests/positive/Builtin.udiv.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  // `udiv` rounds towards zero.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.udiv_i64((7 as UInt64).value, (2 as UInt64).value),
+    (3 as UInt64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.udiv_i64(UInt64.max().value, UInt64.max().value),
+    (1 as UInt64).value))
+
+  // The `exact` variant is defined when there is no remainder.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.udiv_exact_i64((8 as UInt64).value, (2 as UInt64).value),
+    (4 as UInt64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.uitofp.hylo
+++ b/Tests/CompilerTests/positive/Builtin.uitofp.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.uitofp_i64_float64((3 as UInt64).value),
+    (3.0 as Float64).value))
+  expect(Builtin.fcmp_oeq_float32(
+    Builtin.uitofp_i64_float32((3 as UInt64).value),
+    (3.0 as Float32).value))
+
+  // The 64-bit maximum rounds to the nearest representable value, 2^64.
+  expect(Builtin.fcmp_oeq_float64(
+    Builtin.uitofp_i64_float64(UInt64.max().value),
+    (18446744073709551616.0 as Float64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.umul_with_overflow.hylo
+++ b/Tests/CompilerTests/positive/Builtin.umul_with_overflow.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  let (r0, o0) = Builtin.umul_with_overflow_i64((6 as UInt64).value, (7 as UInt64).value)
+  expect(Builtin.icmp_eq_i64(r0, (42 as UInt64).value))
+  expect_not(o0)
+
+  // Overflow wraps and is reported.
+  let (r1, o1) = Builtin.umul_with_overflow_i64(UInt64.max().value, (2 as UInt64).value)
+  expect(Builtin.icmp_eq_i64(r1, (18446744073709551614 as UInt64).value))
+  expect(o1)
+}

--- a/Tests/CompilerTests/positive/Builtin.urem.hylo
+++ b/Tests/CompilerTests/positive/Builtin.urem.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.urem_i64((7 as UInt64).value, (2 as UInt64).value),
+    (1 as UInt64).value))
+
+  // `urem` is defined at the limits.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.urem_i64(UInt64.max().value, UInt64.max().value),
+    (0 as UInt64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.urem_i64(UInt64.max().value, (2 as UInt64).value),
+    (1 as UInt64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.usub_with_overflow.hylo
+++ b/Tests/CompilerTests/positive/Builtin.usub_with_overflow.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  let (r0, o0) = Builtin.usub_with_overflow_i64((5 as UInt64).value, (3 as UInt64).value)
+  expect(Builtin.icmp_eq_i64(r0, (2 as UInt64).value))
+  expect_not(o0)
+
+  // Overflow wraps and is reported.
+  let (r1, o1) = Builtin.usub_with_overflow_i64((0 as UInt64).value, (1 as UInt64).value)
+  expect(Builtin.icmp_eq_i64(r1, UInt64.max().value))
+  expect(o1)
+}

--- a/Tests/CompilerTests/positive/Builtin.xor.hylo
+++ b/Tests/CompilerTests/positive/Builtin.xor.hylo
@@ -1,0 +1,17 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.xor_i64((12 as Int64).value, (10 as Int64).value),
+    (6 as Int64).value))
+
+  // All-ones complements; `x ^ x` is zero.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.xor_i64((5 as Int64).value, (-1 as Int64).value),
+    (-6 as Int64).value))
+  expect(Builtin.icmp_eq_i64(
+    Builtin.xor_i64((42 as Int64).value, (42 as Int64).value),
+    (0 as Int64).value))
+}

--- a/Tests/CompilerTests/positive/Builtin.zeroinitializer.hylo
+++ b/Tests/CompilerTests/positive/Builtin.zeroinitializer.hylo
@@ -1,0 +1,18 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+fun expect_not(c: Builtin.i1) {
+  precondition(!Bool(value: c))
+}
+
+public fun main() {
+  // `zeroinitializer` produces the all-zeroes value of each machine type.
+  expect_not(Builtin.zeroinitializer_i1())
+  expect(Builtin.icmp_eq_i8(Builtin.zeroinitializer_i8(), (0 as Int8).value))
+  expect(Builtin.icmp_eq_i64(Builtin.zeroinitializer_i64(), (0 as Int64).value))
+  expect(Builtin.icmp_eq_word(Builtin.zeroinitializer_word(), (0 as Int).value))
+  expect(Builtin.fcmp_oeq_float32(Builtin.zeroinitializer_float32(), (0.0 as Float32).value))
+  expect(Builtin.fcmp_oeq_float64(Builtin.zeroinitializer_float64(), (0.0 as Float64).value))
+  expect(Builtin.icmp_eq_ptr(Builtin.zeroinitializer_ptr(), Builtin.zeroinitializer_ptr()))
+}

--- a/Tests/CompilerTests/positive/Builtin.zext.hylo
+++ b/Tests/CompilerTests/positive/Builtin.zext.hylo
@@ -1,0 +1,19 @@
+fun expect(c: Builtin.i1) {
+  precondition(Bool(value: c))
+}
+
+public fun main() {
+  expect(Builtin.icmp_eq_i64(
+    Builtin.zext_i8_i64((127 as Int8).value),
+    (127 as Int64).value))
+
+  // `zext` extends with zeroes, so sign bits become value bits.
+  expect(Builtin.icmp_eq_i64(
+    Builtin.zext_i8_i64((-1 as Int8).value),
+    (255 as Int64).value))
+
+  let t = true
+  expect(Builtin.icmp_eq_i64(
+    Builtin.zext_i1_i64(t.value),
+    (1 as Int64).value))
+}


### PR DESCRIPTION
This PR adds a handful of missing instructions and adds execution tests for all builtin instructions via the naming convention `Builtin.instruction_name`. Fixes https://github.com/hylo-lang/hylo-new/issues/358

I had to modify the driver to add a linking flag on Linux, as the floating point math may require linking the math library.

Float16 and float128 support is deferred to #435.

## Added instructions

Integer arithmetic
- `add`, `sub`, `mul`  wrapping and poisonous nuw/nsw variants
- `urem`, `srem`

Overflow-reporting arithmetic (return `{result, i1}` tuples)
- `uadd_with_overflow`, `usub_with_overflow`, `umul_with_overflow`

Bitwise logic
- `and`, `or`, `xor`

Integer width conversions
- `trunc`
- `zext`
- `sext`

Conversion between integer and floating-point numbers
- `uitofp`, `sitofp`
- `fptoui`, `fptosi`

Floating-point conversions
- `fptrunc`
- `fpext`

Floating-point arithmetic (all accept fast-math flags)
- `fadd`, `fsub`, `fmul`, `fdiv`, `frem`

Floating-point comparison (accepts fast-math flags and predicate selection)
- fcmp

Pointer arithmetic
- `advanced_by_bytes`