### PR TITLE
Correct the exit condition of SubstitutionTable walk when walked is not a variable

### DIFF
--- a/Sources/FrontEnd/Typer/SubstitutionTable.swift
+++ b/Sources/FrontEnd/Typer/SubstitutionTable.swift
@@ -45,7 +45,10 @@ public struct SubstitutionTable: Hashable, Sendable {
   internal mutating func assign(_ substitution: AnyTypeIdentity, to variable: TypeVariable.ID) {
     var walked = variable
     while let a = types[walked] {
-      assert(a.isVariable || a == substitution, "variable is already bound")
+      if !a.isVariable {
+        assert(a == substitution, "variable is already bound to something else")
+        return
+      }
       walked = .init(uncheckedFrom: a)
     }
     types[walked] = substitution


### PR DESCRIPTION
Previously we were doing an unchecked cast to TypeVariable.ID, which may not be valid when `a == substitution`.