### PR TITLE
Demangle symbols in linker errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
     .executableTarget(
       name: "hylo-demangle",
       dependencies: [
-        .target(name: "FrontEnd"),
+        .target(name: "Demangler"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       swiftSettings: commonSwiftSettings),
@@ -80,6 +80,7 @@ let package = Package(
       name: "Driver",
       dependencies: [
         .target(name: "BackEnd"),
+        .target(name: "Demangler"),
         .target(name: "FrontEnd"),
         .target(name: "StandardLibrary"),
         .target(name: "Utilities"),
@@ -97,6 +98,13 @@ let package = Package(
       ],
       swiftSettings: commonSwiftSettings,
     ),
+
+    .target(
+      name: "Demangler",
+      dependencies: [
+        .target(name: "FrontEnd")
+      ],
+      swiftSettings: commonSwiftSettings),
 
     .target(
       name: "FrontEnd",
@@ -157,6 +165,13 @@ let package = Package(
       dependencies: [
         .target(name: "FrontEnd"),
         .target(name: "StandardLibrary"),
+      ],
+      swiftSettings: commonSwiftSettings),
+
+    .testTarget(
+      name: "DemanglerTests",
+      dependencies: [
+        .target(name: "Demangler")
       ],
       swiftSettings: commonSwiftSettings),
 

--- a/Sources/Demangler/TextDemangler.swift
+++ b/Sources/Demangler/TextDemangler.swift
@@ -1,0 +1,71 @@
+import FrontEnd
+
+/// Demangles Hylo symbols embedded in text.
+public enum TextDemangler {
+
+  /// A mangled symbol and its demangled representation.
+  public typealias Symbol = (mangled: Substring, demangled: String)
+
+  /// Returns `input` with each mangled Hylo symbol replaced by its demangled representation.
+  public static func rewrite(_ input: String) -> String {
+    var result = ""
+    var lastIndex = input.startIndex
+
+    input.enumerateManglingCandidates { (candidate) in
+      if lastIndex < candidate.startIndex {
+        result.append(contentsOf: input[lastIndex..<candidate.startIndex])
+      }
+      result.append(contentsOf: demangle(candidate) ?? String(candidate))
+      lastIndex = candidate.endIndex
+    }
+
+    if lastIndex < input.endIndex {
+      result.append(contentsOf: input[lastIndex..<input.endIndex])
+    }
+    return result
+  }
+
+  /// Returns each mangled Hylo symbol found in `input` and its demangled representation.
+  public static func symbols(in input: String) -> [Symbol] {
+    var result: [Symbol] = []
+    input.enumerateManglingCandidates { (candidate) in
+      if let demangled = demangle(candidate) {
+        result.append((mangled: candidate, demangled: demangled))
+      }
+    }
+    return result
+  }
+
+  /// Returns the demangled form of `candidate`, or `nil` if parsing is incomplete.
+  private static func demangle(_ candidate: Substring) -> String? {
+    guard let result = String(candidate).demangled(), !result.contains("#!") else { return nil }
+    return result
+  }
+
+}
+
+extension String {
+
+  /// Enumerates candidate mangled symbols in `self`.
+  ///
+  /// A candidate starts at `$` and continues while characters remain valid mangling symbols.
+  fileprivate func enumerateManglingCandidates(_ action: (Substring) -> Void) {
+    var remaining = self[...]
+    while let start = remaining.firstIndex(of: "$") {
+      let token = remaining[start...]
+      let end = token.firstIndex(where: { (c) in !c.isValidManglingSymbol }) ?? token.endIndex
+      action(token[..<end])
+      remaining = token[end...]
+    }
+  }
+
+}
+
+extension Character {
+
+  /// `true` iff `self` is valid in a mangled Hylo symbol.
+  fileprivate var isValidManglingSymbol: Bool {
+    isASCII && (isLetter || isNumber || self == "_" || self == "." || self == "$")
+  }
+
+}

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -1,5 +1,6 @@
 import Archivist
 import BackEnd
+import Demangler
 import Foundation
 import FrontEnd
 import StandardLibrary
@@ -379,7 +380,11 @@ public struct Driver {
     #endif
 
     let clang = try Host.findNativeExecutable(invokedAs: "clang")
-    _ = try Process.executionOutput(clang, arguments: arguments)
+    do {
+      _ = try Process.executionOutput(clang, arguments: arguments)
+    } catch let error as Process.NonzeroExit {
+      throw error.demanglingHyloSymbols()
+    }
   }
 
   /// The name of `module`.
@@ -432,6 +437,20 @@ public struct Driver {
       self.containsError = containsError
     }
 
+  }
+
+}
+
+extension Process.NonzeroExit {
+
+  /// Returns a copy with Hylo symbols in the process output demangled.
+  func demanglingHyloSymbols() -> Self {
+    .init(
+      exitCode: exitCode,
+      standardOutput: TextDemangler.rewrite(standardOutput),
+      standardError: TextDemangler.rewrite(standardError),
+      executable: executable,
+      arguments: arguments)
   }
 
 }

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -20,6 +20,18 @@ extension Process {
     /// The arguments passed to the process.
     public let arguments: [String]
 
+    /// Creates an instance with the given process result.
+    public init(
+      exitCode: Int32, standardOutput: String, standardError: String, executable: URL,
+      arguments: [String]
+    ) {
+      self.exitCode = exitCode
+      self.standardOutput = standardOutput
+      self.standardError = standardError
+      self.executable = executable
+      self.arguments = arguments
+    }
+
     /// A textual description of the failure.
     public var description: String {
       """

--- a/Sources/hylo-demangle/CommandLine.swift
+++ b/Sources/hylo-demangle/CommandLine.swift
@@ -1,6 +1,6 @@
 import ArgumentParser
+import Demangler
 import Foundation
-import FrontEnd
 
 /// Demangles Hylo mangled symbols found in input text.
 @main struct CommandLine: ParsableCommand {
@@ -50,56 +50,14 @@ import FrontEnd
 
   /// Prints `input` with each matched mangled symbol replaced by its demangled form.
   private func printRewritten(_ input: String) {
-    var lastIndex = input.startIndex
-    input.enumerateTokens { (token) in
-      if lastIndex < token.startIndex {
-        print(input[lastIndex..<token.startIndex], terminator: "")
-      }
-      if let demangled = String(token).demangled() {
-        print(demangled, terminator: "")
-      } else {
-        print(token, terminator: "")
-      }
-      lastIndex = token.endIndex
-    }
-    if lastIndex < input.endIndex {
-      print(input[lastIndex..<input.endIndex], terminator: "")
-    }
+    print(TextDemangler.rewrite(input), terminator: "")
   }
 
   /// Prints the demangled form of each matched mangled symbol in `input`.
   private func printDemangled(_ input: String) {
-    input.enumerateTokens { (token) in
-      if let demangled = String(token).demangled() {
-        print("\(token) => \(demangled)")
-      }
+    for symbol in TextDemangler.symbols(in: input) {
+      print("\(symbol.mangled) => \(symbol.demangled)")
     }
-  }
-
-}
-
-extension String {
-
-  /// Enumerates candidate mangled symbols in `self`.
-  ///
-  /// A candidate starts at `$` and continues while characters remain valid mangling symbols.
-  fileprivate func enumerateTokens(_ action: (Substring) -> Void) {
-    var remaining = self[...]
-    while let start = remaining.firstIndex(of: "$") {
-      let token = remaining[start...]
-      let end = token.firstIndex(where: { (c) in !c.isValidManglingSymbol() }) ?? token.endIndex
-      action(token[..<end])
-      remaining = token[end...]
-    }
-  }
-
-}
-
-extension Character {
-
-  /// Returns `true` iff `self` is a valid symbol in a mangled Hylo symbol.
-  fileprivate func isValidManglingSymbol() -> Bool {
-    isASCII && (isLetter || isNumber || self == "_" || self == "." || self == "$")
   }
 
 }

--- a/Tests/CompilerTests/DriverTests.swift
+++ b/Tests/CompilerTests/DriverTests.swift
@@ -1,4 +1,5 @@
 @testable import Driver
+import Foundation
 import SwiftyLLVM
 import XCTest
 import FrontEnd
@@ -39,6 +40,28 @@ final class DriverTests: XCTestCase {
       moduleCachePath: FileManager.default.temporaryDirectory, 
       targetSpecification: .native())
     XCTAssertNil(d.archive(of: "test"))
+  }
+
+  func testLinkerErrorDemanglesHyloSymbols() {
+    let mangled = "$hR1F06initlT01tR516selfsTR1tR5"
+    let error = Process.NonzeroExit(
+      exitCode: 1,
+      standardOutput: "stdout: undefined reference to '\(mangled)'",
+      standardError: "stderr: undefined reference to '\(mangled)'",
+      executable: URL(fileURLWithPath: "/usr/bin/clang"),
+      arguments: ["-o", "Test"])
+
+    let demangled = error.demanglingHyloSymbols()
+
+    XCTAssertEqual(
+      demangled.standardOutput,
+      "stdout: undefined reference to 'Hylo.Bool.fun init: [Void](self: Hylo.Bool) let -> Void'")
+    XCTAssertEqual(
+      demangled.standardError,
+      "stderr: undefined reference to 'Hylo.Bool.fun init: [Void](self: Hylo.Bool) let -> Void'")
+    XCTAssertEqual(demangled.exitCode, error.exitCode)
+    XCTAssertEqual(demangled.executable, error.executable)
+    XCTAssertEqual(demangled.arguments, error.arguments)
   }
 
   func testInvalidArchive() async throws {

--- a/Tests/DemanglerTests/TextDemanglerTests.swift
+++ b/Tests/DemanglerTests/TextDemanglerTests.swift
@@ -1,0 +1,37 @@
+import Demangler
+import XCTest
+
+final class TextDemanglerTests: XCTestCase {
+
+  let mangled = "$hR1F06initlT01tR516selfsTR1tR5"
+  let demangled = "Hylo.Bool.fun init: [Void](self: Hylo.Bool) let -> Void"
+
+  func testRewriteDemanglesSymbolsInText() {
+    let input = "undefined reference to '\(mangled)' and \(mangled)"
+
+    XCTAssertEqual(
+      TextDemangler.rewrite(input),
+      "undefined reference to '\(demangled)' and \(demangled)")
+  }
+
+  func testRewritePreservesTextWithoutMangledSymbols() {
+    let input = "clang: error: linker command failed with exit code 1"
+    XCTAssertEqual(TextDemangler.rewrite(input), input)
+  }
+
+  func testMalformedMangledSymbolIsPreservedAndNotListed() {
+    let input = "undefined reference to '$hello'"
+
+    XCTAssertEqual(TextDemangler.rewrite(input), input)
+    XCTAssertTrue(TextDemangler.symbols(in: input).isEmpty)
+  }
+
+  func testSymbolsListsEachOccurrence() {
+    let symbols = TextDemangler.symbols(in: "\(mangled), \(mangled)")
+
+    XCTAssertEqual(symbols.count, 2)
+    XCTAssertEqual(symbols.map({ String($0.mangled) }), [mangled, mangled])
+    XCTAssertEqual(symbols.map(\.demangled), [demangled, demangled])
+  }
+
+}


### PR DESCRIPTION
## Summary
- extract text-level Hylo symbol rewriting from `hylo-demangle` into a reusable `Demangler` library target
- demangle linker stdout and stderr before `Process.NonzeroExit` reaches compiler callers
- preserve malformed symbol-like text and all process exit metadata
- add focused demangler, malformed-input, and driver error regressions

## Verification
- `swift test` (443 passed)
- `swift build --build-tests -Xswiftc -enable-testing -c release`
- focused demangler and driver tests
- `hylo-demangle` rewrite and `--list` smoke tests
- 100-character line-length check
- `git diff --check`
- independent review completed with no remaining findings

Closes #328