### PR TITLE
Fix priority inversion 2

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -204,8 +204,8 @@ public struct Driver {
     from module: Module.ID,
     withCSources cSources: [URL] = [],
     writingTo output: URL
-  ) throws -> PhaseResult {
-    let elapsed = try ContinuousClock().measure {
+  ) async throws -> PhaseResult {
+    let elapsed = try await ContinuousClock().measure {
       let modulesToLink = [module]
       // FIXME: link the dependencies of `module`.
 
@@ -217,12 +217,13 @@ public struct Driver {
         cSources.append(chosenStandardLibraryRoot.appending(component: cShimSource))
       }
 
-      try FileManager.default.withUniqueTemporaryDirectory { (d) in
+      try await FileManager.default.withUniqueTemporaryDirectory { (d) in
         let hyloObjects = try writeObjectFiles(for: modulesToLink, into: d)
-        let cObjects = try cSources.map { (s) in
-          try compileCToObject(source: s, destinationDirectory: d)
+        var cObjects: [URL] = []
+        for s in cSources {
+          cObjects.append(try await compileCToObject(source: s, destinationDirectory: d))
         }
-        try linkExecutable(from: hyloObjects + cObjects, writingTo: output)
+        try await linkExecutable(from: hyloObjects + cObjects, writingTo: output)
       }
     }
     return .init(elapsed: elapsed, containsError: program[module].containsError)
@@ -259,7 +260,7 @@ public struct Driver {
   /// Compiles `source` using `clang` to an object file.
   ///
   /// Returns the path to the object file within `destinationDirectory`.
-  public func compileCToObject(source: URL, destinationDirectory: URL) throws -> URL {
+  public func compileCToObject(source: URL, destinationDirectory: URL) async throws -> URL {
     let uniquePrefix = source.hashValue
     let fileName = source.deletingPathExtension().appendingPathExtension("o").lastPathComponent
 
@@ -269,7 +270,7 @@ public struct Driver {
     var a = ["-c", source.path, "-o", o.path]
     if let r = relocation.asClangArgument { a.append(r) }
 
-    _ = try Process.executionOutput(
+    _ = try await Process.executionOutput(
       try Host.findBinaryExecutable(invokedAs: "clang"), arguments: a)
     return o
   }
@@ -368,7 +369,7 @@ public struct Driver {
   /// Links the provided object files into an executable at `output`, using lld.
   ///
   /// - Throws: if the parent folder of `output` doesn't exist.
-  private func linkExecutable(from objectFiles: [URL], writingTo output: URL) throws {
+  private func linkExecutable(from objectFiles: [URL], writingTo output: URL) async throws {
     var arguments = ["-o", output.path]
     arguments += librarySearchPaths.map({ "-L\($0.path)" })
     arguments += librariesToLink.map({ "-l\($0)" })
@@ -376,13 +377,14 @@ public struct Driver {
 
     #if os(macOS)
     let xcrun = try Host.findBinaryExecutable(invokedAs: "xcrun")
-    let sdk = try Process.executionOutput(xcrun, arguments: ["--sdk", "macosx", "--show-sdk-path"])
-      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let sdk = try await Process.executionOutput(
+      xcrun, arguments: ["--sdk", "macosx", "--show-sdk-path"]
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
     arguments += ["-isysroot", sdk, "-lSystem"]
     #endif
 
     let clang = try Host.findBinaryExecutable(invokedAs: "clang")
-    _ = try Process.executionOutput(clang, arguments: arguments)
+    _ = try await Process.executionOutput(clang, arguments: arguments)
   }
 
   /// The name of `module`.

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -80,8 +80,8 @@ extension Process {
     process.waitUntilExit()
 
     // Retrieve the data (blocks until background reads complete)
-    let output = stdoutData().decodedAsRepairedUTF8()
-    let error = stderrData().decodedAsRepairedUTF8()
+    let output = try stdoutData().decodedAsRepairedUTF8()
+    let error = try stderrData().decodedAsRepairedUTF8()
 
     return .init(
       standardOutput: output,
@@ -124,7 +124,7 @@ extension Process {
 /// Returns a closure that blocks until reading completes and returns the data.
 /// This prevents pipe buffer deadlocks by draining pipes while the process runs.
 /// Uses non-blocking I/O with readability handlers for efficiency.
-private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
+private func readPipeInBackground(_ pipe: Pipe) -> () throws -> Data {
   // Box to safely share mutable state across concurrency boundary
   final class ReadCompletion: Operation, @unchecked Sendable {
     var data = Data()
@@ -139,7 +139,6 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
   pipe.fileHandleForReading.readabilityHandler = { handle in
     let chunk = handle.availableData
     if chunk.isEmpty {  // EOF on the pipe
-      pipe.fileHandleForReading.closeFile()
       pipe.fileHandleForReading.readabilityHandler = nil
       completion.start()
     } else {
@@ -148,6 +147,7 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
   }
 
   return {
+    try pipe.fileHandleForReading.close()
     completion.waitUntilFinished()
     return completion.data
   }

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -128,13 +128,11 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
   // Box to safely share mutable state across concurrency boundary
   final class ReadCompletion: Operation, @unchecked Sendable {
     var data = Data()
-    /*
     override init() {
       super.init()
       self.qualityOfService = .userInteractive
       self.queuePriority = .veryHigh
     }
-     */
   }
 
   let completion = ReadCompletion()

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -128,18 +128,14 @@ private func readPipeInBackground(_ pipe: Pipe) -> () throws -> Data {
   // Box to safely share mutable state across concurrency boundary
   final class ReadCompletion: Operation, @unchecked Sendable {
     var data = Data()
-    override init() {
-      super.init()
-      self.qualityOfService = .userInteractive
-      self.queuePriority = .veryHigh
-    }
   }
 
   let completion = ReadCompletion()
   pipe.fileHandleForReading.readabilityHandler = { handle in
     let chunk = handle.availableData
     if chunk.isEmpty {  // EOF on the pipe
-      pipe.fileHandleForReading.readabilityHandler = nil
+      // pipe.fileHandleForReading.readabilityHandler = nil
+      try! pipe.fileHandleForReading.close()
       completion.start()
     } else {
       completion.data.append(chunk)
@@ -147,7 +143,6 @@ private func readPipeInBackground(_ pipe: Pipe) -> () throws -> Data {
   }
 
   return {
-    try pipe.fileHandleForReading.close()
     completion.waitUntilFinished()
     return completion.data
   }

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -80,8 +80,8 @@ extension Process {
     process.waitUntilExit()
 
     // Retrieve the data (blocks until background reads complete)
-    let output = try stdoutData().decodedAsRepairedUTF8()
-    let error = try stderrData().decodedAsRepairedUTF8()
+    let output = stdoutData().decodedAsRepairedUTF8()
+    let error = stderrData().decodedAsRepairedUTF8()
 
     return .init(
       standardOutput: output,
@@ -124,7 +124,7 @@ extension Process {
 /// Returns a closure that blocks until reading completes and returns the data.
 /// This prevents pipe buffer deadlocks by draining pipes while the process runs.
 /// Uses non-blocking I/O with readability handlers for efficiency.
-private func readPipeInBackground(_ pipe: Pipe) -> () throws -> Data {
+private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
   // Box to safely share mutable state across concurrency boundary
   final class ReadCompletion: Operation, @unchecked Sendable {
     var data = Data()
@@ -134,9 +134,13 @@ private func readPipeInBackground(_ pipe: Pipe) -> () throws -> Data {
   pipe.fileHandleForReading.readabilityHandler = { handle in
     let chunk = handle.availableData
     if chunk.isEmpty {  // EOF on the pipe
-      // pipe.fileHandleForReading.readabilityHandler = nil
-      try! pipe.fileHandleForReading.close()
-      completion.start()
+      pipe.fileHandleForReading.readabilityHandler = nil
+      //#if os(Windows)
+      //try! pipe.fileHandleForReading.close()
+      //#endif
+      Task {
+        completion.start()
+      }
     } else {
       completion.data.append(chunk)
     }

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -135,12 +135,10 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
     let chunk = handle.availableData
     if chunk.isEmpty {  // EOF on the pipe
       pipe.fileHandleForReading.readabilityHandler = nil
-      Task {
-        #if os(Windows)
-        try! pipe.fileHandleForReading.close()
-        #endif
-        completion.start()
-      }
+      #if os(Windows)
+      try! pipe.fileHandleForReading.close()
+      #endif
+      completion.start()
     } else {
       completion.data.append(chunk)
     }

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -130,7 +130,8 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
     var data = Data()
     override init() {
       super.init()
-      self.qualityOfService = .userInitiated
+      self.qualityOfService = .userInteractive
+      self.queuePriority = .veryHigh
     }
   }
 

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -128,11 +128,13 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
   // Box to safely share mutable state across concurrency boundary
   final class ReadCompletion: Operation, @unchecked Sendable {
     var data = Data()
+    /*
     override init() {
       super.init()
       self.qualityOfService = .userInteractive
       self.queuePriority = .veryHigh
     }
+     */
   }
 
   let completion = ReadCompletion()
@@ -140,6 +142,7 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
     let chunk = handle.availableData
     if chunk.isEmpty {  // EOF on the pipe
       pipe.fileHandleForReading.readabilityHandler = nil
+      pipe.fileHandleForReading.closeFile()
       completion.start()
     } else {
       completion.data.append(chunk)

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -128,7 +128,9 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
   // Box to safely share mutable state across concurrency boundary
   final class ReadCompletion: Operation, @unchecked Sendable {
     var data = Data()
-    override func main() {
+    override init() {
+      super.init()
+      self.qualityOfService = .userInitiated
     }
   }
 

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -24,7 +24,7 @@ extension Process {
     public var description: String {
       """
       '\(executable) \(arguments.joined(separator: " "))' exited with status \(exitCode).
-      
+
       Standard Output:
       \(standardOutput)
 
@@ -41,8 +41,8 @@ extension Process {
   /// Throws a `NonzeroExit` upon terminating with non-zero exit code.
   public static func executionOutput(
     _ executable: URL, arguments: [String] = []
-  ) throws -> String {
-    let x = try execute(executable, arguments: arguments)
+  ) async throws -> String {
+    let x = try await execute(executable, arguments: arguments)
     if x.exitCode != 0 {
       throw NonzeroExit(
         exitCode: x.exitCode,
@@ -56,9 +56,11 @@ extension Process {
 
   /// Runs `executable` with `arguments`, setting the working
   /// directory if provided, and returns its execution report.
+  ///
+  /// Task cancellation during execution has no effect.
   public static func execute(
     _ executable: URL, arguments: [String] = [], workingDirectory: URL? = nil
-  ) throws -> ExecutionReport {
+  ) async throws -> ExecutionReport {
     let process = Process()
     let standardOutput = Pipe()
     let standardError = Pipe()
@@ -69,29 +71,40 @@ extension Process {
     if let d = workingDirectory {
       process.currentDirectoryURL = d
     }
-    try process.run()
 
-    // Read pipes on background threads to prevent deadlock if output
-    // exceeds pipe buffer size.  The child process will block if pipe
-    // buffers fill up, so we must drain them continuously.
-    let stdoutData = readPipeInBackground(standardOutput)
-    let stderrData = readPipeInBackground(standardError)
+    // Drain both pipes concurrently while the process runs.
+    async let output = readToEnd(standardOutput.fileHandleForReading)
+    async let error = readToEnd(standardError.fileHandleForReading)
 
-    process.waitUntilExit()
+    // Launch the process and wait for it to exit.
+    //
+    // Cancellation of the current task is ignored. We always wait for the process to terminate.
+    do {
+      try await withCheckedThrowingContinuation { (continuation) in
+        process.terminationHandler = { (_) in continuation.resume() }
+        do {
+          try process.run()
+        } catch {
+          continuation.resume(throwing: error)
+        }
+      }
+    } catch {
+      // Close files when `run` fails, then rethrow.
+      try? standardOutput.fileHandleForWriting.close()
+      try? standardError.fileHandleForWriting.close()
+      throw error
+    }
 
-    // Retrieve the data (blocks until background reads complete)
-    let output = stdoutData().decodedAsRepairedUTF8()
-    let error = stderrData().decodedAsRepairedUTF8()
-
+    // Read failures are rethrown once the process has exited.
     return .init(
-      standardOutput: output,
-      standardError: error,
+      standardOutput: try await output.get().decodedAsRepairedUTF8(),
+      standardError: try await error.get().decodedAsRepairedUTF8(),
       exitCode: process.terminationStatus,
       terminationReason: process.terminationReason)
   }
 
   /// The result of executing a process.
-  public struct ExecutionReport {
+  public struct ExecutionReport: Sendable {
 
     /// The data written to the standard output of the process.
     public let standardOutput: String
@@ -119,34 +132,14 @@ extension Process {
   }
 }
 
-/// Starts reading all data from `pipe` using event-driven I/O.
-///
-/// Returns a closure that blocks until reading completes and returns the data.
-/// This prevents pipe buffer deadlocks by draining pipes while the process runs.
-/// Uses non-blocking I/O with readability handlers for efficiency.
-private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
-  // Box to safely share mutable state across concurrency boundary
-  final class ReadCompletion: Operation, @unchecked Sendable {
-    var data = Data()
-  }
-
-  let completion = ReadCompletion()
-  pipe.fileHandleForReading.readabilityHandler = { handle in
-    let chunk = handle.availableData
-    if chunk.isEmpty {  // EOF on the pipe
-      pipe.fileHandleForReading.readabilityHandler = nil
-      #if os(Windows)
-      try! pipe.fileHandleForReading.close()
-      #endif
-      completion.start()
-    } else {
-      completion.data.append(chunk)
-    }
-  }
-
-  return {
-    completion.waitUntilFinished()
-    return completion.data
+/// Returns the data read from `handle` until end-of-file, or the error that
+/// interrupted the read.
+private func readToEnd(_ handle: FileHandle) async -> Result<Data, any Error> {
+  await withCheckedContinuation { (continuation) in
+    Thread {
+      // Block the thread until we read the file to end.
+      continuation.resume(returning: Result { try handle.readToEnd() ?? Data() })
+    }.start()
   }
 }
 

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -126,26 +126,26 @@ extension Process {
 /// Uses non-blocking I/O with readability handlers for efficiency.
 private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
   // Box to safely share mutable state across concurrency boundary
-  final class DataBox: @unchecked Sendable {
+  final class ReadCompletion: Operation, @unchecked Sendable {
     var data = Data()
+    override func main() {
+    }
   }
-  let box = DataBox()
-  let group = DispatchGroup()
 
-  group.enter()
+  let completion = ReadCompletion()
   pipe.fileHandleForReading.readabilityHandler = { handle in
     let chunk = handle.availableData
     if chunk.isEmpty {  // EOF on the pipe
       pipe.fileHandleForReading.readabilityHandler = nil
-      group.leave()
+      completion.start()
     } else {
-      box.data.append(chunk)
+      completion.data.append(chunk)
     }
   }
 
   return {
-    group.wait()
-    return box.data
+    completion.waitUntilFinished()
+    return completion.data
   }
 }
 

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -135,10 +135,10 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
     let chunk = handle.availableData
     if chunk.isEmpty {  // EOF on the pipe
       pipe.fileHandleForReading.readabilityHandler = nil
-      //#if os(Windows)
-      //try! pipe.fileHandleForReading.close()
-      //#endif
       Task {
+        #if os(Windows)
+        try! pipe.fileHandleForReading.close()
+        #endif
         completion.start()
       }
     } else {

--- a/Sources/Utilities/Process+Extensions.swift
+++ b/Sources/Utilities/Process+Extensions.swift
@@ -139,8 +139,8 @@ private func readPipeInBackground(_ pipe: Pipe) -> () -> Data {
   pipe.fileHandleForReading.readabilityHandler = { handle in
     let chunk = handle.availableData
     if chunk.isEmpty {  // EOF on the pipe
-      pipe.fileHandleForReading.readabilityHandler = nil
       pipe.fileHandleForReading.closeFile()
+      pipe.fileHandleForReading.readabilityHandler = nil
       completion.start()
     } else {
       completion.data.append(chunk)

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -213,7 +213,7 @@ private typealias Module = FrontEnd.Module
 
       assert(outputType == .binary)
       try await perform("generating executable", for: module) {
-        try driver.generateExecutable(from: module, writingTo: binaryFile(product))
+        try await driver.generateExecutable(from: module, writingTo: binaryFile(product))
       }
     }
 

--- a/Tests/BackEndTests/SimpleFunctionEmitterTest.swift
+++ b/Tests/BackEndTests/SimpleFunctionEmitterTest.swift
@@ -47,10 +47,10 @@ final class SimpleFunctionEmitterTest: XCTestCase {
         }
         """))
 
-    let output = try FileManager.default.withUniqueTemporaryDirectory { (d) in
+    let output = try await FileManager.default.withUniqueTemporaryDirectory { (d) in
       let executable = d.appendingPathComponent(driver.program[m].name)
-      _ = try driver.generateExecutable(from: m, writingTo: executable)
-      return try Process.executionOutput(executable)
+      _ = try await driver.generateExecutable(from: m, writingTo: executable)
+      return try await Process.executionOutput(executable)
     }
 
     XCTAssertEqual(output.trimming(while: \.isWhitespace), "")

--- a/Tests/CompilerTests/CompilerTests.swift
+++ b/Tests/CompilerTests/CompilerTests.swift
@@ -249,7 +249,7 @@ final class CompilerTests: XCTestCase {
       // Should an executable be tested?
       if input.manifest.stage == .execution {
         let e = try XCTUnwrap(r.artifacts.executable)
-        let x = try Process.execute(e, workingDirectory: input.workingDirectory)
+        let x = try await Process.execute(e, workingDirectory: input.workingDirectory)
         if input.manifest.shouldTrap {
           XCTAssert(x.terminationReason == .uncaughtSignal, "program did not trap")
         } else {
@@ -408,7 +408,8 @@ final class CompilerTests: XCTestCase {
     if stage == .execution {
       let outputDirectory = try FileManager.default.createUniqueTemporaryDirectory()
       let executable = outputDirectory.appendingPathComponent(driver.program[m].name)
-      _ = try driver.generateExecutable(from: m, withCSources: cSources, writingTo: executable)
+      _ = try await driver.generateExecutable(
+        from: m, withCSources: cSources, writingTo: executable)
       artifacts.executable = executable
     }
   }

--- a/Tests/UtilitiesTests/HostTests.swift
+++ b/Tests/UtilitiesTests/HostTests.swift
@@ -21,24 +21,28 @@ final class HostTests: XCTestCase {
   }
 
   #if os(Windows)
-    func testFindBinaryExecutableFindsAndExecutesWhereExe() throws {
+    func testFindBinaryExecutableFindsAndExecutesWhereExe() async throws {
       let whereExe = try Host.findBinaryExecutable(invokedAs: "where")
       XCTAssertEqual(whereExe.lastPathComponent.lowercased(), "where.exe")
 
-      let output = try Process.executionOutput(whereExe, arguments: ["cmd"])
+      let output = try await withTimeout {
+        try await Process.executionOutput(whereExe, arguments: ["cmd"])
+      }
       XCTAssertTrue(output.lowercased().contains("cmd.exe"))
     }
   #else
-    func testFindBinaryExecutableFindsAndExecutesBash() throws {
+    func testFindBinaryExecutableFindsAndExecutesBash() async throws {
       let bash = try Host.findBinaryExecutable(invokedAs: "bash")
       XCTAssertEqual(bash.lastPathComponent, "bash")
 
-      let output = try Process.executionOutput(bash, arguments: ["-lc", "printf '%s' bash-ok"])
+      let output = try await withTimeout {
+        try await Process.executionOutput(bash, arguments: ["-lc", "printf '%s' bash-ok"])
+      }
       XCTAssertEqual(output, "bash-ok")
     }
   #endif
 
-  func testExecutionOutputThrowsOnNonzeroExit() throws {
+  func testExecutionOutputThrowsOnNonzeroExit() async throws {
     #if os(Windows)
       let executable = try Host.findBinaryExecutable(invokedAs: "cmd")
       let arguments = ["/c", "exit", "42"]
@@ -47,22 +51,21 @@ final class HostTests: XCTestCase {
       let arguments = ["-lc", "exit 42"]
     #endif
 
-    XCTAssertThrowsError(
-      try Process.executionOutput(executable, arguments: arguments), "",
-      { (error) in
-        if let e = error as? Process.NonzeroExit {
-          XCTAssertEqual(e.exitCode, 42)
-          XCTAssertEqual(e.executable, executable)
-          XCTAssertEqual(e.arguments, arguments)
+    do {
+      _ = try await Process.executionOutput(executable, arguments: arguments)
+      XCTFail("Expected Process.NonzeroExit to be thrown")
+    } catch let e as Process.NonzeroExit {
+      XCTAssertEqual(e.exitCode, 42)
+      XCTAssertEqual(e.executable, executable)
+      XCTAssertEqual(e.arguments, arguments)
 
-          XCTAssert(e.description.contains("exited with status 42"))
-        } else {
-          XCTFail("Expected Process.NonzeroExit, got \(error)")
-        }
-      })
+      XCTAssert(e.description.contains("exited with status 42"))
+    } catch {
+      XCTFail("Expected Process.NonzeroExit, got \(error)")
+    }
   }
 
-  func testExecuteReturnsReportOnNonzeroExit() throws {
+  func testExecuteReturnsReportOnNonzeroExit() async throws {
     #if os(Windows)
       let executable = try Host.findBinaryExecutable(invokedAs: "cmd")
       let arguments = ["/c", "exit", "42"]
@@ -71,7 +74,7 @@ final class HostTests: XCTestCase {
       let arguments = ["-lc", "exit 42"]
     #endif
 
-    let r = try Process.execute(executable, arguments: arguments)
+    let r = try await withTimeout { try await Process.execute(executable, arguments: arguments) }
     XCTAssertEqual(r.exitCode, 42)
     XCTAssertEqual(r.standardOutput, "")
     XCTAssertEqual(r.standardError, "")

--- a/Tests/UtilitiesTests/Process+ExtensionsTests.swift
+++ b/Tests/UtilitiesTests/Process+ExtensionsTests.swift
@@ -5,8 +5,8 @@ final class ProcessExtensionsTests: XCTestCase {
 
   /// Tests that we properly handle large amounts of output without
   /// either deadlocking or dropping any.
-  func testLargeProcessOutput() throws {
-
+  func testLargeProcessOutput() async throws {
+    let lineLengthWithNewline = 64
     let lineLength = 63
     let oneLine = String(repeating: "x", count: lineLength)
 
@@ -15,22 +15,20 @@ final class ProcessExtensionsTests: XCTestCase {
     // Number of buffers worth we will output.
     let outputSizeInBuffers = 4
     let totalOutputSize = outputSizeInBuffers * outputBufferSize
-    let lineCount = totalOutputSize / (lineLength + 1)
+    let lineCount = totalOutputSize / lineLengthWithNewline
     print("line count", lineCount)
     XCTAssertEqual(
-      totalOutputSize % (lineLength + 1), 0,
+      totalOutputSize % lineLengthWithNewline, 0,
       "Something is wrong with the test.")
 
-    var executable: String
-    var arguments: [String]
     #if os(Windows)
-    executable = "cmd"
-    arguments = [
-      "-c",
-      "for /l %i in (1, 1, \(lineCount)) do echo \(oneLine)"]
+    let executable = "cmd"
+    let arguments = [
+      "/c",
+      "for /l %i in (1, 1, \(lineCount)) do @echo \(oneLine)"]
     #else
-    executable = "sh"
-    arguments = [
+    let executable = "sh"
+    let arguments = [
       "-c",
       // The format string keeps seq from formatting its numbers in
       // scientific notation once they reach 1e+06.  It only matters
@@ -40,8 +38,21 @@ final class ProcessExtensionsTests: XCTestCase {
     #endif
 
     let binary = try Host.findBinaryExecutable(invokedAs: executable)
-    let output = try Process.executionOutput(binary, arguments: arguments)
+    let output = try await withTimeout {
+      try await Process.executionOutput(binary, arguments: arguments)
+    }
     XCTAssertEqual(output.count - totalOutputSize, 0)
+  }
+
+  /// Tests that a process that fails to launch reports the failure instead of hanging.
+  func testLaunchFailure() async {
+    let missing = URL(fileURLWithPath: "/definitely-not-an-executable")
+    do {
+      _ = try await withTimeout { try await Process.execute(missing) }
+      XCTFail("Expected an error")
+    } catch is TimedOut {
+      XCTFail("Expected an error, but the call hung")
+    } catch {}
   }
 
 }

--- a/Tests/UtilitiesTests/Process+ExtensionsTests.swift
+++ b/Tests/UtilitiesTests/Process+ExtensionsTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import Utilities
+
+final class ProcessExtensionsTests: XCTestCase {
+
+  /// Tests that we properly handle large amounts of output without
+  /// either deadlocking or dropping any.
+  func testLargeProcessOutput() throws {
+
+    let lineLength = 63
+    let oneLine = String(repeating: "x", count: lineLength)
+
+    // Known size of pipe output buffer
+    let outputBufferSize = 64 * 1024 // 64K
+    // Number of buffers worth we will output.
+    let outputSizeInBuffers = 4
+    let totalOutputSize = outputSizeInBuffers * outputBufferSize
+    let lineCount = totalOutputSize / (lineLength + 1)
+    print("line count", lineCount)
+    XCTAssertEqual(
+      totalOutputSize % (lineLength + 1), 0,
+      "Something is wrong with the test.")
+
+    var executable: String
+    var arguments: [String]
+    #if os(Windows)
+    executable = "cmd"
+    arguments = [
+      "-c",
+      "for /l %i in (1, 1, \(lineCount)) do echo \(oneLine)"]
+    #else
+    executable = "sh"
+    arguments = [
+      "-c",
+      // The format string keeps seq from formatting its numbers in
+      // scientific notation once they reach 1e+06.  It only matters
+      // when `outputSizeInBuffers` exceeds 976 but we want the test
+      // to work if we increase the value for stress-testing purposes.
+      "for i in $(seq -f '%1.0f' 1 \(lineCount)); do echo \(oneLine); done"]
+    #endif
+
+    let binary = try Host.findBinaryExecutable(invokedAs: executable)
+    let output = try Process.executionOutput(binary, arguments: arguments)
+    XCTAssertEqual(output.count - totalOutputSize, 0)
+  }
+
+}

--- a/Tests/UtilitiesTests/XCTestCase+Timeout.swift
+++ b/Tests/UtilitiesTests/XCTestCase+Timeout.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+extension XCTestCase {
+
+  /// The error thrown when an operation does not complete within its time allowance.
+  struct TimedOut: Error {
+    let exceedingSeconds: TimeInterval
+
+    var localizedDescription: String {
+      "Test exceeded \(exceedingSeconds)s."
+    }
+  }
+
+  /// Runs `operation`, failing the test and throwing `TimedOut` if it does not complete within
+  /// `timeout` seconds.
+  func withTimeout<T: Sendable>(
+    seconds timeout: TimeInterval = 30,
+    _ operation: @escaping @Sendable () async throws -> T
+  ) async throws -> T {
+    let done = expectation(description: "operation completes within \(timeout)s")
+    let task = Task {
+      defer { done.fulfill() }
+      return try await operation()
+    }
+
+    // The task's value is only awaited once it is known to have completed.
+    let outcome = await XCTWaiter().fulfillment(of: [done], timeout: timeout)
+    if outcome == .completed {
+      return try await task.value
+    } else {
+      task.cancel()
+      throw TimedOut(exceedingSeconds: timeout)
+    }
+  }
+
+}


### PR DESCRIPTION
The solution was a combination of waiting synchronously on process output in dedicated threads, then for everything to finish in the caller in an asynchronous way, without blocking the main thread.

I kept the test case (slightly adjusted to use `/c` on Windows instead of `-c`), and added a test timeout, so test is failed after 3 seconds of running. Process cancellation would be much more tricky to implement, so if we want that, we should adopt https://github.com/swiftlang/swift-subprocess