### PR TITLE
Simplify WitnessExpression constructors

### DIFF
--- a/Sources/FrontEnd/Syntax/WitnessExpression.swift
+++ b/Sources/FrontEnd/Syntax/WitnessExpression.swift
@@ -85,12 +85,6 @@ public struct WitnessExpression: Hashable, Sendable {
     self.type = type
   }
 
-  /// Creates a reference to a built-in entity.
-  public init(builtin entity: BuiltinEntity, type: AnyTypeIdentity) {
-    self.value = .builtin(entity)
-    self.type = type
-  }
-
   /// `true` iff this expression mentions open variable.
   public var hasVariable: Bool {
     if type[.hasVariable] { return true }

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -3718,7 +3718,7 @@ public struct Typer {
     let e = thread.environment.assuming(givens: gs)
     let t = demand(EqualityWitness(lhs: a, rhs: b)).erased
     let w = WitnessExpression(
-      value: .termApplication(.init(builtin: .coercion, type: t), thread.witness),
+      value: .termApplication(.init(value: .builtin(.coercion), type: t), thread.witness),
       type: b)
     return .next([thread.copy(matching: w, to: b, in: e)])
   }


### PR DESCRIPTION
Removed extra trivial constructor since it had only 1 usage and didn't do anything more than shortening that use site by a couple characters.