### PR TITLE
Add cache to Typer.applies

### DIFF
--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -111,6 +111,23 @@ public struct Typer {
     /// The cache of `Typer.canDeriveCoercion(_:applying:)`.
     fileprivate var canDeriveCoercion: [Given: [TypePair: UInt8]]
 
+    /// A key identifying an extension-applicability query.
+    fileprivate struct AppliesKey: Hashable {
+
+      /// The scope in which the extension is being applied.
+      let s: ScopeIdentity
+
+      /// The extension being tested.
+      let d: ExtensionDeclaration.ID
+
+      /// The subject type.
+      let t: AnyTypeIdentity
+
+    }
+
+    /// The cache of `Typer.applies(_:to:in:)`.
+    fileprivate var applies: [AppliesKey: SummonResult?]
+
     /// Creates an instance for typing `m`, which is a module in `p`.
     fileprivate init(typing m: Module.ID, in p: Program) {
       self.moduleToIdentifierToDeclaration = .init(repeating: nil, count: p.modules.count)
@@ -130,6 +147,7 @@ public struct Typer {
       self.predefinedGivens = [:]
       self.standardLibraryEntityToType = [:]
       self.canDeriveCoercion = [:]
+      self.applies = [:]
     }
 
   }
@@ -4604,12 +4622,23 @@ public struct Typer {
     // Fast path: types are trivially equal.
     if t == u { return .init(witness: w, substitutions: .init(), penalties: 0) }
 
+    // Consult the cache.
+    let key = Memos.AppliesKey(s: s, d: d, t: t)
+    if !t[.hasVariable], let m = cache.applies[key] {
+      return m
+    }
+
     // Slow path: use the match judgement of implicit resolution to create a witness describing
     // "how" the type matches the extension.
     let (context, head) = program.types.contextAndHead(t)
     assert(context.usings.isEmpty)
     let thread = formThread(matching: w, to: head, in: .empty)
-    return takeSummonResults(from: [thread], in: s).uniqueElement
+    let result = takeSummonResults(from: [thread], in: s).uniqueElement
+
+    if !t[.hasVariable] && !hasImplicitOnStack() {
+      cache.applies[key] = result
+    }
+    return result
   }
 
   /// Returns the modules that are imported by `f`, which is in the module being typed.

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -60,6 +60,9 @@ public struct Typer {
     /// A pair of types.
     fileprivate typealias TypePair = Pair<AnyTypeIdentity, AnyTypeIdentity>
 
+    /// A pair composed of an extension and a type.
+    fileprivate typealias ExtensionAndType = Pair<ExtensionDeclaration.ID, AnyTypeIdentity>
+
     /// The cache of `Typer.lookup(_:atTopLevelOf:)`.
     fileprivate var moduleToIdentifierToDeclaration: [LookupTable?]
 
@@ -111,22 +114,8 @@ public struct Typer {
     /// The cache of `Typer.canDeriveCoercion(_:applying:)`.
     fileprivate var canDeriveCoercion: [Given: [TypePair: UInt8]]
 
-    /// A key identifying an extension-applicability query.
-    fileprivate struct AppliesKey: Hashable {
-
-      /// The scope in which the extension is being applied.
-      let s: ScopeIdentity
-
-      /// The extension being tested.
-      let d: ExtensionDeclaration.ID
-
-      /// The subject type.
-      let t: AnyTypeIdentity
-
-    }
-
     /// The cache of `Typer.applies(_:to:in:)`.
-    fileprivate var applies: [AppliesKey: SummonResult?]
+    fileprivate var scopeToExtensionApplies: [ScopeIdentity: [ExtensionAndType: SummonResult]]
 
     /// Creates an instance for typing `m`, which is a module in `p`.
     fileprivate init(typing m: Module.ID, in p: Program) {
@@ -147,7 +136,7 @@ public struct Typer {
       self.predefinedGivens = [:]
       self.standardLibraryEntityToType = [:]
       self.canDeriveCoercion = [:]
-      self.applies = [:]
+      self.scopeToExtensionApplies = [:]
     }
 
   }
@@ -4610,12 +4599,17 @@ public struct Typer {
     }
   }
 
-  /// Returns how to match a value of type `t` to apply the members of `d` in `s`.
+  /// Returns how to match a value of type `t` to apply the members of `d` in `scopeOfUse`.
   ///
   /// - Requires: The context clause of `t`, if present, has no usings.
   private mutating func applies(
-    _ d: ExtensionDeclaration.ID, to t: AnyTypeIdentity, in s: ScopeIdentity
+    _ d: ExtensionDeclaration.ID, to t: AnyTypeIdentity, in scopeOfUse: ScopeIdentity
   ) -> SummonResult? {
+    // If there aren't any givens in `scopeOfUse`, forward the query to the parent scope.
+    if givens(lexicallyIn: scopeOfUse).isEmpty, let p = program.parent(containing: scopeOfUse) {
+      return applies(d, to: t, in: p)
+    }
+
     let u = extendeeType(d)
     let w = WitnessExpression(value: .reference(.init(d)), type: u)
 
@@ -4623,20 +4617,18 @@ public struct Typer {
     if t == u { return .init(witness: w, substitutions: .init(), penalties: 0) }
 
     // Consult the cache.
-    let key = Memos.AppliesKey(s: s, d: d, t: t)
-    if !t[.hasVariable], let m = cache.applies[key] {
-      return m
-    }
+    let key = Memos.ExtensionAndType(d, t)
+    if let memoized = cache.scopeToExtensionApplies[scopeOfUse]?[key] { return memoized }
 
     // Slow path: use the match judgement of implicit resolution to create a witness describing
     // "how" the type matches the extension.
     let (context, head) = program.types.contextAndHead(t)
     assert(context.usings.isEmpty)
     let thread = formThread(matching: w, to: head, in: .empty)
-    let result = takeSummonResults(from: [thread], in: s).uniqueElement
+    let result = takeSummonResults(from: [thread], in: scopeOfUse).uniqueElement
 
     if !t[.hasVariable] && !hasImplicitOnStack() {
-      cache.applies[key] = result
+      cache.scopeToExtensionApplies[scopeOfUse, default: [:]][key] = result
     }
     return result
   }


### PR DESCRIPTION
`applies` -> `takeSummonResults` were taking 93% of total CPU time when run on Dave's test. Adding a cache collapsed the 73-second type-checking to 2.8 seconds. The speedup is likely not this big in less pathological examples, but it's quite expensive to recompute `applies` on every statement.

The whole test suite runs 4 seconds faster (51s -> 47s), and a file containing 20 `let x<N> = 1`  in the same scope got speed up from 63ms -> 24ms in type-checking. If there are only 3 integer literals in the same scope, this already saves 3ms.
<img width="1244" height="449" alt="image" src="https://github.com/user-attachments/assets/a46cd87e-b5bd-4ed7-93e6-bf5a362b1b18" />
<img width="1244" height="449" alt="image" src="https://github.com/user-attachments/assets/6492be91-fae7-402d-980e-9d77cb2b3475" />

Note: I copied the gating of cache saving from `summon`, but I'm not sure if `hasImplicitOnStack` is relevant in this case.