### PR TITLE
Interpreter remove unused properties

### DIFF
--- a/Sources/Interpreter/Memory.swift
+++ b/Sources/Interpreter/Memory.swift
@@ -152,7 +152,7 @@ struct Memory {
   }
 
   /// A memory location.
-  public struct Address: Regular {
+  public struct Address: Regular, CustomStringConvertible {
 
     /// The containing allocation.
     public let allocation: Allocation.ID
@@ -160,10 +160,12 @@ struct Memory {
     /// The offset from the beginning of that `allocation`.
     public let offset: Storage.Index
 
+    public var description: String { "@\(allocation):0x\(String(offset, radix: 16))" }
+
   }
 
   /// A typed location in memory.
-  public struct TypedAddress: Regular {
+  public struct TypedAddress: Regular, CustomStringConvertible {
 
     /// The containing allocation.
     public let allocation: Allocation.ID
@@ -173,6 +175,8 @@ struct Memory {
 
     /// The type to be accessed at `offset` in `allocation`.
     public let type: MonomorphicTypeIdentity
+
+    public var description: String { "@\(allocation):0x\(String(offset, radix: 16))[\(type)]" }
 
   }
 

--- a/Sources/Interpreter/Memory.swift
+++ b/Sources/Interpreter/Memory.swift
@@ -152,7 +152,7 @@ struct Memory {
   }
 
   /// A memory location.
-  public struct Address: Regular, CustomStringConvertible {
+  public struct Address: Regular {
 
     /// The containing allocation.
     public let allocation: Allocation.ID
@@ -160,11 +160,10 @@ struct Memory {
     /// The offset from the beginning of that `allocation`.
     public let offset: Storage.Index
 
-    public var description: String { "@\(allocation):0x\(String(offset, radix: 16))" }
   }
 
   /// A typed location in memory.
-  public struct TypedAddress: Regular, CustomStringConvertible {
+  public struct TypedAddress: Regular {
 
     /// The containing allocation.
     public let allocation: Allocation.ID
@@ -175,12 +174,6 @@ struct Memory {
     /// The type to be accessed at `offset` in `allocation`.
     public let type: MonomorphicTypeIdentity
 
-    /// Address having same `allocation` and `offset` as of `self`.
-    public var address: Address {
-      .init(allocation: allocation, offset: offset)
-    }
-
-    public var description: String { "@\(allocation):0x\(String(offset, radix: 16))[\(type)]" }
   }
 
   /// Allocates `n` contiguous instances of `t` and returns the`Address` of the first instance.

--- a/Sources/Interpreter/TypeLayout.swift
+++ b/Sources/Interpreter/TypeLayout.swift
@@ -12,10 +12,6 @@ struct TypeLayout: Regular {
     /// The number of bytes occupied by an instance.
     let size: Int
 
-    /// The number of bytes between the beginnings of consecutive array elements.
-    var stride: Int {
-      size.rounded(upToNearestMultipleOf: alignment)
-    }
   }
 
   /// A (potential, in the case of enum types) named or unnambed member of a type.
@@ -49,9 +45,6 @@ struct TypeLayout: Regular {
   /// The number of bytes occupied by an instance.
   public var size: Int { whole.size }
 
-  /// The number of bytes between the beginnings of consecutive array elements.
-  public var stride: Int { whole.stride }
-
   /// The type whose layout is described by `self`.
   public let type: MonomorphicTypeIdentity
 
@@ -63,39 +56,9 @@ struct TypeLayout: Regular {
   /// Empty otherwise (built-in types).
   public let parts: [Part]
 
-  /// The parentage of the parts.
-  ///
-  /// For product types, the parentage of each stored property in storage order.
-  /// For enum types, the parentage of each case when it is active, followed
-  /// by the parentage of the discriminator.
-  /// Empty otherwise (built-in types).
-  public var partParentages: some Collection<Part.Parentage> {
-    parts.indices.lazy.map { .init(self, $0) }
-  }
-
   /// True iff `self` is the layout of an enum type, which changes how
   /// its `parts` are interpreted.
   public let isEnumLayout: Bool
-}
-
-extension TypeLayout {
-
-  /// The discriminator of an enum layout.
-  public var discriminator: Part {
-    precondition(isEnumLayout)
-    return parts.last!
-  }
-
-  /// The id of the discriminator of an enum layout.,
-  public var discriminatorParentage: Part.Parentage {
-    precondition(isEnumLayout)
-    return .init(self, parts.count - 1)
-  }
-
-  /// The number of parts that will be stored at one time for a given instance.
-  public var storedPartCount: Int {
-    isEnumLayout ? 2 : parts.count
-  }
 }
 
 extension BinaryInteger {
@@ -119,28 +82,6 @@ extension TypeLayout.Bytes {
   func appending(_ t: Self) -> Self {
     let r = self.size.roundedUp(toNearestMultipleOf: t.alignment)
     return .init(alignment: Int(lcm(self.alignment, t.alignment)), size: r + t.size)
-  }
-
-}
-
-extension TypeLayout.Part {
-
-  struct Parentage: Regular, CustomStringConvertible {
-
-    /// The type in which the part exists.
-    public let parent: TypeLayout
-
-    /// The part index in the parent.
-    public let partIndex: Int
-
-    init(_ layout: TypeLayout, _ part: Int) {
-      self.parent = layout
-      self.partIndex = part
-    }
-
-    public var description: String {
-      "{part \(partIndex) of \(parent.type)}"
-    }
   }
 
 }

--- a/Tests/InterpreterTests/MemoryTests.swift
+++ b/Tests/InterpreterTests/MemoryTests.swift
@@ -29,6 +29,20 @@ final class InterpreterMemoryTests: XCTestCase {
     }
   }
 
+  func testMemoryAddressArithmetic() throws {
+    let a = m.allocate(.init(id(MachineType.i(8))), count: 128)
+
+    XCTAssertEqual(a + 1, .init(allocation: a.allocation, offset: a.offset + 1))
+    XCTAssertEqual(1 + a, .init(allocation: a.allocation, offset: a.offset + 1))
+    XCTAssertEqual(a + 1 - 1, a)
+
+    var b = a
+    b += 1
+    XCTAssertEqual(b, .init(allocation: a.allocation, offset: a.offset + 1))
+    b -= 1
+    XCTAssertEqual(b, a)
+  }
+
   /// Returns the type erased identity of `t`.
   private func id<T: TypeTree>(_ t: T) -> AnyTypeIdentity {
     m.program.id(t)


### PR DESCRIPTION
Interpreter code brings lines (for completeness purpose) which are not currently being used as they will be useful in later phase. But that is leading to breaking coverage of main. Thus the PR removes those lines and will add them when will really be used and thus tested.