### PR TITLE
Diagnose illegal mutations of 'sink let' bindings

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1373,7 +1373,7 @@ internal struct IREmitter {
 
       // Is `d` a stored property of a type whose layout is visible?
       if let i = storedPropertyIndex(of: d, in: program.parent(containing: e)) {
-        return lowering(e, { $0._subfield(q, at: [i]) })
+        return lowering(e, { $0._subfield(q, at: [i], declaredBy: d) })
       } else {
         return lowering(e, { $0._property(d, of: q, withType: t) })
       }
@@ -2215,17 +2215,19 @@ internal struct IREmitter {
   }
 
   /// Inserts a `subfield` instruction.
-  internal mutating func _subfield(_ base: IRValue, at path: IndexPath) -> IRValue {
+  internal mutating func _subfield(
+    _ base: IRValue, at path: IndexPath, declaredBy declaration: DeclarationIdentity? = nil
+  ) -> IRValue {
     // The instruction is equivalent to the identity if the path is empty.
     if path.isEmpty { return base }
 
     let (root, _) = currentFunction.result(of: base) ?? badOperand()
-    let typeOfSubfield = program.withTyper(typing: module) { (tp) in
+    let subfieldType = program.withTyper(typing: module) { (tp) in
       tp.field(of: root, at: path)
     }
 
     let s = IRSubfield(
-      base: base, path: path, typeOfSubfield: typeOfSubfield!,
+      base: base, path: path, subfieldType: subfieldType!, declaration: declaration,
       anchor: currentAnchor)
     return insert(s)!
   }

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -271,6 +271,8 @@ public struct IRFunction: Sendable {
     var s = at(i).source
     while let r = s.register {
       switch tag(of: r) {
+      case IRCase.self:
+        s = (at(r) as! IRCase).source
       case IRPlaceCast.self:
         s = (at(r) as! IRPlaceCast).source
       case IRSubfield.self:

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -267,21 +267,26 @@ public struct IRFunction: Sendable {
   }
 
   /// Returns the value defining the root of the place on which `i` forms an access.
-  public func source(_ i: IRAccess.ID) -> IRValue {
-    var s = at(i).source
-    while let r = s.register {
-      switch tag(of: r) {
-      case IRCase.self:
-        s = (at(r) as! IRCase).source
-      case IRPlaceCast.self:
-        s = (at(r) as! IRPlaceCast).source
-      case IRSubfield.self:
-        s = (at(r) as! IRSubfield).base
-      default:
-        return s
-      }
+  public func root(_ i: IRAccess.ID) -> IRValue {
+    var result = at(i).source
+    while let r = result.register.flatMap(source(_:)) {
+      result = r
     }
-    return s
+    return result
+  }
+
+  /// Returns the source of the place denoted by `i`, if any.
+  public func source(_ i: AnyInstructionIdentity) -> IRValue? {
+    switch tag(of: i) {
+    case IRCase.self:
+      return (at(i) as! IRCase).source
+    case IRPlaceCast.self:
+      return (at(i) as! IRPlaceCast).source
+    case IRSubfield.self:
+      return (at(i) as! IRSubfield).base
+    default:
+      return nil
+    }
   }
 
   /// Returns the last use of `v` in `b`, if any.

--- a/Sources/FrontEnd/IR/Instructions/IRSubfield.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRSubfield.swift
@@ -15,14 +15,22 @@ public struct IRSubfield: Instruction {
   public let path: IndexPath
 
   /// The type of the subfield being accessed.
-  public let typeOfSubfield: AnyTypeIdentity
+  public let subfieldType: AnyTypeIdentity
+
+  /// The declaration of the entity that the subfield represents, if any.
+  public let declaration: DeclarationIdentity?
 
   /// Creates an instance with the given properties.
-  public init(base: IRValue, path: IndexPath, typeOfSubfield: AnyTypeIdentity, anchor: Anchor) {
+  public init(
+    base: IRValue, path: IndexPath, subfieldType: AnyTypeIdentity,
+    declaration: DeclarationIdentity?,
+    anchor: Anchor
+  ) {
     self.operands = [base]
     self.anchor = anchor
     self.path = path
-    self.typeOfSubfield = typeOfSubfield
+    self.subfieldType = subfieldType
+    self.declaration = declaration
   }
 
   /// Creates a copy of `other`, substituting its properties with `properties`.
@@ -30,7 +38,8 @@ public struct IRSubfield: Instruction {
     self.operands = [properties[other.base]]
     self.anchor = properties.anchor(other)
     self.path = other.path
-    self.typeOfSubfield = other.typeOfSubfield
+    self.subfieldType = other.subfieldType
+    self.declaration = other.declaration
   }
 
   /// The address of the record containing the subfield whose address is computed.
@@ -40,7 +49,7 @@ public struct IRSubfield: Instruction {
 
   /// The type of the instruction's result.
   public var type: IRType {
-    .place(typeOfSubfield)
+    .place(subfieldType)
   }
 
   /// `true`.
@@ -53,7 +62,7 @@ extension IRSubfield: Showable {
 
   /// Returns a textual representation of `self` using `printer`.
   public func show(using printer: inout TreePrinter) -> String {
-    "subfield \(printer.show(base)) at \(list: path) as \(printer.show(typeOfSubfield))"
+    "subfield \(printer.show(base)) at \(list: path) as \(printer.show(subfieldType))"
   }
 
 }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -28,7 +28,7 @@ extension IRFunction {
 
   /// Returns the access instruction from which `i` reborrows, if any.
   fileprivate func reborrowedSource(_ i: IRAccess.ID) -> IRAccess.ID? {
-    source(i).register.flatMap({ (r) in cast(r, to: IRAccess.self) })
+    root(i).register.flatMap({ (r) in cast(r, to: IRAccess.self) })
   }
 
   /// Returns `true` iff it is legal to form an immutable access on a place bound by `bs` with an

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+Folding.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+Folding.swift
@@ -15,10 +15,14 @@ extension IRFunction {
   /// Combines `i` with its user if there is only one.
   private mutating func fold(_ i: IRSubfield.ID) {
     let s = at(i)
-    if let u = uses[.register(i.erased)]?.uniqueElement, let t = at(u.user) as? IRSubfield {
+    if
+      let u = uses[.register(i.erased)]?.uniqueElement,
+      let t = at(u.user) as? IRSubfield,
+      s.declaration == t.declaration
+    {
       let folded = IRSubfield(
         base: s.base, path: s.path.appending(contentsOf: t.path),
-        typeOfSubfield: t.typeOfSubfield, anchor: t.anchor)
+        subfieldType: t.subfieldType, declaration: t.declaration, anchor: t.anchor)
       replace(u.user, with: folded)
       remove(i.erased)
     }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -694,28 +694,27 @@ private struct Transfer: AbstractTransferFunction {
     }
   }
 
-  /// Returns the pattern binding declaration introducing the entity referred to by `v`, which is
-  /// the source of an access in `f`, or `nil` if such a declaration cannot be identified.
-  private func binding(declaring v: IRValue, in f: IRFunction) -> BindingDeclaration.ID? {
-    let b: VariableDeclaration.ID? = if let d = f.declaration(v) {
-      program.cast(d, to: VariableDeclaration.self)
+  /// Returns the declaration binding `v`, which computes the source of an access in `f`, or `nil`
+  /// if such a declaration cannot be identified.
+  private func binding(declaring v: IRValue, in f: IRFunction) -> VariableDeclaration.ID? {
+    if let d = f.declaration(v) {
+      return program.cast(d, to: VariableDeclaration.self)
     } else if let r = v.register, let s = f.at(r) as? IRSubfield, let d = s.declaration {
-      program.cast(d, to: VariableDeclaration.self)
+      return program.cast(d, to: VariableDeclaration.self)
     } else {
-      nil
+      return nil
     }
-    return b.flatMap(program.bindingDeclaration(containing:))
   }
 
-  /// Returns the introducer of the binding associated with `v`, which is the source of an access
-  /// in `f`, along with a value defining the place referred to by `v`.
+  /// Returns the introducer of the binding associated with `v`, which computes the source of an
+  /// access in `f`, along with a value defining the place referred to by `v`.
   private func introducer(
     binding v: IRValue, in f: IRFunction
   ) -> (BindingPattern.Introducer?, IRValue) {
     var s = v
     while true {
       // Is `s` attached to a binding declaration?
-      if let b = binding(declaring: s, in: f) {
+      if let b = binding(declaring: s, in: f).flatMap(program.bindingDeclaration(containing:)) {
         let k = program[program[b].pattern].introducer.value
         if (k == .let) && (!program.isLocal(b) || program.isMember(b)) {
           return (.sinklet, s)

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -13,6 +13,9 @@ extension IRFunction {
   /// deallocated or flows into a `set` access. This situation may occur when deinitialization was
   /// left implicit during IR lowering. These new instructions are emitted into `m`, using `typer`
   /// to resolve implementations.
+  ///
+  /// Lifetime normalization is part of the mandatory transformation pipeline and is expected to
+  /// run after access reification and last use analysis.
   internal mutating func normalizeLifetimes(
     emittingInto m: Module.ID, using typer: inout Typer
   ) -> Bool {

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -235,7 +235,7 @@ private struct Transfer: AbstractTransferFunction {
 
     // Check if the access is violating immutability. If it is, then report an illegal access and
     // skip further changes to the context to avoid cascading diagnostics.
-    let isLegal = isUpholdingImmutability(i, in: f)
+    let isLegal = upholdsBindingImmutability(i, in: f)
     if !isLegal {
       report(program.illegalAccess(k, at: access.anchor))
     }
@@ -739,7 +739,7 @@ private struct Transfer: AbstractTransferFunction {
   /// Control flow is taken into account when the place is referred to by a `sink let` binding. In
   /// this case, a `set` access is legal only if the source is fully uninitialized, and a `sink`
   /// access is legal only if the source is fully initialized.
-  private mutating func isUpholdingImmutability(_ i: IRAccess.ID, in f: IRFunction) -> Bool {
+  private mutating func upholdsBindingImmutability(_ i: IRAccess.ID, in f: IRFunction) -> Bool {
     let s = f.at(i)
     let k = s.capabilities.uniqueElement!
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -733,6 +733,12 @@ private struct Transfer: AbstractTransferFunction {
   }
 
   /// Returns `true` iff `i`, which is in `f`, is not a mutable access on an immutable binding.
+  ///
+  /// At a high level, this method checks whether an access is "syntactically" legal, verifying
+  /// that a mutating capability cannot be formed on a place represented by an immutable binding.
+  /// Control flow is taken into account when the place is referred to by a `sink let` binding. In
+  /// this case, a `set` access is legal only if the source is fully uninitialized, and a `sink`
+  /// access is legal only if the source is fully initialized.
   private mutating func isUpholdingImmutability(_ i: IRAccess.ID, in f: IRFunction) -> Bool {
     let s = f.at(i)
     let k = s.capabilities.uniqueElement!

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -725,18 +725,7 @@ private struct Transfer: AbstractTransferFunction {
       }
 
       // Should we look further?
-      else if let r = s.register {
-        switch f.tag(of: r) {
-        case IRCase.self:
-          s = (f.at(r) as! IRCase).source
-        case IRPlaceCast.self:
-          s = (f.at(r) as! IRPlaceCast).source
-        case IRSubfield.self:
-          s = (f.at(r) as! IRSubfield).base
-        default:
-          return (nil, s)
-        }
-      }
+      else if let r = s.register.flatMap(f.source(_:)) { s = r }
 
       // No binding declaration.
       else { return (nil, s) }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -235,7 +235,7 @@ private struct Transfer: AbstractTransferFunction {
 
     // Check if the access is violating immutability. If it is, then report an illegal access and
     // skip further changes to the context to avoid cascading diagnostics.
-    let isLegal = (k == .let) || !f.isBoundImmutably(access.source)
+    let isLegal = isUpholdingImmutability(i, in: f)
     if !isLegal {
       report(program.illegalAccess(k, at: access.anchor))
     }
@@ -691,6 +691,88 @@ private struct Transfer: AbstractTransferFunction {
       return us
     case .mixed(let ps):
       return .init(combining: ps.map(consumers(_:)))
+    }
+  }
+
+  /// Returns the pattern binding declaration introducing the entity referred to by `v`, which is
+  /// the source of an access in `f`, or `nil` if such a declaration cannot be identified.
+  private func binding(declaring v: IRValue, in f: IRFunction) -> BindingDeclaration.ID? {
+    let b: VariableDeclaration.ID? = if let d = f.declaration(v) {
+      program.cast(d, to: VariableDeclaration.self)
+    } else if let r = v.register, let s = f.at(r) as? IRSubfield, let d = s.declaration {
+      program.cast(d, to: VariableDeclaration.self)
+    } else {
+      nil
+    }
+    return b.flatMap(program.bindingDeclaration(containing:))
+  }
+
+  /// Returns the introducer of the binding associated with `v`, which is the source of an access
+  /// in `f`, along with a value defining the place referred to by `v`.
+  private func introducer(
+    binding v: IRValue, in f: IRFunction
+  ) -> (BindingPattern.Introducer?, IRValue) {
+    var s = v
+    while true {
+      // Is `s` attached to a binding declaration?
+      if let b = binding(declaring: s, in: f) {
+        let k = program[program[b].pattern].introducer.value
+        if (k == .let) && (!program.isLocal(b) || program.isMember(b)) {
+          return (.sinklet, s)
+        } else {
+          return (k, s)
+        }
+      }
+
+      // Should we look further?
+      else if let r = s.register {
+        switch f.tag(of: r) {
+        case IRCase.self:
+          s = (f.at(r) as! IRCase).source
+        case IRPlaceCast.self:
+          s = (f.at(r) as! IRPlaceCast).source
+        case IRSubfield.self:
+          s = (f.at(r) as! IRSubfield).base
+        default:
+          return (nil, s)
+        }
+      }
+
+      // No binding declaration.
+      else { return (nil, s) }
+    }
+  }
+
+  /// Returns `true` iff `i`, which is in `f`, is not a mutable access on an immutable binding.
+  private mutating func isUpholdingImmutability(_ i: IRAccess.ID, in f: IRFunction) -> Bool {
+    let s = f.at(i)
+    let k = s.capabilities.uniqueElement!
+
+    // A `let` access never violates immutability.
+    if k == .let { return true }
+
+    // Look for the binding declaration associated with the source of the access, if any.
+    switch introducer(binding: s.source, in: f) {
+    case (.some(.let), _):
+      return false
+
+    case (.some(.sinklet), let source):
+      // An `inout` access to a `sink let` binding is always invalid.
+      if (k == .inout) || f.isBoundImmutably(source) { return false }
+
+      // Otherwise validity depends on the sequencing of the access relative to other uses.
+      let a = context.locals[s.source]!.place!
+      let o = context.withObject(at: a, computingLayoutWith: &typer, { (o, _) in o })
+      if k == .sink {
+        return o.value == .uniform(.initialized)
+      }
+      if k == .set {
+        return o.value == .uniform(.uninitialized)
+      }
+      unreachable()
+
+    case (_, let source):
+      return !f.isBoundImmutably(source)
     }
   }
 

--- a/Sources/FrontEnd/Parser/Parser.swift
+++ b/Sources/FrontEnd/Parser/Parser.swift
@@ -1832,8 +1832,15 @@ public struct Parser {
   ) throws -> RemoteTypeExpression.ID {
     let k = parseAccessEffect()
     let e = try parseExpression(in: &file)
-    return file.insert(
-      RemoteTypeExpression(access: k, projectee: e, site: k.site.extended(upTo: position.index)))
+    let s = k.site.extended(upTo: position.index)
+
+    if let n = file[e] as? RemoteTypeExpression {
+      report(.init("type expression may have at most one access effect", at: n.access.site))
+      let r = RemoteTypeExpression(access: k, projectee: n.projectee, site: s)
+      return file.replace(e, with: r)
+    } else {
+      return file.insert(RemoteTypeExpression(access: k, projectee: e, site: s))
+    }
   }
 
   /// Parses an access effect.

--- a/Tests/CompilerTests/negative/illegal-remote-type.diagnostics.expected
+++ b/Tests/CompilerTests/negative/illegal-remote-type.diagnostics.expected
@@ -1,0 +1,3 @@
+negative/illegal-remote-type.hylo:1.22-25: error: type expression may have at most one access effect
+fun identity(x: sink let Int) -> Int { x }
+                     ~~~

--- a/Tests/CompilerTests/negative/illegal-remote-type.hylo
+++ b/Tests/CompilerTests/negative/illegal-remote-type.hylo
@@ -1,0 +1,1 @@
+fun identity(x: sink let Int) -> Int { x }

--- a/Tests/CompilerTests/negative/illegal-sink-global.diagnostics.expected
+++ b/Tests/CompilerTests/negative/illegal-sink-global.diagnostics.expected
@@ -1,6 +1,6 @@
-negative/illegal-sink-global.hylo:8.11-14: error: illegal 'sink' access
+negative/illegal-sink-global.hylo:6.11-14: error: illegal 'sink' access
   var x = foo
           ~~~
-negative/illegal-sink-global.hylo:9.11-16: error: illegal 'sink' access
+negative/illegal-sink-global.hylo:7.11-16: error: illegal 'sink' access
   var y = S.foo
           ~~~~~

--- a/Tests/CompilerTests/negative/illegal-sink-global.hylo
+++ b/Tests/CompilerTests/negative/illegal-sink-global.hylo
@@ -1,5 +1,3 @@
-//! stage:lowering
-
 let foo = ()
 
 struct S { public static let foo = () }

--- a/Tests/CompilerTests/negative/illegal-sink-let.diagnostics.expected
+++ b/Tests/CompilerTests/negative/illegal-sink-let.diagnostics.expected
@@ -1,0 +1,15 @@
+negative/illegal-sink-let.hylo:11.17-18: error: illegal 'set' access
+      &self.x = 1     // error
+                ^
+negative/illegal-sink-let.hylo:21.15-16: error: illegal 'set' access
+    &self.x = 0       // error
+              ^
+negative/illegal-sink-let.hylo:33.14-15: error: illegal 'set' access
+      &w.1 = 1        // error
+             ^
+negative/illegal-sink-let.hylo:34.14-15: error: illegal 'set' access
+      &w.0 = 2        // error
+             ^
+negative/illegal-sink-let.hylo:36.9-10: error: illegal 'sink' access
+    _ = z             // error
+        ^

--- a/Tests/CompilerTests/negative/illegal-sink-let.hylo
+++ b/Tests/CompilerTests/negative/illegal-sink-let.hylo
@@ -22,7 +22,7 @@ struct S {
     &self.y = 1       // OK (assignment)
   }
 
-  fun f0() sink -> Int {
+  fun f1() sink -> Int {
     self.x            // OK (move out)
   }
 

--- a/Tests/CompilerTests/negative/illegal-sink-let.hylo
+++ b/Tests/CompilerTests/negative/illegal-sink-let.hylo
@@ -1,0 +1,44 @@
+struct S {
+
+  let x: Int
+  var y: Int
+
+  static let z = 0    // OK (initialization)
+
+  init() {
+    if true {
+      &self.x = 0     // OK (assignment)
+      &self.x = 1     // error
+    } else {
+      &self.x = 2     // OK (assignment)
+    }
+
+    &self.y = 0       // OK (initialization)
+    &self.y = 1       // OK (assignment)
+  }
+
+  fun f0() inout {
+    &self.x = 0       // error
+    &self.y = 1       // OK (assignment)
+  }
+
+  fun f0() sink -> Int {
+    self.x            // OK (move out)
+  }
+
+  static fun g0() {
+    sink let w: Int[2]
+    &w.0 = 0          // OK (initialization)
+    while true {
+      &w.1 = 1        // error
+      &w.0 = 2        // error
+    }
+    _ = z             // error
+  }
+
+  static fun g1() -> Int {
+    sink let w = (0, 1)
+    return w.0        // OK (move out)
+  }
+
+}


### PR DESCRIPTION
This patch fixes #344