### PR TITLE
Optimize 'Typer.canDeriveCoercions'

### DIFF
--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -91,7 +91,7 @@ public struct Typer {
     fileprivate var scopeToTypeOfSelf: [ScopeIdentity: AnyTypeIdentity?]
 
     /// The cache of `Typer.canDeriveCoercions(_:_:in:where:)`.
-    fileprivate var scopeToPossibleCoercions: [ScopeIdentity: [TypePair: Bool]]
+    fileprivate var scopeToPotentialCoercions: [ScopeIdentity: [TypePair: Bool]]
 
     /// The cache of `Typer.typeOfTraitSelf(in:)`.
     fileprivate var traitToTypeOfTraitSelf: [TraitDeclaration.ID: AnyTypeIdentity]
@@ -123,7 +123,7 @@ public struct Typer {
       self.scopeToGivens = [:]
       self.scopeToSummoned = [:]
       self.scopeToTypeOfSelf = [:]
-      self.scopeToPossibleCoercions = [:]
+      self.scopeToPotentialCoercions = [:]
       self.traitToTypeOfTraitSelf = [:]
       self.witnessToAliases = [:]
       self.declarationToTentativeType = [:]
@@ -3953,20 +3953,20 @@ public struct Typer {
 
     // Make sure the cache key does not depend on the order in which `a` and `b` have been passed.
     let p = (b.bits < a.bits) ? Pair(b, a) : Pair(a, b)
-    if let memoized = cache.scopeToPossibleCoercions[scopeOfUse]?[p] { return memoized }
+    if let memoized = cache.scopeToPotentialCoercions[scopeOfUse]?[p] { return memoized }
 
     // Check if there are givens in scope that could be used to derive a coercion.
     var result: UInt8 = 0
     for g in chain(environment.givens, givens(visibleFrom: scopeOfUse).joined())  {
       result |= canDeriveCoercion(p, applying: g)
       if result == 0b11 {
-        cache.scopeToPossibleCoercions[scopeOfUse, default: [:]][p] = true
+        cache.scopeToPotentialCoercions[scopeOfUse, default: [:]][p] = true
         return true
       }
     }
 
     assert((result & 0b11) != 0b11)
-    cache.scopeToPossibleCoercions[scopeOfUse, default: [:]][p] = false
+    cache.scopeToPotentialCoercions[scopeOfUse, default: [:]][p] = false
     return false
   }
 

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -90,6 +90,9 @@ public struct Typer {
     /// The cache of `Typer.typeOfSelf(in:)`.
     fileprivate var scopeToTypeOfSelf: [ScopeIdentity: AnyTypeIdentity?]
 
+    /// The cache of `Typer.canDeriveCoercions(_:_:in:where:)`.
+    fileprivate var scopeToPossibleCoercions: [ScopeIdentity: [TypePair: Bool]]
+
     /// The cache of `Typer.typeOfTraitSelf(in:)`.
     fileprivate var traitToTypeOfTraitSelf: [TraitDeclaration.ID: AnyTypeIdentity]
 
@@ -105,8 +108,8 @@ public struct Typer {
     /// The cache of `Typer.standardLibraryType(_:)`.
     fileprivate var standardLibraryEntityToType: [Program.StandardLibraryEntity: AnyTypeIdentity]
 
-    /// The cache of `Typer.canDeriveCoercion(_:_:applying:)`.
-    fileprivate var canDeriveCoercion: [Given: [TypePair: (Bool, Bool)]]
+    /// The cache of `Typer.canDeriveCoercion(_:applying:)`.
+    fileprivate var canDeriveCoercion: [Given: [TypePair: UInt8]]
 
     /// Creates an instance for typing `m`, which is a module in `p`.
     fileprivate init(typing m: Module.ID, in p: Program) {
@@ -120,6 +123,7 @@ public struct Typer {
       self.scopeToGivens = [:]
       self.scopeToSummoned = [:]
       self.scopeToTypeOfSelf = [:]
+      self.scopeToPossibleCoercions = [:]
       self.traitToTypeOfTraitSelf = [:]
       self.witnessToAliases = [:]
       self.declarationToTentativeType = [:]
@@ -3942,27 +3946,38 @@ public struct Typer {
     _ a: AnyTypeIdentity, _ b: AnyTypeIdentity, in scopeOfUse: ScopeIdentity,
     where environment: ResolutionThread.Environment
   ) -> Bool {
-    var lhs = false
-    var rhs = false
-
-    for g in chain(environment.givens, givens(visibleFrom: scopeOfUse).joined())  {
-      let (x, y) = canDeriveCoercion(a, b, applying: g)
-      lhs = lhs || x
-      rhs = rhs || y
-      if lhs && rhs { return true }
+    // If there aren't any givens in `scopeOfUse`, forward the query to the parent scope.
+    if givens(lexicallyIn: scopeOfUse).isEmpty, let p = program.parent(containing: scopeOfUse) {
+      return canDeriveCoercions(a, b, in: p, where: environment)
     }
 
-    assert(!lhs || !rhs)
+    // Make sure the cache key does not depend on the order in which `a` and `b` have been passed.
+    let p = (b.bits < a.bits) ? Pair(b, a) : Pair(a, b)
+    if let memoized = cache.scopeToPossibleCoercions[scopeOfUse]?[p] { return memoized }
+
+    // Check if there are givens in scope that could be used to derive a coercion.
+    var result: UInt8 = 0
+    for g in chain(environment.givens, givens(visibleFrom: scopeOfUse).joined())  {
+      result |= canDeriveCoercion(p, applying: g)
+      if result == 0b11 {
+        cache.scopeToPossibleCoercions[scopeOfUse, default: [:]][p] = true
+        return true
+      }
+    }
+
+    assert((result & 0b11) != 0b11)
+    cache.scopeToPossibleCoercions[scopeOfUse, default: [:]][p] = false
     return false
   }
 
-  /// Returns `(lhs, rhs)` where `lhs` (respectively `rhs`) is `true` iff `g` might be used to
-  /// prove a coercion from from `a` to `x` (respectively `x` to `b`) for some type `x`.
-  private mutating func canDeriveCoercion(
-    _ a: AnyTypeIdentity, _ b: AnyTypeIdentity, applying g: Given
-  ) -> (Bool, Bool) {
-    // Make sure the cache key does not depend on the order in which `a` and `b` have been passed.
-    let p = (b.bits < a.bits) ? Pair(b, a) : Pair(a, b)
+  /// Returns two bits indicating whether `g` may be used to prove a coercion from `p.first` to `x`
+  /// and from `x` to `p.second`, respectively.
+  ///
+  /// The two least significant bits of the result encode a pair of Boolean values, satisfying the
+  /// two following statements:
+  /// - `r & 0b10 != 0` iff `g` may witness a coercion from `p.first` to `x`; and
+  /// - `r & 0b01 != 0` iff `g` may witness a coercion from `p.second` to `x`.
+  private mutating func canDeriveCoercion(_ p: Memos.TypePair, applying g: Given) -> UInt8 {
     if let memoized = cache.canDeriveCoercion[g]?[p] { return memoized }
 
     let t = declaredType(of: g)
@@ -3970,24 +3985,25 @@ public struct Typer {
 
     // Can the given match any type (e.g., `<T> T`)?
     if u.context.parameters.contains(where: { (p) in p == u.head }) {
-      cache.canDeriveCoercion[g, default: [:]][p] = (true, true)
-      return (true, true)
+      cache.canDeriveCoercion[g, default: [:]][p] = 0b11
+      return 0b11
     }
 
     // Is the given of the form `T ~ U`?
-    if let e = program.types.cast(u.head, to: EqualityWitness.self) {
+    else if let e = program.types.cast(u.head, to: EqualityWitness.self) {
       let l = program.types.open(u.context.parameters, in: program.types[e].lhs)
       let r = program.types.open(u.context.parameters, in: program.types[e].rhs)
 
-      let lhs = unifiable(a, l) || unifiable(a, r)
-      let rhs = unifiable(b, l) || unifiable(b, r)
-      cache.canDeriveCoercion[g, default: [:]][p] = (lhs, rhs)
-      return (lhs, rhs)
+      var result: UInt8 = 0
+      if unifiable(p.first, l) || unifiable(p.first, r) { result |= 0b10 }
+      if unifiable(p.second, l) || unifiable(p.second, r) { result |= 0b01 }
+      cache.canDeriveCoercion[g, default: [:]][p] = result
+      return result
     }
 
     // The given can't be used to form a coercion.
-    cache.canDeriveCoercion[g, default: [:]][p] = (false, false)
-    return (false, false)
+    cache.canDeriveCoercion[g, default: [:]][p] = 0b00
+    return 0b00
   }
 
   // MARK: Name resolution


### PR DESCRIPTION
This patch slightly optimizes the implementation of `Typer.canDeriveCoercions`, which is used during name resolution as conservative test to determine whether the typer should attempt to prove the equality of two types.

Three optimizations are implemented.
- The first simply applies memoization.
- The second leverages the idea that if a scope contains no local given, then any query to the implicit context can be forwarded to the parent scope.
- The third uses but masking to avoid branches and reduce memory footprint.

These optimizations result in a tiny but noticeable speedup on my laptop.