### PR TITLE
Refactor the typing of conditional statements

### DIFF
--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -1165,6 +1165,10 @@ public struct Typer {
   }
 
   /// Type checks `s`.
+  ///
+  /// `s` occurs as the else branch of a conditional statement occurring as a statement. If the
+  /// branch is another conditional expression (i.e., `... if else ...`), then that expression is
+  /// also checked as a statement.
   private mutating func check(_ s: If.ElseIdentity) {
     if let n = program.cast(s, to: If.self) {
       checkAsStatement(n)

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -1153,9 +1153,26 @@ public struct Typer {
   }
 
   /// Type checks `s`.
+  private mutating func check(_ s: Block.ID) {
+    for n in program[s].statements { check(n) }
+    program[s.module].setType(.void, for: s)
+  }
+
+  /// Type checks `s`.
   private mutating func check(_ s: Discard.ID) {
     check(program[s].value)
     program[s.module].setType(.void, for: s)
+  }
+
+  /// Type checks `s`.
+  private mutating func check(_ s: If.ElseIdentity) {
+    if let n = program.cast(s, to: If.self) {
+      checkAsStatement(n)
+    } else if let n = program.cast(s, to: Block.self) {
+      check(n)
+    } else {
+      program.unexpected(s)
+    }
   }
 
   /// Type checks `s`.
@@ -2261,10 +2278,8 @@ public struct Typer {
 
     // Is the expression occurring as a statement?
     if isStatement {
-      context.withSubcontext { (ctx) in
-        _ = inferredType(of: program[e].success, occurringAsStatement: true, in: &ctx)
-        _ = inferredType(of: program[e].failure, occurringAsStatement: true, in: &ctx)
-      }
+      check(program[e].success)
+      check(program[e].failure)
       return context.obligations.assume(e, hasType: .void, at: program[e].site)
     }
 
@@ -2820,34 +2835,6 @@ public struct Typer {
   ) -> AnyTypeIdentity {
     let t = fresh().erased
     return context.obligations.assume(d, hasType: t, at: program[d].site)
-  }
-
-  /// Returns the inferred type of `b`, which occurs in `context`.
-  private mutating func inferredType(
-    of b: Block.ID, occurringAsStatement isStatement: Bool,
-    in context: inout InferenceContext
-  ) -> AnyTypeIdentity {
-    context.obligations.assume(b, hasType: .void, at: program[b].site)
-    if !isStatement, let e = program.singleExpression(of: b) {
-      return inferredType(of: e, in: &context)
-    } else {
-      for s in program[b].statements { check(s) }
-      return .void
-    }
-  }
-
-  /// Returns the inferred type of `b`, which occurs in `context`.
-  private mutating func inferredType(
-    of b: If.ElseIdentity, occurringAsStatement isStatement: Bool,
-    in context: inout InferenceContext
-  ) -> AnyTypeIdentity {
-    if let e = program.cast(b, to: If.self) {
-      return inferredType(of: e, occurringAsStatement: isStatement, in: &context)
-    } else if let s = program.cast(b, to: Block.self) {
-      return inferredType(of: s, occurringAsStatement: isStatement, in: &context)
-    } else {
-      program.unexpected(b)
-    }
   }
 
   /// Returns the inferred type `q`, which is the qualification of some name expression occurring


### PR DESCRIPTION
Just a minor simplification of type inference, removing needless parameters.

Closes https://github.com/hylo-lang/hylo-new/issues/424