### PR TITLE
Fix the implementation of 'Program.isExposed(_:)' in the presence of extensions

### DIFF
--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -469,8 +469,8 @@ public struct Program: Sendable {
 
   /// Returns `true` if the contents of `d` is visible in all modules.
   ///
-  /// The result is `true` if `d` is annotated with `@exposed` and/or `d` and all the scopes
-  /// enclosing it are public.
+  /// The result is `true` if `d` is annotated with `@exposed` or `d` and all the scopes enclosing
+  /// it are public. Note that the scope of an extension is always public.
   public func isExposed<T: ModifiableDeclaration>(_ d: T.ID) -> Bool {
     // Is `d` explicitly exposed?
     if (annotation("exposed", appliedTo: d) != nil) { return true }
@@ -479,8 +479,13 @@ public struct Program: Sendable {
     if !self[d].is(.public) { return false }
     var p = parent(containing: d)
     while let a = p.node {
-      guard let b = self[a] as? (any ModifiableDeclaration), b.is(.public) else { return false }
-      p = parent(containing: a)
+      if tag(of: a) == ExtensionDeclaration.self {
+        p = parent(containing: a)
+      } else if let b = self[a] as? (any ModifiableDeclaration), b.is(.public) {
+        p = parent(containing: a)
+      } else {
+        return false
+      }
     }
     return p.isFile
   }

--- a/Tests/CompilerTests/positive/inlining-with-extensions.hylo
+++ b/Tests/CompilerTests/positive/inlining-with-extensions.hylo
@@ -1,0 +1,17 @@
+//! exit-status:1
+
+extension Int32 {
+
+  @inline(always)
+  public fun incremented() -> Int32 { self + (1 as Int32) }
+
+}
+
+@inline(always)
+public fun one() -> Int32 {
+  Int32().incremented()
+}
+
+public fun main() -> Int32 {
+  return one()
+}


### PR DESCRIPTION
An alternative to #407 to fix #404 (`Program.isExposed(_:)` involving extensions).