### PR TITLE
Build system integration support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,7 +90,13 @@ jobs:
 
       - name: Export code coverage
         if: ${{ matrix.export-coverage }}
-        run: llvm-cov export $(swift build --show-bin-path)/HyloPackageTests.xctest  --format="lcov" --instr-profile $(swift build --show-bin-path)/codecov/default.profdata > info.lcov
+        # The merge picks up the .profraw files written by 'hc' subprocesses spawned from the
+        # end-to-end command-line tests.
+        # '-object' includes the 'hc' binary's coverage mapping in the export.
+        run: |
+          BIN_PATH=$(swift build --show-bin-path)
+          llvm-profdata merge -sparse $BIN_PATH/codecov/*.profraw -o $BIN_PATH/codecov/merged.profdata
+          llvm-cov export $BIN_PATH/HyloPackageTests.xctest -object $BIN_PATH/hc --format="lcov" --instr-profile $BIN_PATH/codecov/merged.profdata > info.lcov
 
       - name: Upload coverage report to Codecov
         if: ${{ matrix.export-coverage }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.build
 /.*-build
 /Packages
+*.profraw
 
 # IDEs
 /.vscode

--- a/Package.swift
+++ b/Package.swift
@@ -159,6 +159,16 @@ let package = Package(
       plugins: ["CompilerTestsPlugin"]),
 
     .testTarget(
+      name: "CommandLineTests",
+      dependencies: [
+        .target(name: "hc"),
+        .target(name: "FrontEnd"),
+        .target(name: "Utilities"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ],
+      swiftSettings: commonSwiftSettings),
+
+    .testTarget(
       name: "FrontEndTests",
       dependencies: [
         .target(name: "FrontEnd"),

--- a/Package.swift
+++ b/Package.swift
@@ -165,6 +165,7 @@ let package = Package(
         .target(name: "FrontEnd"),
         .target(name: "Utilities"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "Subprocess", package: "swift-subprocess"),
       ],
       swiftSettings: commonSwiftSettings),
 

--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ The project requires the Swift 6.3 compiler or later.
 ## Hylo Compiler's Runtime Dependencies
 `hc` uses `clang` and `lld` for linking, resolving them from PATH. On macOS, you will need `xcrun` 
 on PATH so the compiler can find the SDK.
+
+## Environment Variables
+
+- `HYLO_DEFAULT_CACHE_ROOT`: the directory in which `hc` saves its module cache by default.

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -34,11 +34,11 @@ public struct Driver {
   /// The code model for code generation.
   public var codeModel: CodeModel
 
-  /// The directories to pass to the linker as library search paths.
-  public var librarySearchPaths: [URL]
+  /// The linker's library search path.
+  public var librarySearchPath: [URL]
 
   /// The directories in which imported module archives (`.hylomodule` files) are searched.
-  public var moduleSearchPaths: [URL]
+  public var moduleSearchPath: [URL]
 
   /// The names of the native libraries to link (in addition to any imported Hylo dependencies).
   public var librariesToLink: [String]
@@ -88,7 +88,7 @@ public struct Driver {
     optimization: OptimizationLevel = .none,
     relocation: RelocationModel = Driver.defaultRelocationModel,
     codeModel: CodeModel = .default,
-    librarySearchPaths: [URL] = [], moduleSearchPaths: [URL] = [],
+    librarySearchPath: [URL] = [], moduleSearchPath: [URL] = [],
     librariesToLink: [String] = []
   ) {
     self.moduleCachePath = moduleCachePath
@@ -96,8 +96,8 @@ public struct Driver {
     self.optimization = optimization
     self.relocation = relocation
     self.codeModel = codeModel
-    self.librarySearchPaths = librarySearchPaths
-    self.moduleSearchPaths = moduleSearchPaths
+    self.librarySearchPath = librarySearchPath
+    self.moduleSearchPath = moduleSearchPath
     self.librariesToLink = librariesToLink
     self.program = .init()
   }
@@ -386,11 +386,11 @@ public struct Driver {
     return try? Data(contentsOf: c.appending(path: module + ".hylomodule"))
   }
 
-  /// Returns the location and contents of `module`'s archive found in `moduleSearchPaths`, if any.
+  /// Returns the location and contents of `module`'s archive found in `moduleSearchPath`, if any.
   ///
   /// - Throws if an archive exists but cannot be read.
   private func importedArchive(of module: Module.Name) throws -> (url: URL, data: Data)? {
-    for prefix in moduleSearchPaths {
+    for prefix in moduleSearchPath {
       let u = prefix.appending(path: module + ".hylomodule")
       if FileManager.default.fileExists(atPath: u.path) {
         do {
@@ -403,7 +403,7 @@ public struct Driver {
     return nil
   }
 
-  /// Loads `module` and its dependencies from archives found in `moduleSearchPaths`, returning the
+  /// Loads `module` and its dependencies from archives found in `moduleSearchPath`, returning the
   /// identity of `module`.
   @discardableResult
   public mutating func loadArchivedModule(_ module: Module.Name) throws -> Module.ID {
@@ -411,7 +411,7 @@ public struct Driver {
     return try loadArchivedModule(module, modulesStartedLoading: &ms)
   }
 
-  /// Loads `module` and its dependencies from archives found in `moduleSearchPaths`, returning the
+  /// Loads `module` and its dependencies from archives found in `moduleSearchPath`, returning the
   /// identity of `module` and using `modulesStartedLoading` to detect circular dependencies.
   @discardableResult
   private mutating func loadArchivedModule(
@@ -425,7 +425,7 @@ public struct Driver {
     }
 
     guard let (source, data) = try importedArchive(of: module) else {
-      let ps = moduleSearchPaths.map(\.path).joined(separator: ", ")
+      let ps = moduleSearchPath.map(\.path).joined(separator: ", ")
       throw Error(message: "no archive found for module '\(module)' in module search paths [\(ps)]")
     }
 
@@ -494,7 +494,7 @@ public struct Driver {
   /// - Throws: if the parent folder of `output` doesn't exist.
   private func linkExecutable(from objectFiles: [URL], writingTo output: URL) async throws {
     var arguments = ["-o", output.path]
-    arguments += librarySearchPaths.map({ "-L\($0.path)" })
+    arguments += librarySearchPath.map({ "-L\($0.path)" })
     arguments += librariesToLink.map({ "-l\($0)" })
     arguments += objectFiles.map(\.path)
 

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -34,10 +34,13 @@ public struct Driver {
   /// The code model for code generation.
   public var codeModel: CodeModel
 
-  /// The list of directories in which to search for libraries to link.
+  /// The directories to pass to the linker as library search paths.
   public var librarySearchPaths: [URL]
 
-  /// The names of the native libraries to link.
+  /// The directories in which imported module archives (`.hylomodule` files) are searched.
+  public var moduleSearchPaths: [URL]
+
+  /// The names of the native libraries to link (in addition to any imported Hylo dependencies).
   public var librariesToLink: [String]
 
   /// `true` iff compilation and linking depend on the standard library and its shim.
@@ -65,11 +68,19 @@ public struct Driver {
 
   #if USE_BUNDLED_STANDARD_LIBRARY // Set compiler flag in distributable builds.
   /// The root folder of the standard library's sources.
-  private let chosenStandardLibraryRoot = bundledStandardLibrarySources
+  public static let standardLibraryRoot = bundledStandardLibrarySources
   #else
   /// The root folder of the standard library's sources.
-  private let chosenStandardLibraryRoot = localStandardLibrarySources
+  public static let standardLibraryRoot = localStandardLibrarySources
   #endif
+
+  /// The file within `standardLibraryRoot` implementing the standard library's
+  /// `@extern_c_indirect` declarations.
+  ///
+  /// Build systems linking Hylo objects must compile and link this except in freestanding mode.
+  public static var standardLibraryCShim: URL {
+    standardLibraryRoot.appending(component: cShimSource)
+  }
 
   /// Creates an instance with the given properties.
   public init(
@@ -77,7 +88,8 @@ public struct Driver {
     optimization: OptimizationLevel = .none,
     relocation: RelocationModel = Driver.defaultRelocationModel,
     codeModel: CodeModel = .default,
-    librarySearchPaths: [URL] = [], librariesToLink: [String] = []
+    librarySearchPaths: [URL] = [], moduleSearchPaths: [URL] = [],
+    librariesToLink: [String] = []
   ) {
     self.moduleCachePath = moduleCachePath
     self.target = targetSpecification
@@ -85,6 +97,7 @@ public struct Driver {
     self.relocation = relocation
     self.codeModel = codeModel
     self.librarySearchPaths = librarySearchPaths
+    self.moduleSearchPaths = moduleSearchPaths
     self.librariesToLink = librariesToLink
     self.program = .init()
   }
@@ -110,9 +123,7 @@ public struct Driver {
 
   /// Assigns the trees in `module` to their scopes.
   @discardableResult
-  public mutating func assignScopes(
-    of module: Module.ID
-  ) async -> PhaseResult {
+  public mutating func assignScopes(of module: Module.ID) async -> PhaseResult {
     let clock = ContinuousClock()
     let elapsed = await clock.measure {
       await program.assignScopes(module)
@@ -135,9 +146,7 @@ public struct Driver {
 
   /// Lowers the contents of `module` to IR.
   @discardableResult
-  public mutating func lower(
-    _ module: Module.ID
-  ) async -> PhaseResult {
+  public mutating func lower(_ module: Module.ID) async -> PhaseResult {
     let clock = ContinuousClock()
     let elapsed = clock.measure {
       program.lower(module)
@@ -147,9 +156,7 @@ public struct Driver {
 
   /// Applies mandatory transformation passes on the IR of `module`.
   @discardableResult
-  public mutating func applyTransformationPasses(
-    _ module: Module.ID
-  ) async -> PhaseResult {
+  public mutating func applyTransformationPasses(_ module: Module.ID) async -> PhaseResult {
     let elapsed = ContinuousClock().measure {
       program.applyTransformationPasses(module)
     }
@@ -168,31 +175,31 @@ public struct Driver {
     let elapsed = try ContinuousClock().measure {
       let t = TargetMachine(
         target: target, optimization: optimization, relocation: relocation, codeModel: codeModel)
-      var m = try program.compileToLLVM(module, target: t)
+      var llvm = try program.compileToLLVM(module, target: t)
 
-      try verify(m)
-      m.runDefaultModulePasses(optimization: optimization)
-      try verify(m)
+      try verify(llvm)
+      llvm.runDefaultModulePasses(optimization: optimization)
+      try verify(llvm)
 
-      llvmModules[module] = LLVMModuleBox(consume m)
+      llvmModules[module] = LLVMModuleBox(consume llvm)
     }
     return .init(elapsed: elapsed, containsError: program[module].containsError)
   }
 
-  /// Applies LLVM IR verification passes to `module` iff this file has been compiled in debug
+  /// Applies LLVM IR verification passes to `m` iff this file has been compiled in debug
   /// mode; does nothing otherwise.
   ///
-  /// - Throws: if the contents of `module` failed verification.
-  private func verify(_ module: borrowing SwiftyLLVM.Module) throws {
+  /// - Throws: if the contents of `m` failed verification.
+  private func verify(_ m: borrowing SwiftyLLVM.Module) throws {
     do {
-      try module.verifyInDebugBuilds()
+      try m.verifyInDebugBuilds()
     } catch let e as LLVMError {
       throw Error(
         message: """
         LLVM verification failed with the following message: \(e.description)
 
         Module contents:
-        \(module.description)
+        \(m.description)
         """)
     }
   }
@@ -215,11 +222,11 @@ public struct Driver {
       if usesStandardLibrary {
         // FIXME: Enable this after we can lower the standard library
         // modulesToLink.append(program.modules[.standardLibrary]!.identity)
-        cSources.append(chosenStandardLibraryRoot.appending(component: cShimSource))
+        cSources.append(Driver.standardLibraryCShim)
       }
 
       try await FileManager.default.withUniqueTemporaryDirectory { (d) in
-        let hyloObjects = try writeObjectFiles(for: modulesToLink, into: d)
+        let hyloObjects = try emitObjectFiles(for: modulesToLink, into: d)
         var cObjects: [URL] = []
         for s in cSources {
           cObjects.append(try await compileCToObject(source: s, destinationDirectory: d))
@@ -235,11 +242,11 @@ public struct Driver {
     llvmModules[module]?.module.llCode()
   }
 
-  /// Returns the assembly of module `m`.
+  /// Returns the assembly of `module`.
   ///
-  /// - Requires: module `m` has been lowered to LLVM.
-  public func assembly(of m: Module.ID) throws -> String {
-    try llvmModules[m]!.module.compile(.assembly).utf8Decoded
+  /// - Requires: `module` has been lowered to LLVM.
+  public func assembly(of module: Module.ID) throws -> String {
+    try llvmModules[module]!.module.compile(.assembly).utf8Decoded
       .unwrapOrThrow(Error(message: "Failed to decode assembly as an UTF8 string."))
   }
 
@@ -248,14 +255,21 @@ public struct Driver {
   /// - Requires: each element of `modules` has been lowered to LLVM.
   /// - Throws: if `destinationDirectory` doesn't exist.
   @discardableResult
-  public func writeObjectFiles(
+  public func emitObjectFiles(
     for modules: [Module.ID], into destinationDirectory: URL
   ) throws -> [URL] {
     try modules.map { (m) in
       let o = destinationDirectory.appendingPathComponent(moduleName(m) + ".o", isDirectory: false)
-      try llvmModules[m]!.module.write(.objectFile, to: o.path)
+      try emitObjectFile(of: m, to: o)
       return o
     }
+  }
+
+  /// Writes the object file of `module` to `output`.
+  ///
+  /// - Requires: `module` has been already lowered to LLVM.
+  public func emitObjectFile(of module: Module.ID, to output: URL) throws {
+    try llvmModules[module]!.module.write(.objectFile, to: output.path)
   }
 
   /// Compiles `source` using `clang` to an object file.
@@ -279,39 +293,52 @@ public struct Driver {
   ///
   /// If `moduleCachePath` is set, the module is loaded from cache if an archive is found and its
   /// fingerprint matches the fingerprint of the source files in `root`. Otherwise, the module is
-  /// compiled from sources and an archive is stored at `moduleCachePath`. If `moduleCachePath` is
-  /// not set, the module is unconditionally compiled from sources and no archive is stored.
+  /// compiled from sources and an archive is stored at `moduleCachePath`; A cached archive that
+  /// cannot be parsed is compiled from sources and overwritten.
   public mutating func load(
     _ module: Module.Name, withSourcesAt root: URL, additionalSources: [SourceFile] = []
   ) async throws {
     let sources = additionalSources + (try sources(at: root))
 
-    // Attempt to load the module from disk.
-    do {
-      if cachingIsEnabled, let data = archive(of: module) {
-        let h = SourceFile.fingerprint(contentsOf: sources)
-        var a = ReadableArchive(data)
-        let (_, fingerprint) = try Module.header(&a)
-        if h == fingerprint {
-          a = ReadableArchive(data)
-          try program.load(module: module, from: &a)
-          return
-        }
+    // If caching is enabled, load the module from disk or compile and cache it if that failed.
+    if cachingIsEnabled {
+      if try !loadCached(module, matching: sources) {
+        let m = try await compile(module, from: sources)
+        try writeToCache(m)
       }
-    } catch ArchiveError.invalidInput {
-      let m = """
-        Failed to parse module archive of '\(module)' at '\(moduleCachePath, default: "nil")'.
-
-        Maybe the archive was compiled with a different version of the compiler. \
-        Try erasing the module cache.
-        """
-      throw Error(message: m)
     }
+    // Otherwise, ignore the cache entirely.
+    else {
+      _ = try await compile(module, from: sources)
+    }
+  }
 
-    // Compile the module from sources.
-    let m = program.demandModule(module)
+  /// Loads `module` from its cache and returns `true` iff its fingerprint matches that of `s`
+  private mutating func loadCached(_ module: Module.Name, matching s: [SourceFile]) throws -> Bool {
+    guard let data = cachedArchive(of: module) else { return false }
+    do {
+      var a = ReadableArchive(data)
+      let (name, fingerprint) = try Module.header(&a)
+      // Invalid name or fingerprint.
+      guard name == module, fingerprint == SourceFile.fingerprint(contentsOf: s) else {
+        return false
+      }
 
-    if usesStandardLibrary && module != Module.standardLibraryName {
+      a = ReadableArchive(data)
+      try program.load(module: module, from: &a)
+      return true
+    } catch is ArchiveError {
+      return false
+    }
+  }
+
+  /// Compiles the module named `n` from `sources` to refined IR, returning its identifier.
+  private mutating func compile(
+    _ n: Module.Name, from sources: [SourceFile]
+  ) async throws -> Module.ID {
+    let m = program.demandModule(n)
+
+    if usesStandardLibrary && (n != Module.standardLibraryName) {
       program[m].addDependency(Module.standardLibraryName)
     }
 
@@ -330,39 +357,135 @@ public struct Driver {
     await applyTransformationPasses(m)
     try throwIfContainsError(m)
 
-    if cachingIsEnabled {
-      let a = try program.archive(module: m)
-      let f = moduleCachePath!.appending(component: module + ".hylomodule")
-      try a.write(into: f)
-    }
+    return m
+  }
+
+  /// Writes `module` to the module cache.
+  ///
+  /// - Requires: `cachingIsEnabled` is `true`.
+  private func writeToCache(_ module: Module.ID) throws {
+    let f = moduleCachePath!.appending(component: program[module].name + ".hylomodule")
+    try writeArchive(of: module, to: f)
   }
 
   /// Loads the standard library with `load(_:withSourcesAt:)` and makes
   /// standard library a dependency of modules loaded thereafter.
-  /// 
+  ///
   /// Use the `USE_BUNDLED_STANDARD_LIBRARY` compiler flag to control whether the  bundled or local
   /// standard library is used. Defaults to local.
   public mutating func loadStandardLibrary() async throws {
     try await load(
-      Module.standardLibraryName, withSourcesAt: chosenStandardLibraryRoot,
+      Module.standardLibraryName, withSourcesAt: Driver.standardLibraryRoot,
       additionalSources: [SourceFile(contentsOf: generatedStandardLibrarySource)])
     usesStandardLibrary = true
   }
 
-  /// Searches for an archive of `module` in `librarySearchPaths`, returning it if found.
-  public func archive(of module: Module.Name) -> Data? {
-    if let prefix = moduleCachePath {
-      let path = prefix.appending(path: module + ".hylomodule")
-      return try? Data(contentsOf: path)
-    } else {
-      return nil
+  /// Returns the archive of `module` in the module cache if present, `nil` otherwise.
+  internal func cachedArchive(of module: Module.Name) -> Data? {
+    guard let c = moduleCachePath else { return nil }
+    return try? Data(contentsOf: c.appending(path: module + ".hylomodule"))
+  }
+
+  /// Returns the location and contents of `module`'s archive found in `moduleSearchPaths`, if any.
+  ///
+  /// - Throws if an archive exists but cannot be read.
+  private func importedArchive(of module: Module.Name) throws -> (url: URL, data: Data)? {
+    for prefix in moduleSearchPaths {
+      let u = prefix.appending(path: module + ".hylomodule")
+      if FileManager.default.fileExists(atPath: u.path) {
+        do {
+          return (u, try Data(contentsOf: u))
+        } catch {
+          throw Error(message: "cannot read module archive at '\(u.path)': \(error)")
+        }
+      }
+    }
+    return nil
+  }
+
+  /// Loads `module` and its dependencies from archives found in `moduleSearchPaths`, returning the
+  /// identity of `module`.
+  @discardableResult
+  public mutating func loadArchivedModule(_ module: Module.Name) throws -> Module.ID {
+    var ms = Set<Module.Name>()
+    return try loadArchivedModule(module, modulesStartedLoading: &ms)
+  }
+
+  /// Loads `module` and its dependencies from archives found in `moduleSearchPaths`, returning the
+  /// identity of `module` and using `modulesStartedLoading` to detect circular dependencies.
+  @discardableResult
+  private mutating func loadArchivedModule(
+    _ module: Module.Name, modulesStartedLoading: inout Set<Module.Name>
+  ) throws -> Module.ID {
+    // Nothing to do if the module is already loaded.
+    if let module = program.identity(module: module) { return module }
+
+    if !modulesStartedLoading.insert(module).inserted {
+      throw Error(message: "circular dependency detected while loading module '\(module)'")
+    }
+
+    guard let (source, data) = try importedArchive(of: module) else {
+      let ps = moduleSearchPaths.map(\.path).joined(separator: ", ")
+      throw Error(message: "no archive found for module '\(module)' in module search paths [\(ps)]")
+    }
+
+    // TODO: save fingerprint of dependencies and check that they match the version `module` was
+    // compiled against.
+
+    // Ensure the dependencies are loaded before we load `module`.
+    var a = ReadableArchive(data)
+
+    let h: (name: Module.Name, fingerprint: UInt64, dependencies: [Module.Name])
+    do { h = try Module.headerAndDependencies(&a) }
+    catch { throw cannotParseArchive(of: module, at: source) }
+
+    guard h.name == module else {
+      throw Error(message: """
+        archive for '\(module)' at '\(source.path)' declares a different module name '\(h.name)'
+        """)
+    }
+    for d in h.dependencies {
+      try loadArchivedModule(d, modulesStartedLoading: &modulesStartedLoading)
+    }
+
+    var body = ReadableArchive(data)
+    do {
+      return try program.load(module: module, from: &body).identity
+    } catch is ArchiveError {
+      throw cannotParseArchive(of: module, at: source)
     }
   }
 
-  /// Throws the diagnostics of `m` if those contain an error.
-  private func throwIfContainsError(_ m: Module.ID) throws {
-    if program[m].containsError {
-      throw CompilationError(diagnostics: .init(program[m].diagnostics))
+  /// Returns an error reporting that the archive of `module` at `location` could not be parsed.
+  private func cannotParseArchive(of module: Module.Name, at location: URL) -> Error {
+    Error(message: """
+      Failed to parse the module archive of '\(module)' at '\(location.path)'.
+
+      Maybe the archive was compiled with a different version of the compiler.
+      """)
+  }
+
+  /// Writes the archive of `module` to `output`.
+  ///
+  /// The parent directories of `output` are expected to exist.
+  public func writeArchive(of module: Module.ID, to output: URL) throws {
+    try program.archive(module: module).write(into: output)
+  }
+
+  /// Returns a hash of `module` that a build system can use as a rebuild key for its dependents.
+  public func moduleInterfaceHash(of module: Module.ID) throws -> UInt64 {
+    // TODO: Make the interface hash resilient to changes in function bodies.
+    // https://github.com/hylo-lang/hylo-new/issues/321
+
+    // Note: avoiding `.hashValue` for consistency across runs and host platforms.
+    let a = try program.archive(module: module)
+    return FNV1.hash(a, into: FNV1.u64()).state
+  }
+
+  /// Throws the diagnostics of `module` if those contain an error.
+  private func throwIfContainsError(_ module: Module.ID) throws {
+    if program[module].containsError {
+      throw CompilationError(diagnostics: .init(program[module].diagnostics))
     }
   }
 
@@ -403,8 +526,8 @@ public struct Driver {
     var module: LLVMModule
 
     /// Wraps `module` by consuming it.
-    init(_ module: consuming LLVMModule) {
-      self.module = module
+    init(_ m: consuming LLVMModule) {
+      self.module = m
     }
 
   }

--- a/Sources/FrontEnd/Module.swift
+++ b/Sources/FrontEnd/Module.swift
@@ -550,6 +550,7 @@ extension Module: Archivable {
       }
 
       var me = Self(name: name, identity: ctx.identities[name]!)
+      me.dependencies = dependencies
 
       // <source count> <identity> <contents> ...
       let count = try Int(archive.readUnsignedLEB128())
@@ -650,7 +651,7 @@ extension Module: Archivable {
         try archive.write(s.variableToBinding, in: &ctx, sortedBy: \.key)
         try archive.write(s.syntaxToType, in: &ctx, sortedBy: \.key)
         try archive.write(s.nameToDeclaration, in: &ctx, sortedBy: \.key)
-        try archive.write(s.witnessTables, in: &ctx)
+        try archive.write(s.witnessTables, in: &ctx, sortedBy: \.key)
       }
 
       // IR functions.
@@ -680,6 +681,22 @@ extension Module: Archivable {
     let name = try archive.read(Name.self)
     let hash = try archive.read(UInt64.self, endianness: .little)
     return (name, hash)
+  }
+
+  /// Returns the name, fingerprint, and dependencies of the module stored in `archive`.
+  public static func headerAndDependencies<A>(
+    _ archive: inout ReadableArchive<A>
+  ) throws -> (name: Module.Name, fingerprint: UInt64, dependencies: [Module.Name]) {
+    let (name, hash) = try header(&archive)
+
+    // <dependency count> [<dependency name> ...]
+    let dependencyCount = try archive.readUnsignedLEB128()
+    var dependencies: [Module.Name] = []
+    for _ in 0 ..< dependencyCount {
+      dependencies.append(try archive.read(Name.self))
+    }
+
+    return (name, hash, dependencies)
   }
 
 }

--- a/Sources/Utilities/Collection+Extensions.swift
+++ b/Sources/Utilities/Collection+Extensions.swift
@@ -7,10 +7,10 @@ extension Collection {
 
   /// Returns the index of the unique element that satisfies `predicate` if any.
   ///
-  /// - Complexity: At most n applications of `preficate`, where n is the length of `self`.
+  /// - Complexity: At most n applications of `predicate`, where n is the length of `self`.
   public func uniqueIndex(where predicate: (Element) throws -> Bool) rethrows -> Index? {
     if let i = try firstIndex(where: predicate) {
-      return try !suffix(from: i).contains(where: predicate) ? i : nil
+      return try !suffix(from: index(after: i)).contains(where: predicate) ? i : nil
     } else {
       return nil
     }
@@ -58,25 +58,6 @@ extension BidirectionalCollection {
   public subscript(toLast distanceToLast: Int) -> Element {
     let i = index(endIndex, offsetBy: -(distanceToLast + 1))
     return self[i]
-  }
-
-}
-
-extension RangeReplaceableCollection where Element: Hashable {
-
-  /// Removes all except the first element from every consecutive group of equivalent elements.
-  ///
-  /// - Complexity: O(n) where n is the length of `self`.
-  public mutating func removeDuplicates() {
-    var s = Set<Element>(minimumCapacity: count)
-    var i = startIndex
-    while i != endIndex {
-      if s.insert(self[i]).inserted {
-        formIndex(after: &i)
-      } else {
-        remove(at: i)
-      }
-    }
   }
 
 }

--- a/Sources/Utilities/Hashing.swift
+++ b/Sources/Utilities/Hashing.swift
@@ -51,6 +51,11 @@ public enum FNV1 {
     return .init(basis: basis, prime: prime)
   }
 
+  /// Creates an instance producing hashes as instances of `UInt64`.
+  public static func u64() -> Implementation<UInt64> {
+    .init(basis: 0xcbf29ce484222325, prime: 0x100000001b3)
+  }
+
   /// Creates an instance producing hashes as instances of `UInt128`.
   public static func u128() -> Implementation<UInt128> {
     let basis: UInt128 = 0x6c62272e07bb014262b821756295c58d

--- a/Sources/Utilities/Subprocess+Extensions.swift
+++ b/Sources/Utilities/Subprocess+Extensions.swift
@@ -70,13 +70,14 @@ extension Executable {
 /// The result of a subprocess execution with captured string outputs.
 public typealias ExecutionReport = ExecutionResult<Void, StringOutput<UTF8>, StringOutput<UTF8>>
 
-/// Runs `executable` with `arguments` in `workingDirectory` (or the current directory if `nil`),
-/// capturing its standard output and standard error as strings.
+/// Runs `executable` with `arguments` and `environment` in `workingDirectory` (or the current
+/// directory if `nil`), capturing its standard output and standard error as strings.
 public func executeSubprocess(
-  _ executable: Executable, arguments: [String] = [], workingDirectory: URL? = nil
+  _ executable: Executable, arguments: [String] = [], workingDirectory: URL? = nil,
+  environment: Environment = .inherit
 ) async throws -> ExecutionReport {
   try await run(
-    executable, arguments: .init(arguments),
+    executable, arguments: .init(arguments), environment: environment,
     workingDirectory: workingDirectory.map({ .init($0.path) }),
     output: .string(limit: .max), error: .string(limit: .max))
 }

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -14,14 +14,14 @@ private typealias Module = FrontEnd.Module
   /// Configuration for this command.
   public static let configuration = CommandConfiguration(commandName: "hc", version: hyloVersion)
 
-  /// The directories to pass to the linker as library search paths.
+  /// The linker's library search path.
   @Option(
     name: [.customShort("L")],
     help: ArgumentHelp(
       "Add a directory to the linker's search path.",
       valueName: "path"),
     transform: URL.init(fileURLWithPath:))
-  private var librarySearchPaths: [URL] = []
+  private var librarySearchPath: [URL] = []
 
   /// The paths at which imported module archives (`.hylomodule`) may be found.
   @Option(
@@ -30,7 +30,7 @@ private typealias Module = FrontEnd.Module
       "Add a directory to the module search path, where imported module archives are found.",
       valueName: "path"),
     transform: URL.init(fileURLWithPath:))
-  private var moduleSearchPaths: [URL] = []
+  private var moduleSearchPath: [URL] = []
 
   /// The path containing cached module data.
   @Option(
@@ -232,8 +232,8 @@ private typealias Module = FrontEnd.Module
       optimization: optimized ? .aggressive : .none,
       relocation: relocationModel ?? Driver.defaultRelocationModel,
       codeModel: codeModel ?? .default,
-      librarySearchPaths: Array(librarySearchPaths.uniqued()),
-      moduleSearchPaths: Array(moduleSearchPaths.uniqued()))
+      librarySearchPath: Array(librarySearchPath.uniqued()),
+      moduleSearchPath: Array(moduleSearchPath.uniqued()))
 
     do {
       // Load the imported modules.

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -36,7 +36,10 @@ private typealias Module = FrontEnd.Module
   @Option(
     name: [.customLong("module-cache")],
     help: ArgumentHelp(
-      "Specify the module cache path (default: a 'hylo' directory in the user's caches directory).",
+      """
+      Specify the module cache path (default: a 'hylo' directory in \
+      $\(CommandLine.defaultCacheRootVariable) or the user's caches directory).
+      """,
       valueName: "path"),
     transform: URL.init(fileURLWithPath:))
   private var moduleCachePath: URL?
@@ -468,13 +471,35 @@ private typealias Module = FrontEnd.Module
     note("written \(u.path)")
   }
 
-  /// Returns the directory to use as the module cache when `--module-cache` is not specified.
+  /// The name of the environment variable denoting the directory in which the default module
+  /// cache is created.
+  ///
+  /// Build systems set this variable to keep the compiler's cache inside their own workspace
+  /// rather than in the user's caches directory.
+  fileprivate static let defaultCacheRootVariable = "HYLO_DEFAULT_CACHE_ROOT"
+
+  /// Returns the directory to use as the module cache when `--module-cache` is not specified,
+  /// creating it if necessary.
+  ///
+  /// The cache is a 'hylo' directory in the root denoted by `HYLO_DEFAULT_CACHE_ROOT` if that
+  /// variable is set to a non-empty value, in the user's caches directory otherwise.
   private func defaultCachePath() throws -> URL {
     let m = FileManager.default
-    let base = m.urls(for: .cachesDirectory, in: .userDomainMask).first ?? m.temporaryDirectory
+
+    let base = defaultCacheRoot
+      ?? m.urls(for: .cachesDirectory, in: .userDomainMask).first
+      ?? m.temporaryDirectory
     let d = base.appending(path: "hylo")
     try m.createDirectory(at: d, withIntermediateDirectories: true)
     return d
+  }
+
+  /// The directory in which the default module cache should be created, as specified by the
+  /// environment, or `nil` if the environment does not specify one.
+  private var defaultCacheRoot: URL? {
+    guard let r = ProcessInfo.processInfo.environment[Self.defaultCacheRootVariable], !r.isEmpty
+    else { return nil }
+    return URL(fileURLWithPath: r)
   }
 
   /// The name of the module being compiled.

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -14,20 +14,29 @@ private typealias Module = FrontEnd.Module
   /// Configuration for this command.
   public static let configuration = CommandConfiguration(commandName: "hc", version: hyloVersion)
 
-  /// The paths at which libraries may be found.
+  /// The directories to pass to the linker as library search paths.
   @Option(
     name: [.customShort("L")],
     help: ArgumentHelp(
-      "Add a directory to the library search path.",
+      "Add a directory to the linker's search path.",
       valueName: "path"),
     transform: URL.init(fileURLWithPath:))
   private var librarySearchPaths: [URL] = []
+
+  /// The paths at which imported module archives (`.hylomodule`) may be found.
+  @Option(
+    name: [.customLong("module-search-path")],
+    help: ArgumentHelp(
+      "Add a directory to the module search path, where imported module archives are found.",
+      valueName: "path"),
+    transform: URL.init(fileURLWithPath:))
+  private var moduleSearchPaths: [URL] = []
 
   /// The path containing cached module data.
   @Option(
     name: [.customLong("module-cache")],
     help: ArgumentHelp(
-      "Specify the module cache path.",
+      "Specify the module cache path (default: a 'hylo' directory in the user's caches directory).",
       valueName: "path"),
     transform: URL.init(fileURLWithPath:))
   private var moduleCachePath: URL?
@@ -90,6 +99,12 @@ private typealias Module = FrontEnd.Module
     help: "Do not load the standard library")
   private var noStandardLibrary: Bool = false
 
+  /// `true` iff the compiler should print the standard library's root and exit.
+  @Flag(
+    name: [.customLong("print-stdlib-root")],
+    help: "Print the path of the standard library's root directory and exit.")
+  private var printStandardLibraryRoot: Bool = false
+
   /// The kind of output that should be produced by the compiler.
   @Option(
     name: [.customLong("emit")],
@@ -103,6 +118,53 @@ private typealias Module = FrontEnd.Module
     name: [.customLong("trace-inference")],
     help: "Trace type inference")
   private var lineTracingInference: LineLocator?
+
+  /// The name of the module being compiled, if specified explicitly.
+  ///
+  /// - See: `effectiveModuleName`.
+  @Option(
+    name: [.customLong("module-name")],
+    help: ArgumentHelp(
+      """
+      The name of the module being compiled. Defaults to the base name of the input if a single \
+      source file is given, or 'Main' otherwise.
+      """,
+      valueName: "name"))
+  private var moduleName: String?
+
+  /// The names of the modules that are dependencies of the module being compiled.
+  ///
+  /// Each dependency is loaded from a `<name>.hylomodule` archive found in the module search paths.
+  @Option(
+    name: [.customLong("import")],
+    help: ArgumentHelp(
+      """
+      Make the given module visible to the module being compiled. Pass this option once for each \
+      dependency.
+      """,
+      valueName: "module"))
+  private var imports: [String] = []
+
+  /// The path at which the archive of the compiled module should be written, if any.
+  @Option(
+    name: [.customLong("emit-module-to")],
+    help: ArgumentHelp(
+      "Serializes the compiled module to <file>, so other modules can import it.",
+      valueName: "file"),
+    transform: URL.init(fileURLWithPath:))
+  private var moduleArchiveURL: URL?
+
+  /// The path at which the compiled module's interface hash should be written, if any.
+  @Option(
+    name: [.customLong("emit-module-interface-hash-to")],
+    help: ArgumentHelp(
+      """
+      Write a hash of the module's observable interface to <file>. When unchanged, \
+      build systems may skip recompiling dependents.
+      """,
+      valueName: "file"),
+    transform: URL.init(fileURLWithPath:))
+  private var writeModuleInterfaceHashAt: URL?
 
   /// The destination to which the result of the compilation is written.
   @Option(
@@ -130,31 +192,70 @@ private typealias Module = FrontEnd.Module
   /// Creates a new instance with default options.
   public init() {}
 
+  /// Checks that the parsed arguments form a consistent configuration.
+  public func validate() throws {
+    if (moduleArchiveURL != nil) && !outputType.supportsModuleEmission {
+      throw ValidationError(
+        "'--emit-module-to' cannot be used with '--emit \(outputType.rawValue)'")
+    }
+    if (writeModuleInterfaceHashAt != nil) && !outputType.supportsModuleEmission {
+      throw ValidationError(
+        "'--emit-module-interface-hash-to' cannot be used with '--emit \(outputType.rawValue)'")
+    }
+    if !imports.isEmpty && outputType.linksDependencies {
+      throw ValidationError("""
+        '--import' is not yet supported with '--emit \(outputType.rawValue)'; \
+        use '--emit object' and link the objects yourself
+        """)
+    }
+    if imports.contains(effectiveModuleName) {
+      throw ValidationError("module '\(effectiveModuleName)' cannot import itself")
+    }
+    if noCaching && (moduleCachePath != nil) {
+      throw ValidationError("'--no-caching' and '--module-cache' are mutually exclusive")
+    }
+    if (outputURL?.relativePath == "-") && !outputType.canBeWrittenToStandardOutput {
+      throw ValidationError("\(outputType.rawValue) cannot be written to the standard output.")
+    }
+  }
+
   /// Executes the command.
   public mutating func run() async throws {
-    try configureSearchPaths()
+    if printStandardLibraryRoot {
+      print(Driver.standardLibraryRoot.path)
+      return
+    }
 
-    var driver = Driver(
-      moduleCachePath: noCaching ? nil : moduleCachePath!,
+    var driver = try Driver(
+      moduleCachePath: noCaching ? nil : (moduleCachePath ?? defaultCachePath()),
       targetSpecification: try resolveTarget(),
       optimization: optimized ? .aggressive : .none,
       relocation: relocationModel ?? Driver.defaultRelocationModel,
       codeModel: codeModel ?? .default,
-      librarySearchPaths: librarySearchPaths)
+      librarySearchPaths: Array(librarySearchPaths.uniqued()),
+      moduleSearchPaths: Array(moduleSearchPaths.uniqued()))
 
     do {
-      // Load the standard library.
+      // Load the imported modules.
       if !noStandardLibrary {
         note("load the Hylo standard library")
         try await driver.loadStandardLibrary()
       }
 
+      for i in imports {
+        note("load imported module \(i)")
+        try driver.loadArchivedModule(.init(i))
+      }
+
       // Create a module for the product being compiled.
-      let product = productName(inputs)
+      let product = effectiveModuleName
       note("start compiling \(product)")
       let module = driver.program.demandModule(product)
       if !noStandardLibrary {
         driver.program[module].addDependency(Module.standardLibraryName)
+      }
+      for i in imports {
+        driver.program[module].addDependency(.init(i))
       }
 
       // Compile from sources.
@@ -185,14 +286,14 @@ private typealias Module = FrontEnd.Module
       await perform("normalization", for: module) {
         await driver.applyTransformationPasses(module)
       }
+
+      try emitInterfaceHashIfNeeded(of: module, from: driver)
+      try emitArchiveIfNeeded(of: module, from: driver)
+
       if outputType == .ir {
         try emitIR(module, in: driver.program, name: product)
         return
       }
-
-      // Write the module to the cache for future runs.
-      let a = try driver.program.archive(module: module)
-      note("module archive size: \(a.count)")
 
       try await perform("code generation", for: module) {
         try driver.compileToLLVM(module)
@@ -204,10 +305,9 @@ private typealias Module = FrontEnd.Module
         try write(driver.assembly(of: module), to: asmFile(product))
         return
       } else if outputType == .object {
-        // FIXME: output the dependencies of `module`, including the standard library.
-        let directory = try objectFilesDirectory()
-        try driver.writeObjectFiles(for: [module], into: directory)
-        note("written \(directory.path)")
+        let f = objectFile(product)
+        try driver.emitObjectFile(of: module, to: f)
+        note("written \(f.path)")
         return
       }
 
@@ -342,21 +442,53 @@ private typealias Module = FrontEnd.Module
     }
   }
 
-  /// Sets up the value of search paths for locating libraries and cached artifacts.
-  private mutating func configureSearchPaths() throws {
-    let m = FileManager.default
-    if let cache = moduleCachePath {
-      librarySearchPaths.append(cache)
+  /// Ensures that the latest interface hash of the currently compiled module is written to disk
+  /// if requested.
+  ///
+  /// Only rewrites the file when the content actually changes, as some build tools only track
+  /// modification time.
+  private func emitInterfaceHashIfNeeded(of module: Module.ID, from driver: Driver) throws {
+    guard let u = writeModuleInterfaceHashAt else { return }
+    let h = try driver.moduleInterfaceHash(of: module)
+    let contents = String(format: "%016llx\n", h)
+    let existing = try? String(contentsOf: u, encoding: .utf8)
+    if existing != contents {
+      try contents.write(to: u, atomically: true, encoding: .utf8)
+      note("written \(u.path)")
     } else {
-      let cache = m.temporaryDirectory.appending(path: ".hylocache")
-      try m.createDirectory(at: cache, withIntermediateDirectories: true)
-      note("module cache path: \(cache.path)")
-      librarySearchPaths.append(cache)
-      moduleCachePath = cache
+      note("interface hash unchanged, leaving \(u.path) untouched")
     }
+  }
 
-    librarySearchPaths = .init(librarySearchPaths.uniqued())
-    librarySearchPaths.removeDuplicates()
+  /// Writes the archive of the module being compiled to the requested location, if any, so that
+  /// other modules can import it.
+  private func emitArchiveIfNeeded(of module: Module.ID, from driver: Driver) throws {
+    guard let u = moduleArchiveURL else { return }
+    try driver.writeArchive(of: module, to: u)
+    note("written \(u.path)")
+  }
+
+  /// Returns the directory to use as the module cache when `--module-cache` is not specified.
+  private func defaultCachePath() throws -> URL {
+    let m = FileManager.default
+    let base = m.urls(for: .cachesDirectory, in: .userDomainMask).first ?? m.temporaryDirectory
+    let d = base.appending(path: "hylo")
+    try m.createDirectory(at: d, withIntermediateDirectories: true)
+    return d
+  }
+
+  /// The name of the module being compiled.
+  ///
+  /// This is `--module-name` if given, the base name of the input if it is a single source file,
+  /// or 'Main' otherwise.
+  private var effectiveModuleName: Module.Name {
+    if let n = moduleName {
+      n
+    } else if inputs.count == 1, !inputs[0].hasDirectoryPath {
+      inputs[0].deletingPathExtension().lastPathComponent
+    } else {
+      "Main"
+    }
   }
 
   /// Returns an array with all the source files in `inputs` and their subdirectories.
@@ -397,7 +529,8 @@ private typealias Module = FrontEnd.Module
   /// Writes `message` to the standard output iff `self.verbose` is `true`.
   private func note(_ message: @autoclosure () -> String) {
     if verbose {
-      print(message())
+      var stderr = StandardError()
+      print(message(), to: &stderr)
     }
   }
 
@@ -406,18 +539,6 @@ private typealias Module = FrontEnd.Module
     for flags: [TreePrinterFlag]
   ) -> TreePrinter.Configuration {
     .init(useVerboseTypes: flags.contains(.verboseTypes))
-  }
-
-  /// If `inputs` contains a single URL `u` whose path is non-empty, returns the last component of
-  /// `u` without any path extension and stripping all leading dots. Otherwise, returns "Main".
-  private func productName(_ inputs: [URL]) -> Module.Name {
-    if let u = inputs.uniqueElement {
-      let n = u.deletingPathExtension().lastPathComponent.drop(while: { (c) in c == "." })
-      if !n.isEmpty {
-        return .init(n)
-      }
-    }
-    return "Main"
   }
 
   /// The type of the output files to generate.
@@ -447,6 +568,35 @@ private typealias Module = FrontEnd.Module
     /// Executable binary.
     case binary = "binary"
 
+    /// `true` iff the invocation may emit a module archive or interface hash, i.e. after mandatory
+    /// transformations.
+    var supportsModuleEmission: Bool {
+      switch self {
+      case .ast, .typedAST, .rawIR:
+        return false
+      case .ir, .llvm, .asm, .object, .binary:
+        return true
+      }
+    }
+
+    /// `true` iff the compiler should link dependencies of the product into the output.
+    var linksDependencies: Bool {
+      switch self {
+      case .binary:
+        return true
+      case .ast, .typedAST, .rawIR, .ir, .llvm, .asm, .object:
+        return false
+      }
+    }
+
+    /// `true` iff the artifact can be written to the standard output when `-o -` is passed.
+    var canBeWrittenToStandardOutput: Bool {
+      switch self {
+      case .ast, .typedAST, .rawIR, .ir, .llvm, .asm: true
+      case .object, .binary: false
+      }
+    }
+
   }
 
   /// Given the desired name of the compiler's product, returns the file to write when "raw-ast" is
@@ -473,12 +623,10 @@ private typealias Module = FrontEnd.Module
     outputURL ?? URL(fileURLWithPath: productName.description + ".s")
   }
 
-  /// Returns the directory to write when "object" is selected as the output type.
-  private func objectFilesDirectory() throws -> URL {
-    guard outputURL?.relativePath != "-" else {
-      throw ValidationError("object files cannot be written to the standard output")
-    }
-    return outputURL ?? URL(fileURLWithPath: "./")
+  /// Given the desired name of the compiler's product, returns the file to write when "object" is
+  /// selected as the output type.
+  private func objectFile(_ productName: Module.Name) -> URL {
+    outputURL ?? URL(fileURLWithPath: "\(productName).o")
   }
 
   /// Given the desired name of the compiler's product, returns the file to write when "binary" is

--- a/Tests/CommandLineTests/CommandLineEndToEndTests.swift
+++ b/Tests/CommandLineTests/CommandLineEndToEndTests.swift
@@ -111,7 +111,7 @@ final class CommandLineEndToEndTests: XCTestCase {
     }
   }
 
-  func testImportWithoutSearchPaths() async throws {
+  func testImportWithoutSearchPath() async throws {
     // Import without a search path should fail.
     try await FileManager.default.withUniqueTemporaryDirectory { (root) in
       let main = try write("public fun main() {}", to: root.appending(path: "main.hylo"))

--- a/Tests/CommandLineTests/CommandLineEndToEndTests.swift
+++ b/Tests/CommandLineTests/CommandLineEndToEndTests.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import FrontEnd
+import Subprocess
 import Utilities
 import XCTest
 
@@ -25,7 +26,8 @@ final class CommandLineEndToEndTests: XCTestCase {
     try await FileManager.default.withUniqueTemporaryDirectory { (root) in
       let main = try write("public fun main() {}", to: root.appending(path: "main.hylo"))
       let r = try await hc(
-        ["--emit", "ast", "--emit-module-to", "M.hylomodule", main.path], in: root, cache: nil)
+        ["--emit", "ast", "--emit-module-to", "M.hylomodule", main.path],
+        in: root, cache: .disabled)
 
       XCTAssertEqual(r.exitCode, ExitCode.validationFailure.rawValue)
       XCTAssert(
@@ -151,14 +153,15 @@ final class CommandLineEndToEndTests: XCTestCase {
       let entry = cache.appending(path: Module.standardLibraryName + ".hylomodule")
 
       // A cold run populates the cache with the standard library's archive.
-      let cold = try await hc(["--emit", "ast", "-o", "out.ast", main.path], in: root, cache: cache)
+      let cold =
+        try await hc(["--emit", "ast", "-o", "out.ast", main.path], in: root, cache: .at(cache))
       XCTAssertEqual(cold.exitCode, 0, cold.standardError)
       XCTAssert(fileExists(atPath: entry.path))
 
       // A corrupted entry is recompiled and overwritten rather than reported as an error.
       try write("corrupt", to: entry)
       let healed =
-        try await hc(["--emit", "ast", "-o", "out.ast", main.path], in: root, cache: cache)
+        try await hc(["--emit", "ast", "-o", "out.ast", main.path], in: root, cache: .at(cache))
       XCTAssertEqual(healed.exitCode, 0, healed.standardError)
       let contents = try Data(contentsOf: entry)
       XCTAssertNotEqual(contents, Data("corrupt".utf8))
@@ -187,7 +190,7 @@ final class CommandLineEndToEndTests: XCTestCase {
             "--emit-module-interface-hash-to", "M\(suffix).hash",
             main.path,
           ],
-          in: root, cache: nil)
+          in: root, cache: .disabled)
         XCTAssertEqual(r.exitCode, 0, r.standardError)
         return (
           try Data(contentsOf: root.appending(path: "M\(suffix).hylomodule")),
@@ -201,9 +204,29 @@ final class CommandLineEndToEndTests: XCTestCase {
     }
   }
 
+  func testDefaultCacheRootFromEnvironment() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let cacheRoot = root.appending(path: "workspace-cache")
+      let main = try write("public fun main() {}", to: root.appending(path: "main.hylo"))
+
+      // Without '--module-cache', the cache is a 'hylo' directory created in the root denoted by
+      // the environment.
+      let r = try await hc(
+        ["--emit", "ast", "-o", "out.ast", main.path], in: root, cache: .implicit,
+        environment: .inherit.updating(["HYLO_DEFAULT_CACHE_ROOT": cacheRoot.path]))
+      XCTAssertEqual(r.exitCode, 0, r.standardError)
+
+      // The default cache root is populated with the standard library's archive.
+      let archive = cacheRoot
+        .appending(path: "hylo")
+        .appending(path: Module.standardLibraryName + ".hylomodule")
+      XCTAssert(fileExists(atPath: archive.path), "no cache entry at \(archive.path)")
+    }
+  }
+
   func testPrintStdlibRoot() async throws {
     try await FileManager.default.withUniqueTemporaryDirectory { (root) in
-      let r = try await hc(["--print-stdlib-root"], in: root, cache: nil)
+      let r = try await hc(["--print-stdlib-root"], in: root, cache: .disabled)
 
       XCTAssertEqual(r.exitCode, 0, r.standardError)
       let path = r.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -238,25 +261,43 @@ final class CommandLineEndToEndTests: XCTestCase {
     super.tearDown()
   }
 
-  /// Runs `hc` with `arguments` in `workingDirectory` and returns its execution report.
+  /// The way a test invocation of `hc` selects its module cache.
+  private enum CacheOption {
+
+    /// Pass `--module-cache <url>`.
+    case at(URL)
+
+    /// Pass `--no-caching`.
+    case disabled
+
+    /// Pass no cache-related option, letting `hc` choose its default cache.
+    case implicit
+
+    /// The command-line arguments corresponding to `self`.
+    var arguments: [String] {
+      switch self {
+      case .at(let u): ["--module-cache", u.path]
+      case .disabled: ["--no-caching"]
+      case .implicit: []
+      }
+    }
+
+  }
+
+  /// Runs `hc` with `arguments` and `environment` in `workingDirectory` and returns its execution
+  /// report.
   ///
-  /// Unless `cache` is `nil`, `--module-cache` is appended to `arguments` so that tests never
-  /// touch the user's actual cache; it defaults to a cache shared by the whole suite. The values
-  /// in `environment` override the corresponding variables inherited from the current process.
+  /// Unless `cache` is `.implicit`, the corresponding option is appended to `arguments` so that
+  /// tests never touch the user's actual cache; it defaults to a cache shared by the whole suite.
   @discardableResult
   private func hc(
     _ arguments: [String], in workingDirectory: URL,
-    cache: URL? = CommandLineEndToEndTests.moduleCache.url
+    cache: CacheOption = .at(CommandLineEndToEndTests.moduleCache.url),
+    environment: Environment = .inherit
   ) async throws -> ExecutionReport {
-    var a = arguments
-    if let c = cache {
-      a.append("--module-cache")
-      a.append(c.path)
-    } else {
-      a.append("--no-caching")
-    }
-    return try await executeSubprocess(
-      .path(Self.hcExecutable), arguments: a, workingDirectory: workingDirectory)
+    try await executeSubprocess(
+      .path(Self.hcExecutable), arguments: arguments + cache.arguments,
+      workingDirectory: workingDirectory, environment: environment)
   }
 
   /// Writes `contents` to `url`, creating intermediate directories, and returns `url`.

--- a/Tests/CommandLineTests/CommandLineEndToEndTests.swift
+++ b/Tests/CommandLineTests/CommandLineEndToEndTests.swift
@@ -1,0 +1,292 @@
+import ArgumentParser
+import Foundation
+import FrontEnd
+import Utilities
+import XCTest
+
+/// End-to-end tests running `hc` as a subprocess.
+final class CommandLineEndToEndTests: XCTestCase {
+
+  func testSuccessfulCompilation() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let main = try write("public fun main() {}", to: root.appending(path: "main.hylo"))
+      let r = try await hc(["--emit", "object", "-o", "out.o", main.path], in: root)
+
+      XCTAssertEqual(r.exitCode, 0, r.standardError)
+      XCTAssert(FileManager.default.fileExists(atPath: root.appending(path: "out.o").path))
+
+      // The product's archive is not written to the module cache.
+      let cached = try Self.cachedArchives()
+      XCTAssert(cached.allSatisfy({ (m) in m == Module.standardLibraryName }), "\(cached)")
+    }
+  }
+
+  func testValidationFailureCode() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let main = try write("public fun main() {}", to: root.appending(path: "main.hylo"))
+      let r = try await hc(
+        ["--emit", "ast", "--emit-module-to", "M.hylomodule", main.path], in: root, cache: nil)
+
+      XCTAssertEqual(r.exitCode, ExitCode.validationFailure.rawValue)
+      XCTAssert(
+        r.standardError.contains("'--emit-module-to' cannot be used with '--emit ast'"),
+        r.standardError)
+      XCTAssert(r.standardError.contains("Usage:"), r.standardError)
+    }
+  }
+
+  func testCompilationFailure() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let main = try write(
+        "public fun main() { undefinedFunction() }", to: root.appending(path: "main.hylo"))
+      let r = try await hc(["--emit", "object", "-o", "out.o", main.path], in: root)
+
+      XCTAssertEqual(r.exitCode, ExitCode.failure.rawValue)
+      XCTAssert(r.standardError.contains("undefined symbol 'undefinedFunction'"), r.standardError)
+      XCTAssert(!FileManager.default.fileExists(atPath: root.appending(path: "out.o").path))
+    }
+  }
+
+  func testEffectiveModuleName() async throws {
+    // A single source file: the module is named after the file.
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let main = try write("public fun main() {}", to: root.appending(path: "a.hylo"))
+      let r = try await hc(["--emit", "object", main.path], in: root)
+
+      XCTAssertEqual(r.exitCode, 0, r.standardError)
+      XCTAssert(FileManager.default.fileExists(atPath: root.appending(path: "a.o").path))
+    }
+
+    // A directory: the module is named 'Main'.
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      try write("public fun main() {}", to: root.appending(path: "src/a.hylo"))
+      let r = try await hc(["--emit", "object", "src/"], in: root)
+
+      XCTAssertEqual(r.exitCode, 0, r.standardError)
+      XCTAssert(FileManager.default.fileExists(atPath: root.appending(path: "Main.o").path))
+    }
+
+    // Multiple source files: the module is named 'Main'.
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let a = try write("public fun main() {}", to: root.appending(path: "a.hylo"))
+      let b = try write("public fun f() {}", to: root.appending(path: "b.hylo"))
+      let r = try await hc(["--emit", "object", a.path, b.path], in: root)
+
+      XCTAssertEqual(r.exitCode, 0, r.standardError)
+      XCTAssert(FileManager.default.fileExists(atPath: root.appending(path: "Main.o").path))
+    }
+  }
+
+  func testModuleArchiveRoundTrip() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      try write(
+        "public fun double(_ x: Int) -> Int { x + x }",
+        to: root.appending(path: "util/util.hylo"))
+      try write(
+        """
+        import Util
+
+        public fun main() {
+          let _ = double(x: 21)
+        }
+        """,
+        to: root.appending(path: "app/main.hylo"))
+
+      let u = try await hc(
+        [
+          "--module-name", "Util", "--emit-module-to", "Util.hylomodule",
+          "--emit", "object", "-o", "Util.o", "util/",
+        ],
+        in: root)
+      XCTAssertEqual(u.exitCode, 0, u.standardError)
+      XCTAssert(fileExists(atPath: root.appending(path: "Util.hylomodule").path))
+
+      let a = try await hc(
+        [
+          "--import", "Util", "--module-search-path", ".", "--emit",
+          "object", "-o", "App.o", "app/"
+        ], in: root)
+      XCTAssertEqual(a.exitCode, 0, a.standardError)
+      XCTAssert(fileExists(atPath: root.appending(path: "App.o").path))
+    }
+  }
+
+  func testImportWithoutSearchPaths() async throws {
+    // Import without a search path should fail.
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let main = try write("public fun main() {}", to: root.appending(path: "main.hylo"))
+      let r =
+        try await hc(["--import", "Util", "--emit", "object", "-o", "out.o", main.path], in: root)
+
+      XCTAssertNotEqual(r.exitCode, 0)
+      XCTAssert(
+        r.standardError.contains("no archive found for module 'Util' in module search paths []"),
+        r.standardError)
+    }
+  }
+
+  func testCorruptImportedArchive() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let archive = root.appending(path: "A.hylomodule")
+      try write("invalid", to: archive)
+      let main = try write("public fun main() {}", to: root.appending(path: "main.hylo"))
+      let r = try await hc(
+        [
+          "--import", "A", "--module-search-path", ".", "--emit", "object",
+          "-o", "out.o", main.path
+        ], in: root)
+
+      XCTAssertNotEqual(r.exitCode, 0)
+      XCTAssert(
+        r.standardError.contains("Failed to parse the module archive of 'A' at '"),
+        r.standardError)
+    }
+  }
+
+  func testSelfHealingCache() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let cache = root.appending(path: "cache")
+      try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+      let main = try write("public fun main() {}", to: root.appending(path: "main.hylo"))
+      let entry = cache.appending(path: Module.standardLibraryName + ".hylomodule")
+
+      // A cold run populates the cache with the standard library's archive.
+      let cold = try await hc(["--emit", "ast", "-o", "out.ast", main.path], in: root, cache: cache)
+      XCTAssertEqual(cold.exitCode, 0, cold.standardError)
+      XCTAssert(fileExists(atPath: entry.path))
+
+      // A corrupted entry is recompiled and overwritten rather than reported as an error.
+      try write("corrupt", to: entry)
+      let healed =
+        try await hc(["--emit", "ast", "-o", "out.ast", main.path], in: root, cache: cache)
+      XCTAssertEqual(healed.exitCode, 0, healed.standardError)
+      let contents = try Data(contentsOf: entry)
+      XCTAssertNotEqual(contents, Data("corrupt".utf8))
+    }
+  }
+
+  func testDeterministicArtifacts() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let main = try write(
+        """
+        public fun double(_ x: Int) -> Int { x + x }
+
+        public fun main() {
+          let _ = double(x: 21)
+        }
+        """,
+        to: root.appending(path: "main.hylo"))
+
+      func emit(withSuffix suffix: String) async throws -> (archive: Data, hash: Data) {
+        // We must compile without module caches, otherwise the compilation conditions may change
+        // between the commands (compiling standard library from source vs deserializing).
+        let r = try await hc(
+          [
+            "--emit", "object", "-o", "out\(suffix).o",
+            "--emit-module-to", "M\(suffix).hylomodule",
+            "--emit-module-interface-hash-to", "M\(suffix).hash",
+            main.path,
+          ],
+          in: root, cache: nil)
+        XCTAssertEqual(r.exitCode, 0, r.standardError)
+        return (
+          try Data(contentsOf: root.appending(path: "M\(suffix).hylomodule")),
+          try Data(contentsOf: root.appending(path: "M\(suffix).hash")))
+      }
+
+      let first = try await emit(withSuffix: "1")
+      let second = try await emit(withSuffix: "2")
+      XCTAssertEqual(first.archive, second.archive)
+      XCTAssertEqual(first.hash, second.hash)
+    }
+  }
+
+  func testPrintStdlibRoot() async throws {
+    try await FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let r = try await hc(["--print-stdlib-root"], in: root, cache: nil)
+
+      XCTAssertEqual(r.exitCode, 0, r.standardError)
+      let path = r.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+      XCTAssert(directoryExists(atPath: path))
+    }
+  }
+
+  // MARK: - Harness
+
+  /// The module cache shared by the tests in this suite, so that the standard library is compiled
+  /// at most once.
+  private static let moduleCache: (url: URL, delete: @Sendable () -> Void) = {
+    let m = FileManager.default
+    let u = try! m.url(
+      for: .itemReplacementDirectory, in: .userDomainMask,
+      appropriateFor: m.temporaryDirectory, create: true)
+    return (u, { try? FileManager.default.removeItem(at: u) })
+  }()
+
+  /// The location of the `hc` executable built alongside the test runner.
+  private static let hcExecutable: URL = {
+    #if os(macOS)
+    let bundle = Bundle.allBundles.first(where: { (b) in b.bundlePath.hasSuffix(".xctest") })!
+    return bundle.bundleURL.deletingLastPathComponent().appending(path: "hc")
+    #else
+    return Bundle.main.bundleURL.appending(path: "hc")
+    #endif
+  }()
+
+  override class func tearDown() {
+    moduleCache.delete()
+    super.tearDown()
+  }
+
+  /// Runs `hc` with `arguments` in `workingDirectory` and returns its execution report.
+  ///
+  /// Unless `cache` is `nil`, `--module-cache` is appended to `arguments` so that tests never
+  /// touch the user's actual cache; it defaults to a cache shared by the whole suite. The values
+  /// in `environment` override the corresponding variables inherited from the current process.
+  @discardableResult
+  private func hc(
+    _ arguments: [String], in workingDirectory: URL,
+    cache: URL? = CommandLineEndToEndTests.moduleCache.url
+  ) async throws -> ExecutionReport {
+    var a = arguments
+    if let c = cache {
+      a.append("--module-cache")
+      a.append(c.path)
+    } else {
+      a.append("--no-caching")
+    }
+    return try await executeSubprocess(
+      .path(Self.hcExecutable), arguments: a, workingDirectory: workingDirectory)
+  }
+
+  /// Writes `contents` to `url`, creating intermediate directories, and returns `url`.
+  @discardableResult
+  private func write(_ contents: String, to url: URL) throws -> URL {
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try contents.write(to: url, atomically: true, encoding: .utf8)
+    return url
+  }
+
+  /// Returns the names of the module archives currently in the shared cache.
+  private static func cachedArchives() throws -> [String] {
+    try FileManager.default.contentsOfDirectory(atPath: moduleCache.url.path)
+      .filter({ (f) in f.hasSuffix(".hylomodule") })
+      .map({ (f) in String(f.dropLast(".hylomodule".count)) })
+  }
+
+}
+
+/// Returns `true` iff a non-directory file exists at `path`.
+private func fileExists(atPath path: String) -> Bool {
+  var isDirectory: ObjCBool = true
+  let e = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+  return e && !isDirectory.boolValue
+}
+
+/// Returns `true` iff a directory exists at `path`.
+private func directoryExists(atPath path: String) -> Bool {
+  var isDirectory: ObjCBool = false
+  let e = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+  return e && isDirectory.boolValue
+}

--- a/Tests/CommandLineTests/CommandLineValidationTests.swift
+++ b/Tests/CommandLineTests/CommandLineValidationTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import hc
+
+final class CommandLineValidationTests: XCTestCase {
+
+  func testModuleEmission() {
+    // '--emit-module-to' requires an output type that produces transformed IR.
+    for emit in ["ast", "typed-ast", "raw-ir"] {
+      assertRejects(
+        ["--emit", emit, "--emit-module-to", "M.hylomodule"],
+        withMessageContaining: "'--emit-module-to' cannot be used with '--emit \(emit)'")
+    }
+    for emit in ["ir", "llvm", "asm", "object", "binary"] {
+      assertAccepts(["--emit", emit, "--emit-module-to", "M.hylomodule"])
+    }
+  }
+
+  func testInterfaceHashEmission() {
+    // '--emit-module-interface-hash-to' requires an output type that produces transformed IR.
+    for emit in ["ast", "typed-ast", "raw-ir"] {
+      assertRejects(
+        ["--emit", emit, "--emit-module-interface-hash-to", "M.hash"],
+        withMessageContaining:
+          "'--emit-module-interface-hash-to' cannot be used with '--emit \(emit)'")
+    }
+    assertAccepts(["--emit", "object", "--emit-module-interface-hash-to", "M.hash"])
+  }
+
+  func testImportAndLinking() {
+    // '--import' is not yet supported when the compiler links the output.
+    assertRejects(
+      ["--emit", "binary", "--import", "Foo"],
+      withMessageContaining: "'--import' is not yet supported with '--emit binary'")
+
+    // `binary` is the default output type.
+    assertRejects(
+      ["--import", "Foo"],
+      withMessageContaining: "'--import' is not yet supported with '--emit binary'")
+
+    assertAccepts(["--emit", "object", "--import", "Foo"])
+  }
+
+  func testSelfImport() {
+    assertRejects(
+      ["--emit", "object", "--module-name", "A", "--import", "A"],
+      withMessageContaining: "module 'A' cannot import itself")
+
+    // The default module name is 'Main' unless a single source file is given.
+    assertRejects(
+      ["--emit", "object", "--import", "Main"],
+      withMessageContaining: "module 'Main' cannot import itself")
+    assertRejects(
+      ["--emit", "object", "--import", "Main", "src/"],
+      withMessageContaining: "module 'Main' cannot import itself")
+    assertRejects(
+      ["--emit", "object", "--import", "Main", "a.hylo", "b.hylo"],
+      withMessageContaining: "module 'Main' cannot import itself")
+
+    // The default module name is the base name of a single source file input.
+    assertRejects(
+      ["--emit", "object", "--import", "foo", "path/to/foo.hylo"],
+      withMessageContaining: "module 'foo' cannot import itself")
+    assertAccepts(["--emit", "object", "--import", "Main", "path/to/foo.hylo"])
+    assertAccepts(["--emit", "object", "--import", "foo", "src/"])
+
+    assertAccepts(["--emit", "object", "--module-name", "A", "--import", "B"])
+  }
+
+  func testObjectToStandardOutput() {
+    // Object files cannot be written to the standard output.
+    assertRejects(
+      ["--emit", "object", "-o", "-"],
+      withMessageContaining: "object cannot be written to the standard output")
+
+    assertAccepts(["--emit", "object", "-o", "out.o"])
+    assertAccepts(["--emit", "asm", "-o", "-"])
+  }
+
+  func testCachingOptions() {
+    // '--no-caching' and '--module-cache' are mutually exclusive.
+    assertRejects(
+      ["--no-caching", "--module-cache", "cache/"],
+      withMessageContaining: "'--no-caching' and '--module-cache' are mutually exclusive")
+
+    assertAccepts(["--no-caching"])
+    assertAccepts(["--module-cache", "cache/"])
+  }
+
+  /// Asserts that parsing `arguments` fails with a message containing `expected`.
+  private func assertRejects(
+    _ arguments: [String], withMessageContaining expected: String,
+    file: StaticString = #filePath, line: UInt = #line
+  ) {
+    XCTAssertThrowsError(
+      try hc.CommandLine.parse(arguments), file: file, line: line
+    ) { (e) in
+      let m = hc.CommandLine.message(for: e)
+      XCTAssert(m.contains(expected), "unexpected message: \(m)", file: file, line: line)
+    }
+  }
+
+  /// Asserts that parsing `arguments` succeeds.
+  private func assertAccepts(
+    _ arguments: [String], file: StaticString = #filePath, line: UInt = #line
+  ) {
+    XCTAssertNoThrow(try hc.CommandLine.parse(arguments), file: file, line: line)
+  }
+
+}

--- a/Tests/CompilerTests/DriverTests.swift
+++ b/Tests/CompilerTests/DriverTests.swift
@@ -31,44 +31,150 @@ final class DriverTests: XCTestCase {
 
   func testModuleCacheDisabled() throws {
     let d = try Driver(moduleCachePath: nil, targetSpecification: .native())
-    XCTAssertNil(d.archive(of: "test"))
+    XCTAssertNil(d.cachedArchive(of: "test"))
   }
 
   func testModuleCacheNotFound() throws {
     let d = try Driver(
-      moduleCachePath: FileManager.default.temporaryDirectory, 
+      moduleCachePath: FileManager.default.temporaryDirectory,
       targetSpecification: .native())
-    XCTAssertNil(d.archive(of: "test"))
+    XCTAssertNil(d.cachedArchive(of: "test"))
   }
 
-  func testInvalidArchive() async throws {
-    try await FileManager.default.withUniqueTemporaryDirectory { (cacheRoot) in 
+  func testCircularDependencyGraph() throws {
+    // Tests that a dependency graph with a cycle is detected and reported as an error.
+    try FileManager.default.withUniqueTemporaryDirectory { (root) in
+      try writeArchives(withDependencies: [("A", ["B"]), ("B", ["A"])], into: root)
+
+      var d = try Driver(targetSpecification: .host(), moduleSearchPaths: [root])
+      XCTAssertThrowsError(try d.loadArchivedModule("A")) { (e) in
+        XCTAssertEqual(
+          (e as? Driver.Error)?.message,
+          "circular dependency detected while loading module 'A'")
+      }
+    }
+  }
+
+  func testDiamondDependencyGraph() throws {
+    // Tests that a diamond dependency graph is serialized and loaded correctly.
+    try FileManager.default.withUniqueTemporaryDirectory { (root) in
+      try writeArchives(
+        withDependencies: [("A", ["B", "C"]), ("B", ["D"]), ("C", ["D"]), ("D", [])], into: root)
+
+      var driver = try Driver(targetSpecification: .host(), moduleSearchPaths: [root])
+      let a = try driver.loadArchivedModule("A")
+
+      XCTAssertEqual(driver.program.identity(module: "A"), a)
+      XCTAssertEqual(driver.program.modules.count, 4)
+      XCTAssertEqual(driver.program[a].dependencies, ["B", "C"])
+
+      let b = try XCTUnwrap(driver.program.identity(module: "B"))
+      XCTAssertEqual(driver.program[b].dependencies, ["D"])
+      let c = try XCTUnwrap(driver.program.identity(module: "C"))
+      XCTAssertEqual(driver.program[c].dependencies, ["D"])
+      let d = try XCTUnwrap(driver.program.identity(module: "D"))
+      XCTAssertEqual(driver.program[d].dependencies, [])
+
+      // Loading a module that is already in the program has no effect.
+      XCTAssertEqual(try driver.loadArchivedModule("A"), a)
+    }
+  }
+
+  // A program's dependency graph.
+  typealias DependencyGraph = [(module: FrontEnd.Module.Name, dependencies: [FrontEnd.Module.Name])]
+
+  /// Writes the archives of empty modules having the dependencies described by `graph` into
+  /// `directory`, using a scratch driver.
+  private func writeArchives(withDependencies graph: DependencyGraph, into directory: URL) throws {
+    var driver = try Driver(targetSpecification: .host())
+
+    // Create the modules of `graph`.
+    for (m, _) in graph { _ = driver.program.demandModule(m) }
+
+    // Set up the dependencies between modules according to `graph`.
+    for (m, dependencies) in graph {
+      let i = driver.program.identity(module: m)!
+      for d in dependencies { driver.program[i].addDependency(d) }
+    }
+
+    // Write the archives to disk.
+    for (m, _) in graph {
+      let i = driver.program.identity(module: m)!
+      try driver.writeArchive(of: i, to: directory.appending(path: m + ".hylomodule"))
+    }
+  }
+
+  func testInvalidCachedArchive() async throws {
+    // An invalid cached archive is recompiled from sources and overwritten.
+    try await FileManager.default.withUniqueTemporaryDirectory { (cacheRoot) in
       try await FileManager.default.withUniqueTemporaryDirectory { (sourceRoot) in
         var d = try Driver(
-          moduleCachePath: cacheRoot, 
+          moduleCachePath: cacheRoot,
           targetSpecification: .native())
-        
+
         let cachePath = cacheRoot.appendingPathComponent("Main.hylomodule")
         // Write an invalid archive
         try "invalid".write(to: cachePath, atomically: true, encoding: .utf8)
 
-        XCTAssertNotNil(d.archive(of: "Main"))
+        XCTAssertNotNil(d.cachedArchive(of: "Main"))
 
+        // The corrupt entry is treated as a miss: the module is compiled from sources and its
+        // archive is rewritten.
+        try await d.load("Main", withSourcesAt: sourceRoot)
+        XCTAssertNotNil(d.program.identity(module: "Main"))
 
-        // Now try to load it - this should fail
-        do {
-          try await d.load("Main", withSourcesAt: sourceRoot)
-          XCTFail("Expected load to fail")
-        } catch let error as Driver.Error {
-          XCTAssertEqual(error.message, """
-            Failed to parse module archive of 'Main' at '\(cacheRoot)'.
+        let healed = try XCTUnwrap(d.cachedArchive(of: "Main"))
+        XCTAssertNotEqual(healed, Data("invalid".utf8))
 
-            Maybe the archive was compiled with a different version of the compiler. \
-            Try erasing the module cache.
-            """)
+        // The rewritten archive is loadable by a fresh driver.
+        var e = try Driver(moduleCachePath: cacheRoot, targetSpecification: .native())
+        try await e.load("Main", withSourcesAt: sourceRoot)
+        XCTAssertNotNil(e.program.identity(module: "Main"))
+      }
+    }
+  }
 
-          XCTAssertEqual("\(error)", error.message)
-        }
+  func testNoImportsFromCache() throws {
+    // Tests that imports are not resolved from the module cache.
+    try FileManager.default.withUniqueTemporaryDirectory { (cacheRoot) in
+      try writeArchives(withDependencies: [("A", [])], into: cacheRoot)
+
+      // The archive is in the cache but in no module search path.
+      var d = try Driver(moduleCachePath: cacheRoot, targetSpecification: .host())
+      XCTAssertNotNil(d.cachedArchive(of: "A"))
+      XCTAssertThrowsError(try d.loadArchivedModule("A")) { (e) in
+        XCTAssertEqual(
+          (e as? Driver.Error)?.message,
+          "no archive found for module 'A' in module search paths []")
+      }
+    }
+  }
+
+  func testUnreadableArchive() throws {
+    try FileManager.default.withUniqueTemporaryDirectory { (root) in
+      // A directory named like an archive exists but cannot be read as a file.
+      try FileManager.default.createDirectory(
+        at: root.appending(path: "A.hylomodule"), withIntermediateDirectories: true)
+
+      var d = try Driver(targetSpecification: .host(), moduleSearchPaths: [root])
+      XCTAssertThrowsError(try d.loadArchivedModule("A")) { (e) in
+        let m = (e as? Driver.Error)?.message ?? ""
+        XCTAssert(m.contains("cannot read module archive at"), "unexpected message: \(m)")
+      }
+    }
+  }
+
+  func testInvalidArchiveContents() throws {
+    try FileManager.default.withUniqueTemporaryDirectory { (root) in
+      let f = root.appending(path: "A.hylomodule")
+      try "invalid".write(to: f, atomically: true, encoding: .utf8)
+
+      var d = try Driver(targetSpecification: .host(), moduleSearchPaths: [root])
+      XCTAssertThrowsError(try d.loadArchivedModule("A")) { (e) in
+        let m = (e as? Driver.Error)?.message ?? ""
+        XCTAssert(
+          m.contains("Failed to parse the module archive of 'A' at '\(f.path)'"),
+          "unexpected message: \(m)")
       }
     }
   }

--- a/Tests/CompilerTests/DriverTests.swift
+++ b/Tests/CompilerTests/DriverTests.swift
@@ -46,7 +46,7 @@ final class DriverTests: XCTestCase {
     try FileManager.default.withUniqueTemporaryDirectory { (root) in
       try writeArchives(withDependencies: [("A", ["B"]), ("B", ["A"])], into: root)
 
-      var d = try Driver(targetSpecification: .host(), moduleSearchPaths: [root])
+      var d = try Driver(targetSpecification: .host(), moduleSearchPath: [root])
       XCTAssertThrowsError(try d.loadArchivedModule("A")) { (e) in
         XCTAssertEqual(
           (e as? Driver.Error)?.message,
@@ -61,7 +61,7 @@ final class DriverTests: XCTestCase {
       try writeArchives(
         withDependencies: [("A", ["B", "C"]), ("B", ["D"]), ("C", ["D"]), ("D", [])], into: root)
 
-      var driver = try Driver(targetSpecification: .host(), moduleSearchPaths: [root])
+      var driver = try Driver(targetSpecification: .host(), moduleSearchPath: [root])
       let a = try driver.loadArchivedModule("A")
 
       XCTAssertEqual(driver.program.identity(module: "A"), a)
@@ -156,7 +156,7 @@ final class DriverTests: XCTestCase {
       try FileManager.default.createDirectory(
         at: root.appending(path: "A.hylomodule"), withIntermediateDirectories: true)
 
-      var d = try Driver(targetSpecification: .host(), moduleSearchPaths: [root])
+      var d = try Driver(targetSpecification: .host(), moduleSearchPath: [root])
       XCTAssertThrowsError(try d.loadArchivedModule("A")) { (e) in
         let m = (e as? Driver.Error)?.message ?? ""
         XCTAssert(m.contains("cannot read module archive at"), "unexpected message: \(m)")
@@ -169,7 +169,7 @@ final class DriverTests: XCTestCase {
       let f = root.appending(path: "A.hylomodule")
       try "invalid".write(to: f, atomically: true, encoding: .utf8)
 
-      var d = try Driver(targetSpecification: .host(), moduleSearchPaths: [root])
+      var d = try Driver(targetSpecification: .host(), moduleSearchPath: [root])
       XCTAssertThrowsError(try d.loadArchivedModule("A")) { (e) in
         let m = (e as? Driver.Error)?.message ?? ""
         XCTAssert(

--- a/Tests/UtilitiesTests/CollectionTests.swift
+++ b/Tests/UtilitiesTests/CollectionTests.swift
@@ -39,10 +39,14 @@ final class CollectionTests: XCTestCase {
     XCTAssertEqual(a[toLast: 2], 1)
   }
 
-  func testRemoveDuplicates() {
-    var a0 = [1, 2, 1, 1, 3, 3, 3, 4, 5, 4]
-    a0.removeDuplicates()
-    XCTAssertEqual(a0, [1, 2, 3, 4, 5])
+  func testUniqueIndex() {
+    let a = [1, 2, -1]
+    XCTAssertNil(a.uniqueIndex(where: { $0 > 0 }))
+    XCTAssertNil(a.uniqueIndex(where: { $0 != 2 }))
+
+    XCTAssertEqual(a.uniqueIndex(where: { $0 == 1 }), 0)
+    XCTAssertEqual(a.uniqueIndex(where: { $0 == 2 }), 1)
+    XCTAssertEqual(a.uniqueIndex(where: { $0 == -1 }), 2)
   }
 
 }


### PR DESCRIPTION
## Summary

This PR introduces the primitives that an external build system needs to compile a multi-module project with module-level incrementality:
- a way to compile one module at a time into a reusable module archive
- a way to import archives produced by earlier steps
- a stable "interface hash" that lets the build system decide whether dependents actually need to be recompiled.

I already made some proof of concept CMake scripts using this, and it works as expected (although CMake is not prepared for multiple sources producing single object files, so I had to use some hacks). 

## Example:

```bash
hc --module-name Foo 
    --emit object 
    -o Foo.o
    --emit-module-to build/Foo.hylomodule
    --emit-module-interface-hash-to build/Foo.hash 
    Sources/Foo

hc --module-name App
    --import Foo 
    --module-search-path build
    --emit object
    -o App.o
    Sources/App

clang -c "$(hc --print-stdlib-root)/shims.c" -o build/stdlib_shims.o

cd build
clang App.o Foo.o stdlib_shims.o  -o app
```

## New CLI flags:

- `--module-name <name>`: name of the module being compiled (default Main). Replaces the old behaviour of deriving the product name from a single input path, which was a bit arbitrary when multiple sources were given.
- `--import <module>`: make a module visible to the one being compiled. Each is loaded from `<module>.hylomodule` from the module search path.
- `--module-search-path <path>`: where to look for imported archives. This is now distinct from `-L`, which is only for native libraries.
- `--emit-module-to <file>`: write the compiled module's archive so others can import it.
- `--emit-module-interface-hash-to <file>`: write a hash a build system can use as a rebuild key for dependents. The file is only rewritten when the hash changes, so tools looking at modififcation time work efficiently.
- `--print-stdlib-root`: print the standard library root and exit.
- `--module-cache` now defaults to `<user caches dir>/hylo` instead of a .hylocache in the temp directory.
- `--emit object` now writes a single object file at -o (by default at `<module>.o`) instead of a directory of objects.

## Other CLI changes:
- `--verbose` notes now go to standard error to avoid mixing with any printed artifacts expected on stdout.
- CLI flags are validated before running the compilation.

## Driver changes

- A cache entry that fails to parse or whose fingerprint doesn't match is now silently recompiled and overwritten, instead of aborting the build with an error.

## CLI Tests
I added an end-to-end test suite that exercises the compiler through the CLI. This initially didn't contribute to code coverage, so I had to modify the CI script to merge the coverage results.

## Limitations
The module interface hash is currently computed by the hash of the entire archive, so currently any change causes a rebuild. In the future we could implement a more efficient solution, e.g. hash the set of IR functions' mangled names that are present in the module.