### PR TITLE
Prioritize lexical scoping when ranking overloads

### DIFF
--- a/Sources/FrontEnd/Parser/Token.swift
+++ b/Sources/FrontEnd/Parser/Token.swift
@@ -122,7 +122,7 @@ public struct Token: Hashable, Sendable {
   /// `true` iff `self` may be at the beginning of a declaration.
   public var isDeclarationHead: Bool {
     switch tag {
-    case .at, .case, .fun, .given, .import, .struct, .subscript, .trait, .type:
+    case .at, .case, .extension, .fun, .given, .import, .struct, .subscript, .trait, .type:
       return true
     default:
       return isBindingIntroducer || isDeclarationModifier

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -841,6 +841,32 @@ public struct Program: Sendable {
     }
   }
 
+  /// Returns (`lhs`, `rhs`, `common`) where `common` is the deepest common scope containing both
+  /// `m` and `n`, and `lhs` (respectively `rhs`) are scopes containing `m` (respectively `n`) and
+  /// its ancestors up to `common`.
+  ///
+  /// - Requires: The module containing `n` is scoped.
+  public func commonAncestry<T: SyntaxIdentity, U: SyntaxIdentity>(
+    _ m: T, _ n: U
+  ) -> ([ScopeIdentity], [ScopeIdentity], ScopeIdentity?) {
+    var lhs = Array(scopes(from: parent(containing: m)))
+    var rhs = Array(scopes(from: parent(containing: n)))
+
+    var l = lhs[...]
+    var r = rhs[...]
+    while l.count > r.count { l.removeFirst() }
+    while r.count > l.count { r.removeFirst() }
+    while !l.isEmpty && (l.first != r.first) {
+      l.removeFirst()
+      r.removeFirst()
+    }
+
+    let lca = lhs[l.startIndex...].first
+    lhs.removeLast(l.count)
+    rhs.removeLast(r.count)
+    return (lhs, rhs, lca)
+  }
+
   /// Returns the type assigned to `n`.
   ///
   /// You cannot make strong assumptions about the exact shape of the returned type in general, as
@@ -1038,50 +1064,84 @@ public struct Program: Sendable {
     }
   }
 
+  /// Returns `true` iff `m` and `n` are in the same file.
+  public func inSameFile<T: SyntaxIdentity, U: SyntaxIdentity>(_ m: T, _ n: U) -> Bool {
+    (m.module == n.module) && (m.file == n.file)
+  }
+
+  /// Returns `true` iff `m` and `n` are in the same file.
+  public func inSameFile<T: SyntaxIdentity>(_ m: T, _ n: ScopeIdentity) -> Bool {
+    (m.module == n.module) && (m.file == n.file)
+  }
+
+  /// Returns `true` iff `m` and `n` are in the same file.
+  public func inSameFile(_ m: ScopeIdentity, _ n: ScopeIdentity) -> Bool {
+    (m.module == n.module) && (m.file == n.file)
+  }
+
+  public func depth<T: SyntaxIdentity>(_ n: T) -> Int {
+    scopes(from: parent(containing: n)).count(where: { _ in true })
+  }
+
   /// Returns whether `m` or `n` is lexically closer to `s`.
+  ///
+  /// The result is:
+  /// - `.ascending` iff `m` is considered closer to `s` than `n`;
+  /// - `.descending` iff `m` is considered father from `s` than `n`;
+  /// - `.equal` otherwise.
   ///
   /// - Requires: The module containing `s` is scoped.
   public func compareLexicalDistances<T: SyntaxIdentity, U: SyntaxIdentity>(
     _ m: T, _ n: U, relativeTo s: ScopeIdentity
   ) -> StrictOrdering {
-    // Is `m` in the same module as `s`?
-    if m.module == s.module {
-      // `m` is closer if it has more ancestors or `n` is in another module.
-      if n.module == s.module {
-        return compareAncestors(m, n)
-      } else {
+    // Are `m` and `n` the same tree.
+    if m == n { return .equal }
+
+    // Are `m` and `n` in separate files?
+    if !inSameFile(m, n) {
+      if inSameFile(m, s) {
         return .ascending
-      }
-    }
-
-    // Is `n` in the same module as `s`?
-    else if n.module == s.module {
-      return .descending
-    }
-
-    // Otherwise, they have the same distance.
-    else { return .equal }
-  }
-
-  /// Returns the result of the three-way comparison of the number of ancestors of `m` and `n`.
-  ///
-  /// - Requires: `m` and `n` are in the same module, which is scoped.
-  public func compareAncestors<T: SyntaxIdentity, U: SyntaxIdentity>(
-    _ m: T, _ n: U
-  ) -> StrictOrdering {
-    assert(m.module == n.module)
-
-    var p = parent(containing: m)
-    var q = parent(containing: n)
-    while let a = p.node {
-      if let b = q.node {
-        p = parent(containing: a)
-        q = parent(containing: b)
-      } else {
+      } else if inSameFile(n, s) {
         return .descending
+      } else {
+        return .init(between: depth(m), and: depth(n))
       }
     }
-    return q.node == nil ? .equal : .ascending
+
+    // `m` and `n` are in the same file and `lca` is their deepest common scope.
+    let (xs, ys, lca) = commonAncestry(m, n)
+
+    // Are `m`/`n` and `s` in separate files?
+    if !inSameFile(lca!, s) {
+      return .init(between: xs.count, and: ys.count)
+    }
+
+    // Are `m` and `n` contained in `s`?
+    if scopes(from: lca!).contains(s) {
+      return .init(between: xs.count, and: ys.count)
+    }
+
+    // Is `m` contained in `s`.
+    if let i = xs.firstIndex(of: s) {
+      return .init(between: i, and: (xs.count - i) + ys.count)
+    }
+
+    // Is `n` contained in `s`.
+    if let i = ys.firstIndex(of: s) {
+      return .init(between: (ys.count - i) + xs.count, and: i)
+    }
+
+    // `s` is nested in the innermost scope containing either `m` or `n`, or it does not share a
+    // common ancestor with neither `m` nor `n`.
+    let p = castToScope(m) ?? parent(containing: m)
+    let q = castToScope(n) ?? parent(containing: n)
+    var origin = s
+    while let o = origin.node {
+      if origin == p { return .ascending }
+      if origin == q { return .descending }
+      origin = parent(containing: o)
+    }
+    return .init(between: xs.count, and: ys.count)
   }
 
   /// Returns the declarations directly contained in `s`.
@@ -2029,6 +2089,30 @@ public indirect enum SyntaxFilter {
     case .satisfies(let p):
       return p(n)
     }
+  }
+
+}
+
+/// The scopes preceding the deepest common ancestor of two syntax trees.
+public struct CommonAncestry {
+
+  /// An array with all the scopes containing the left tree.
+  fileprivate let leftAndShared: [ScopeIdentity]
+
+  /// The position of the deepest common ancestor of the two trees.
+  fileprivate let deepestCommonAncestor: Int
+
+  /// The scopes containing the right tree up to `shared`.
+  public let right: [ScopeIdentity]
+
+  /// The scopes containing the left tree up to `shared`.
+  public var left: ArraySlice<ScopeIdentity> {
+    leftAndShared[..<deepestCommonAncestor]
+  }
+
+  /// The deepest common ancestor of the two trees, if any.
+  public var shared: ArraySlice<ScopeIdentity> {
+    leftAndShared[deepestCommonAncestor...]
   }
 
 }

--- a/Sources/FrontEnd/Typer/NameResolutionCandidate.swift
+++ b/Sources/FrontEnd/Typer/NameResolutionCandidate.swift
@@ -15,7 +15,7 @@ extension Program {
 
   /// Returns `true` iff `lhs` is preferred over `rhs` for overload resolution.
   internal func isPreferred(
-    _ lhs: NameResolutionCandidate, other rhs: NameResolutionCandidate,
+    _ lhs: NameResolutionCandidate, over rhs: NameResolutionCandidate,
     in scopeOfUse: ScopeIdentity
   ) -> StrictOrdering {
     let d: StrictOrdering = switch (lhs.reference, rhs.reference) {

--- a/Sources/FrontEnd/Typer/NameResolutionCandidate.swift
+++ b/Sources/FrontEnd/Typer/NameResolutionCandidate.swift
@@ -1,3 +1,5 @@
+import Utilities
+
 /// A candidate for resolving a name component.
 internal struct NameResolutionCandidate {
 
@@ -15,28 +17,27 @@ extension Program {
   internal func isPreferred(
     _ lhs: NameResolutionCandidate, other rhs: NameResolutionCandidate,
     in scopeOfUse: ScopeIdentity
-  ) -> Bool {
-    // No candidate is cheaper to elaborate?
-    if lhs.reference.elaborationCost == rhs.reference.elaborationCost {
-      switch (lhs.reference, rhs.reference) {
-      case (.inherited(_, let a, _), .inherited(_, let b, _)):
-        // Members declared in extension are preferred over members inherited by conformance. The
-        // rationale is that the former may serve as implementations for the latter.
-        if isExtensionMember(a) && !isExtensionMember(b) {
-          return true
-        } else {
-          return compareLexicalDistances(a, b, relativeTo: scopeOfUse) == .ascending
-        }
+  ) -> StrictOrdering {
+    let d: StrictOrdering = switch (lhs.reference, rhs.reference) {
+    case (.inherited(_, let a, _), .inherited(_, let b, _)):
+      // Members declared in extension are preferred over members inherited by conformance. The
+      // rationale is that the former may serve as implementations for the latter.
+      if isExtensionMember(a) && !isExtensionMember(b) {
+        .ascending
+      } else {
+        compareLexicalDistances(a, b, relativeTo: scopeOfUse)
+      }
 
-      default:
-        return false
+    default:
+      if let a = lhs.reference.target, let b = rhs.reference.target {
+        compareLexicalDistances(a, b, relativeTo: scopeOfUse)
+      } else {
+        .equal
       }
     }
 
-    // Return `true` iff `lhs` is cheaper to elaborate.
-    else {
-      return lhs.reference.elaborationCost < rhs.reference.elaborationCost
-    }
+    return d.inequalElse(
+      .init(between: lhs.reference.elaborationCost, and: rhs.reference.elaborationCost))
   }
 
 }

--- a/Sources/FrontEnd/Typer/Solver.swift
+++ b/Sources/FrontEnd/Typer/Solver.swift
@@ -589,7 +589,7 @@ internal struct Solver {
     // Otherwise, identify the right choice.
     let scopeOfUse = program.parent(containing: k.name)
     let least = viable.least { (a, b) in
-      program.isPreferred(a.choice, other: b.choice, in: scopeOfUse)
+      program.isPreferred(a.choice, over: b.choice, in: scopeOfUse)
     }
 
     if let (_, s) = least {

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -3808,7 +3808,7 @@ public struct Typer {
       swap(&next, &work)
     }
 
-    return done.minimalElements(by: { (a, b) in a.penalties < b.penalties })
+    return done.minimalElements(by: StrictOrdering.comparing(\SummonResult.penalties))
   }
 
   /// Returns the givens whose definitions are at the top-level of `m`.

--- a/Sources/Utilities/Sequence+Extensions.swift
+++ b/Sources/Utilities/Sequence+Extensions.swift
@@ -14,36 +14,38 @@ extension Sequence {
   }
 
   /// Returns the set of elements in `self` that are not greater than any other element in `self`
-  /// according to `areInIncreasingOrder`.
-  public func minimalElements(by areInIncreasingOrder: (Element, Element) -> Bool) -> [Element] {
+  /// according to `compare`.
+  public func minimalElements(by compare: (Element, Element) -> StrictOrdering) -> [Element] {
     var it = makeIterator()
     var leaves: [Element] = []
-    var hasLeast = false
 
     while let x = it.next() {
-      if hasLeast {
-        if areInIncreasingOrder(leaves[0], x) {
+      if let e = leaves.uniqueElement {
+        switch compare(e, x) {
+        case .ascending:
           continue
-        } else if !areInIncreasingOrder(x, leaves[0]) {
+        case .equal:
           leaves.append(x)
-          hasLeast = false
           continue
+        case .descending:
+          break
         }
       }
 
-      if leaves.allSatisfy({ (y) in areInIncreasingOrder(x, y) }) {
+      if leaves.allSatisfy({ (y) in compare(x, y) == .ascending }) {
         leaves = [x]
-        hasLeast = true
+      } else {
+        leaves.append(x)
       }
     }
 
     return leaves
   }
 
-  /// Returns the least element in `self` according to `areInIncreasingOrder`, or `nil` if `self`
-  /// contains no such element.
-  public func least(by areInIncreasingOrder: (Element, Element) -> Bool) -> Element? {
-    minimalElements(by: areInIncreasingOrder).uniqueElement
+  /// Returns the least element in `self` according to `compare`, or `nil` if `self` contains no
+  /// such element.
+  public func least(by compare: (Element, Element) -> StrictOrdering) -> Element? {
+    minimalElements(by: compare).uniqueElement
   }
 
   /// Returns the result of applying `transform` to each element in `self`, joined by the given

--- a/Sources/Utilities/StrictOrdering.swift
+++ b/Sources/Utilities/StrictOrdering.swift
@@ -1,5 +1,5 @@
 /// The result type of a three-way comparison implementing a strict total order.
-public enum StrictOrdering: Hashable {
+public enum StrictOrdering: CaseIterable, Hashable {
 
   /// The LHS is ordered before the RHS.
   case ascending
@@ -13,6 +13,16 @@ public enum StrictOrdering: Hashable {
   /// Creates the comparison of `a` with `b`.
   public init<T: Comparable>(between a: T, and b: T) {
     self = (a < b) ? .ascending : ((b < a) ? .descending : .equal)
+  }
+
+  /// Returns `self` iff it is not `.equal`; otherwise, returns `other`.
+  public func inequalElse(_ other: StrictOrdering) -> StrictOrdering {
+    self == .equal ? other : self
+  }
+
+  /// Returns a function comparing instances of `T` at `p`.
+  public static func comparing<T, U: Comparable>(_ p: KeyPath<T, U>) -> (T, T) -> StrictOrdering {
+    { (a, b) in .init(between: a[keyPath: p], and: b[keyPath: p]) }
   }
 
 }

--- a/Tests/CompilerTests/positive/lexical-distance.package/package.json
+++ b/Tests/CompilerTests/positive/lexical-distance.package/package.json
@@ -1,0 +1,1 @@
+{ "options": ["stage:typing", "no-std"] }

--- a/Tests/CompilerTests/positive/lexical-distance.package/src/ABC.hylo
+++ b/Tests/CompilerTests/positive/lexical-distance.package/src/ABC.hylo
@@ -1,0 +1,3 @@
+public struct A { public memberwise init }
+public struct B { public memberwise init }
+public struct C { public memberwise init }

--- a/Tests/CompilerTests/positive/lexical-distance.package/src/E.hylo
+++ b/Tests/CompilerTests/positive/lexical-distance.package/src/E.hylo
@@ -1,0 +1,5 @@
+extension S {
+
+  public static fun g() -> B { B() }
+
+}

--- a/Tests/CompilerTests/positive/lexical-distance.package/src/S.hylo
+++ b/Tests/CompilerTests/positive/lexical-distance.package/src/S.hylo
@@ -1,0 +1,15 @@
+public struct S {
+
+  public memberwise init
+
+  public static fun f() -> S { S() }
+
+  public static fun g() -> S { S() }
+
+}
+
+extension S {
+
+  public static fun g() -> A { A() }
+
+}

--- a/Tests/CompilerTests/positive/lexical-distance.package/src/main.hylo
+++ b/Tests/CompilerTests/positive/lexical-distance.package/src/main.hylo
@@ -1,0 +1,45 @@
+fun check<T>(x: T) {}
+
+// File-scoped extensions.
+extension S { static fun f() -> A { A() } }
+
+fun m0() {
+  // File-scoped definition has priority.
+  let x0 = S.f()
+  check<A>(x0)
+}
+
+fun m1() {
+  // Local-scoped extension.
+  extension S { static fun f() -> B { B() } }
+  extension <T> T { static fun f() -> C { C() } }
+
+  // Local-scoped definitions have priority. There is no ambiguity because matching the generic one
+  // is more expensive than matching the non-generic one.
+  let x0 = S.f()    // From local-scoped extension
+  check<B>(x0)
+
+  // Other definitions are still accessible.
+  let _: S = S.f()  // From type declaration
+  let _: A = S.f()  // From file-scoped extension
+  let _: C = S.f()  // From generic local-scoped extension
+}
+
+fun m2() {
+  // All definitions are in different files, at equal lexical distance. There is no ambiguity
+  // because resolving the ones declared in the extensions has an elaboration costs.
+  let x0 = S.g()    // From S.hylo
+  check<S>(x0)
+
+  // Other definitions are still accessible.
+  let _: A = S.g()  // From S.hylo
+  let _: B = S.g()  // From E.hylo
+}
+
+fun h() -> A { A() }
+
+fun h() -> B {
+  // There is no ambiguity because the use is nested into one of the definitions.
+  sink let x0 = h()
+  return x0
+}

--- a/Tests/UtilitiesTests/SequenceTests.swift
+++ b/Tests/UtilitiesTests/SequenceTests.swift
@@ -9,41 +9,18 @@ final class SequenceTests: XCTestCase {
   }
 
   func testLeast() {
-    let x0: [E] = []
-    XCTAssertNil(x0.least(by: E.areInIncreasingOrder(_:_:)))
-    let x1: [E] = [.d, .b, .c]
-    XCTAssertNil(x1.least(by: E.areInIncreasingOrder(_:_:)))
-    let x2: [E] = [.d, .b, .e, .f]
-    XCTAssertEqual(x2.least(by: E.areInIncreasingOrder(_:_:)), .f)
+    let x0: [Int] = []
+    XCTAssertNil(x0.least(by: StrictOrdering.comparing(\.self)))
+    let x1: [Int] = [1, 2, 1, 3]
+    XCTAssertNil(x1.least(by: StrictOrdering.comparing(\.self)))
+    let x2: [Int] = [1, 2, 0, 3]
+    XCTAssertEqual(x2.least(by: StrictOrdering.comparing(\.self)), 0)
   }
 
   func testMin() {
     let xs = [1, 2, 3, 4]
     XCTAssertEqual(xs.min(measuredBy: { (x) in x }), 1)
     XCTAssertEqual(xs.min(measuredBy: { (x) in -x }), 4)
-  }
-
-}
-
-private enum E: Equatable {
-
-  case a, b, c, d, e, f
-
-  static func areInIncreasingOrder(_ lhs: E, _ rhs: E) -> Bool {
-    switch (lhs, rhs) {
-    case (_, .a):
-      return lhs != .a
-    case (_, .b):
-      return (lhs == .d) || (lhs == .e) || (lhs == .f)
-    case (_, .c):
-      return false
-    case (_, .d):
-      return lhs == .f
-    case (_, .e):
-      return lhs == .f
-    case (_, .f):
-      return false
-    }
   }
 
 }

--- a/Tests/UtilitiesTests/StrictOrderingTests.swift
+++ b/Tests/UtilitiesTests/StrictOrderingTests.swift
@@ -1,0 +1,27 @@
+import Utilities
+import XCTest
+
+final class StrictOrderingTests: XCTestCase {
+
+  func testInitFromComparable() {
+    XCTAssertEqual(StrictOrdering(between: 3, and: 5), .ascending)
+    XCTAssertEqual(StrictOrdering(between: 3, and: 3), .equal)
+    XCTAssertEqual(StrictOrdering(between: 5, and: 3), .descending)
+  }
+
+  func testInequalOrElse() {
+    for o in StrictOrdering.allCases {
+      XCTAssertEqual(StrictOrdering.ascending.inequalElse(o), .ascending)
+      XCTAssertEqual(StrictOrdering.equal.inequalElse(o), o)
+      XCTAssertEqual(StrictOrdering.descending.inequalElse(o), .descending)
+    }
+  }
+
+  func testComparing() {
+    let f = StrictOrdering.comparing(\Int.magnitude)
+    XCTAssertEqual(f(3, -5), .ascending)
+    XCTAssertEqual(f(3, -3), .equal)
+    XCTAssertEqual(f(-5, 3), .descending)
+  }
+
+}


### PR DESCRIPTION
This patch fixes #357.

The implementation is tricky and deserves some attention.

Outside of the constraints that would simply leave an expression ill-typed, there are essentially 2 axes to rank candidates.
1. Lexical distance, which measures the number of lexical scopes one has to traverse to get from a use to its definition.
2. Elaboration cost, which measures the number of arguments the compiler has to infer for context parameters.

It is important to keep in mind that extensions in Hylo do not extend scopes; they extend types. Intuitively, that means `extension A { fun f() {} }` does not add a function to the declaration of `A`. Instead, it creates a function `fun<T where T == A>(self: T) {}`. Consequently, resolving `f` compels the compiler to resolve a witness that `T` is equal to `A` (it does not work *exactly* like that, but close enough), meaning that resolving a function in extension has a non-zero elaboration cost, no matter what.

With this background, consider the following situation:

```hylo
trait P {}
struct S is P { static fun f() -> A }

fun local() {
  extension S { static fun f() -> B }
  extension <T is P> T { static fun f() -> C }
  let x = S.f()
}
```

There are three candidates to consider when resolving `S.f`. The question is to determine how we should rank them. This patch unambiguously answers with the definition in the non-generic extension because
1. it is lexically closer than the definition in the type declaration; and
2. resolving the definition in the generic extension has a higher elaboration cost.

It is not obvious that prioritizing lexical distance is the right bet. In particular, it should be noted that:
- It means a very abstract extension can effectively shadow a very concrete implementation.
- This prioritization is inconsistent with the way we resolve arguments to context parameters.
- This prioritization is inconsistent with the way we select implementations when forming conformance witnesses. There we favor declarations in types for performance.

If we would like to revisit the rules in the future, the key function to examine is `Program.isPreferred(_:over:in)`.