### PR TITLE
Refactor the fixed point computation of the abstract interpreter

### DIFF
--- a/Sources/FrontEnd/IR/AbstractInterpreter/AbstractContext.swift
+++ b/Sources/FrontEnd/IR/AbstractInterpreter/AbstractContext.swift
@@ -127,14 +127,21 @@ internal struct AbstractContext<Domain: AbstractDomain>: Hashable, Sendable {
   /// The state of memory.
   internal var memory: [IRValue: AbstractObject<Domain>] = [:]
 
+  /// `true` iff the context contains an error.
+  internal private(set) var containsError: Bool = false
+
   /// Creates an empty context.
   internal init() {}
 
   /// Merges `other` into `self`.
   internal mutating func merge(_ other: Self) {
-    locals.merge(other.locals)
-    memory.merge(other.memory, uniquingKeysWith: &&)
+    self.locals.merge(other.locals)
+    self.memory.merge(other.memory, uniquingKeysWith: &&)
+    self.containsError = self.containsError || other.containsError
   }
+
+  /// Sets the flag indicating that an error was encountered in this context.
+  internal mutating func setError() {}
 
   /// Returns the result calling `action` with a projection of the object at `place`, using `typer`
   /// to compute abstract layouts.

--- a/Sources/FrontEnd/IR/AbstractInterpreter/AbstractContext.swift
+++ b/Sources/FrontEnd/IR/AbstractInterpreter/AbstractContext.swift
@@ -28,16 +28,7 @@ internal struct AbstractContext<Domain: AbstractDomain>: Hashable, Sendable {
     private var contents: ContiguousArray<Slot> = []
 
     /// Creates an empty context.
-    internal init() {}
-
-    /// Forms a context by merging the contents of `batch`.
-    internal init<T: Collection<Self>>(merging batch: T) {
-      if let (h, t) = batch.headAndTail {
-        self = t.reduce(into: h, { (a, b) in a.merge(b) })
-      } else {
-        self.init()
-      }
-    }
+    fileprivate init() {}
 
     /// Accesses the value at assigned to `key`, which is either a register or a parameter.
     ///
@@ -82,7 +73,7 @@ internal struct AbstractContext<Domain: AbstractDomain>: Hashable, Sendable {
     }
 
     /// Merges `other` into `self`.
-    internal mutating func merge(_ other: Self) {
+    fileprivate mutating func merge(_ other: Self) {
       var l = 0
       var r = 0
 

--- a/Sources/FrontEnd/IR/AbstractInterpreter/AbstractMachine.swift
+++ b/Sources/FrontEnd/IR/AbstractInterpreter/AbstractMachine.swift
@@ -23,17 +23,17 @@ internal protocol AbstractTransferFunction {
   /// `typer` to compute type-related information.
   ///
   /// `c` is the context obtained by merging the contents of `predecessors`, which is a map from
-  /// a subset of the predecessors of `b` to their corresponding post-context. This map is only
+  /// a subset of the predecessors of `b` to their corresponding post-contexts. This map is only
   /// defined for the basic blocks that have been visited at least once.
   ///
-  /// The return value is a set containing the basic blocks that may have been modified during the
-  /// application of this method. Those blocks are placed back to the work list of the interpreter
-  /// during the computation of a fixed point.
+  /// The return value is the set of basic blocks that have been modified during the call, each of
+  /// which must be a predecessor of `b`. These blocks are moved to the work list of the abstract
+  /// interpreter during the computation of a fixed point, even if they have already been visited.
   mutating func apply(
     _ b: IRBlock.ID, from f: inout IRFunction, in c: inout Context,
     precededBy predecessors: SortedDictionary<IRBlock.ID, Context>,
     using typer: inout Typer
-  ) -> [IRBlock.ID]
+  ) -> IRBlockSet
 
 }
 
@@ -79,9 +79,6 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
   /// A FILO list of blocks to visit.
   private var work: Deque<IRBlock.ID> = []
 
-  /// The set of blocks that no longer need to be visited.
-  private var done: IRBlockSet = []
-
   /// Creates an instance for interpreting `f` with transfer function `interpret`.
   fileprivate init(interpreting f: IRFunction) {
     self.cfg = f.controlFlow()
@@ -96,17 +93,9 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
     with interpret: inout Transfer, _ typer: inout Typer,
     startingFrom initialContext: Transfer.Context
   ) -> Bool {
-    // Process the entry.
-    let entry = dominance.root
-    let (contextAfterEntry, _) = postContext(
-      of: entry, in: &f, precededBy: [:], mergedInto: initialContext,
-      using: &interpret, &typer)
-
-    state = [entry: (sources: [], pre: initialContext, contextAfterEntry)]
-    done.insert(entry)
-
-    // Enumerate the blocks to visit according to the dominance relation.
-    work = Deque(dominance.dropFirst())
+    // The dominance relation is a good heuristic to visit basic blocks in the right order.
+    work = Deque(dominance)
+    state = [:]
 
     // Search for a fixed point.
     var success = true
@@ -116,35 +105,36 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
         continue
       }
 
-      let (sources, before) = preContext(of: blockToProcess)
+      let (sources, before) = preContext(of: blockToProcess, root: initialContext)
 
       // Did the initial conditions of the block changed since the last time we processed it?
       if let s = state[blockToProcess], s.sources == sources.keys, s.pre == before {
-        if sources.count == cfg.predecessors(of: blockToProcess).count {
-          done.insert(blockToProcess)
-        } else {
+        if sources.count != cfg.predecessors(of: blockToProcess).count {
           work.append(blockToProcess)
         }
       }
 
       // If the initial conditions changed, interpret the block.
       else {
-        let (after, updated) = postContext(
+        let (after, updates) = postContext(
           of: blockToProcess, in: &f, precededBy: sources, mergedInto: before,
           using: &interpret, &typer)
         state[blockToProcess] = (sources: sources.keys, pre: before, post: after)
-        work.append(blockToProcess)
+        success = success && !after.containsError
 
-        // `updated` contains the blocks that have been modified by the transfer function and must
-        // be re-inserted into the work list, along with their successors.
-        var ls: [IRBlock.ID] = []
-        for u in updated {
-          state[u] = nil
-          if done.remove(u) != nil { ls.append(u) }
-        }
-        while let u = ls.popLast() {
-          work.append(u)
-          ls.append(contentsOf: cfg.successors(of: u).filter(done.contains(_:)))
+        if updates.isEmpty {
+          // No changes to other blocks; just schedule an additional visit.
+          if !after.containsError { work.append(blockToProcess) }
+        } else {
+          // Other blocks changed. The post context of each block reachable from a modified block
+          // has to be invalidated and a visit must be rescheduled.
+          let invalidated = f.blocks(reachableFrom: Array(updates.elements))
+          for b in invalidated.elements {
+            if let s = state[b], !s.post.containsError {
+              state[b] = nil
+              work.append(b)
+            }
+          }
         }
       }
     }
@@ -173,13 +163,16 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
     state[b] != nil
   }
 
-  /// Returns the pre-context of `b` and the predecessors from which it's been computed.
+  /// Returns the pre-context of `b` and the predecessors from which it's been computed iff `b` is
+  /// not the function's entry; otherwise, returns `initialContext`.
   ///
   /// - Requires: `isVisitable(b)` is `true`
   private func preContext(
-    of b: IRBlock.ID
+    of b: IRBlock.ID, root initialContext: Transfer.Context
   ) -> (sources: SortedDictionary<IRBlock.ID, Transfer.Context>, pre: Transfer.Context) {
-    assert(b != dominance.root, "entry shouldn't have any predecessor")
+    if b == dominance.root {
+      return ([:], initialContext)
+    }
 
     // If no predecessor has been visited yet, just create an empty context.
     let predecessors = cfg.predecessors(of: b)
@@ -214,10 +207,10 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
     precededBy predecessors: SortedDictionary<IRBlock.ID, Transfer.Context>,
     mergedInto initialContext: Transfer.Context,
     using interpret: inout Transfer, _ typer: inout Typer
-  ) -> (next: Transfer.Context, updated: [IRBlock.ID]) {
+  ) -> (next: Transfer.Context, updates: IRBlockSet) {
     var next = initialContext
-    let updated = interpret.apply(b, from: &f, in: &next, precededBy: predecessors, using: &typer)
-    return (next, updated)
+    let updates = interpret.apply(b, from: &f, in: &next, precededBy: predecessors, using: &typer)
+    return (next, updates)
   }
 
 }

--- a/Sources/FrontEnd/IR/AbstractInterpreter/AbstractMachine.swift
+++ b/Sources/FrontEnd/IR/AbstractInterpreter/AbstractMachine.swift
@@ -50,9 +50,9 @@ extension AbstractTransferFunction {
   internal mutating func fixedPoint(
     interpreting f: inout IRFunction, startingFrom initialContext: Context,
     using typer: inout Typer,
-  ) {
+  ) -> Bool {
     var m = AbstractMachine<Self>(interpreting: f)
-    m.fixedPoint(interpreting: &f, with: &self, &typer, startingFrom: initialContext)
+    return m.fixedPoint(interpreting: &f, with: &self, &typer, startingFrom: initialContext)
   }
 
 }
@@ -95,7 +95,7 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
     interpreting f: inout IRFunction,
     with interpret: inout Transfer, _ typer: inout Typer,
     startingFrom initialContext: Transfer.Context
-  ) {
+  ) -> Bool {
     // Process the entry.
     let entry = dominance.root
     let (contextAfterEntry, _) = postContext(
@@ -109,6 +109,7 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
     work = Deque(dominance.dropFirst())
 
     // Search for a fixed point.
+    var success = true
     while let blockToProcess = work.popFirst() {
       guard visitable(blockToProcess) else {
         work.append(blockToProcess)
@@ -147,6 +148,8 @@ internal struct AbstractMachine<Transfer: AbstractTransferFunction> {
         }
       }
     }
+
+    return success
   }
 
   /// Returns `true` if `b` is ready to be visited.

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -421,9 +421,14 @@ public struct IRFunction: Sendable {
     }
   }
 
-  /// Returns the set of basic blocks reachable from `b`, which includes `b`.
-  public func blocks(reachableFrom b: IRBlock.ID) -> IRBlockSet {
-    var work = [b]
+  /// Returns the set of basic blocks reachable from `root`, which includes `root`.
+  public func blocks(reachableFrom root: IRBlock.ID) -> IRBlockSet {
+    blocks(reachableFrom: [root])
+  }
+
+  /// Returns the set of basic blocks reachable from `roots`, which includes `roots`.
+  public func blocks(reachableFrom roots: [IRBlock.ID]) -> IRBlockSet {
+    var work = roots
     var reachable = IRBlockSet()
     while let w = work.popLast() {
       reachable.insert(w)

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -14,8 +14,8 @@ extension IRFunction {
     var transfer = Transfer(emittingInto: m)
     transfer.fixedPoint(interpreting: &self, startingFrom: initial, using: &typer)
 
-    assert(!transfer.didFoundError || typer.program[m].containsError, "undiagnosed error")
-    return !transfer.didFoundError
+    assert(!transfer.foundError || typer.program[m].containsError, "undiagnosed error")
+    return !transfer.foundError
   }
 
   /// Configures `context` with the initial state of `p`, which is the `i`-th parameter of `self`.
@@ -77,7 +77,7 @@ private struct Transfer: AbstractTransferFunction {
   private var context: Context = .init()
 
   /// `true` iff an application of this function raised an error.
-  fileprivate private(set) var didFoundError: Bool = false
+  fileprivate private(set) var foundError: Bool = false
 
   /// Creates an instance for interpreting the contents of `m`.
   fileprivate init(emittingInto m: Module.ID) {
@@ -310,7 +310,7 @@ private struct Transfer: AbstractTransferFunction {
 
   /// Reports the diagnostic `d`.
   private mutating func report(_ d: Diagnostic) {
-    if d.level == .error { didFoundError = true }
+    if d.level == .error { foundError = true }
     program[module].addDiagnostic(d)
   }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -88,7 +88,7 @@ private struct Transfer: AbstractTransferFunction {
     _ b: IRBlock.ID, from f: inout IRFunction, in c: inout Context,
     precededBy predecessors: SortedDictionary<IRBlock.ID, Context>,
     using typer: inout Typer
-  ) -> [IRBlock.ID] {
+  ) -> IRBlockSet {
     self.typer = consume typer
     swap(&context, &c)
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -12,10 +12,7 @@ extension IRFunction {
     }
 
     var transfer = Transfer(emittingInto: m)
-    transfer.fixedPoint(interpreting: &self, startingFrom: initial, using: &typer)
-
-    assert(!transfer.foundError || typer.program[m].containsError, "undiagnosed error")
-    return !transfer.foundError
+    return transfer.fixedPoint(interpreting: &self, startingFrom: initial, using: &typer)
   }
 
   /// Configures `context` with the initial state of `p`, which is the `i`-th parameter of `self`.
@@ -75,9 +72,6 @@ private struct Transfer: AbstractTransferFunction {
 
   /// The context being updated.
   private var context: Context = .init()
-
-  /// `true` iff an application of this function raised an error.
-  fileprivate private(set) var foundError: Bool = false
 
   /// Creates an instance for interpreting the contents of `m`.
   fileprivate init(emittingInto m: Module.ID) {
@@ -310,7 +304,7 @@ private struct Transfer: AbstractTransferFunction {
 
   /// Reports the diagnostic `d`.
   private mutating func report(_ d: Diagnostic) {
-    if d.level == .error { foundError = true }
+    if d.level == .error { context.setError() }
     program[module].addDiagnostic(d)
   }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -25,10 +25,7 @@ extension IRFunction {
     }
 
     var transfer = Transfer(emittingInto: m)
-    transfer.fixedPoint(interpreting: &self, startingFrom: initial, using: &typer)
-
-    assert(!transfer.foundError || typer.program[m].containsError, "undiagnosed error")
-    return !transfer.foundError
+    return transfer.fixedPoint(interpreting: &self, startingFrom: initial, using: &typer)
   }
 
   /// Configures `context` with the initial state of `p`, which is the `i`-th parameter of `self`.
@@ -59,9 +56,6 @@ private struct Transfer: AbstractTransferFunction {
 
   /// The context being updated.
   private var context: Context = .init()
-
-  /// `true` iff an application of this function raised an error.
-  fileprivate private(set) var foundError: Bool = false
 
   /// Creates an instance for interpreting the contents of `m`.
   fileprivate init(emittingInto m: Module.ID) {
@@ -903,7 +897,7 @@ private struct Transfer: AbstractTransferFunction {
 
     if !initialized.isEmpty {
       let success = deinitialize(initialized, at: place, before: i, in: &f)
-      if !success { foundError = true }
+      if !success { context.setError() }
       return success
     } else {
       return false
@@ -997,7 +991,7 @@ private struct Transfer: AbstractTransferFunction {
 
   /// Reports the diagnostic `d`.
   private mutating func report(_ d: Diagnostic) {
-    if d.level == .error { foundError = true }
+    if d.level == .error { context.setError() }
     program[module].addDiagnostic(d)
   }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -27,8 +27,8 @@ extension IRFunction {
     var transfer = Transfer(emittingInto: m)
     transfer.fixedPoint(interpreting: &self, startingFrom: initial, using: &typer)
 
-    assert(!transfer.didFoundError || typer.program[m].containsError, "undiagnosed error")
-    return !transfer.didFoundError
+    assert(!transfer.foundError || typer.program[m].containsError, "undiagnosed error")
+    return !transfer.foundError
   }
 
   /// Configures `context` with the initial state of `p`, which is the `i`-th parameter of `self`.
@@ -61,7 +61,7 @@ private struct Transfer: AbstractTransferFunction {
   private var context: Context = .init()
 
   /// `true` iff an application of this function raised an error.
-  fileprivate private(set) var didFoundError: Bool = false
+  fileprivate private(set) var foundError: Bool = false
 
   /// Creates an instance for interpreting the contents of `m`.
   fileprivate init(emittingInto m: Module.ID) {
@@ -903,7 +903,7 @@ private struct Transfer: AbstractTransferFunction {
 
     if !initialized.isEmpty {
       let success = deinitialize(initialized, at: place, before: i, in: &f)
-      if !success { didFoundError = true }
+      if !success { foundError = true }
       return success
     } else {
       return false
@@ -997,7 +997,7 @@ private struct Transfer: AbstractTransferFunction {
 
   /// Reports the diagnostic `d`.
   private mutating func report(_ d: Diagnostic) {
-    if d.level == .error { didFoundError = true }
+    if d.level == .error { foundError = true }
     program[module].addDiagnostic(d)
   }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -72,7 +72,7 @@ private struct Transfer: AbstractTransferFunction {
     _ b: IRBlock.ID, from f: inout IRFunction, in c: inout Context,
     precededBy predecessors: SortedDictionary<IRBlock.ID, Context>,
     using typer: inout Typer
-  ) -> [IRBlock.ID] {
+  ) -> IRBlockSet {
     self.typer = consume typer
     swap(&context, &c)
 
@@ -82,8 +82,8 @@ private struct Transfer: AbstractTransferFunction {
     }
 
     // Are there unstable states that need fixing?
-    let changed = stabilize(predecessors: predecessors, from: &f)
-    if !changed.isEmpty { return changed }
+    let modified = stabilize(predecessors: predecessors, from: &f)
+    if !modified.isEmpty { return modified }
 
     // Interpret the instructions of the block.
     var pc = f.blocks[b].first
@@ -160,8 +160,8 @@ private struct Transfer: AbstractTransferFunction {
   /// the basic blocks that have been modified, if any.
   private mutating func stabilize(
     predecessors: SortedDictionary<IRBlock.ID, Context>, from f: inout IRFunction
-  ) -> [IRBlock.ID] {
-    var changed: [IRBlock.ID] = []
+  ) -> IRBlockSet {
+    var changed: IRBlockSet = []
     for (k, v) in context.locals {
       switch v {
       case .object(let o):
@@ -174,7 +174,7 @@ private struct Transfer: AbstractTransferFunction {
           for (p, c) in predecessors {
             inContext(c) { (me) in
               if me.ensureDeinitialized(parts, at: k, before: f.blocks[p].last!, in: &f) {
-                changed.append(p)
+                changed.insert(p)
               }
             }
           }

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -131,8 +131,11 @@ public struct Program: Sendable {
         return ir.functions.values.endIndex
       }
 
-      // Mandatory intra-procedural passes.
+      // Apply mandatory intra-procedural passes.
       for i in work.indices {
+        // Make sure there are no silent errors.
+        defer { assert(work[i].function.isDefined || typer.program[m].containsError) }
+
         work[i].function.foldRedundantInstructions()
         work[i].function.simplifyControlFlow()
         work[i].function.removeCodeAfterNeverReturningCalls()

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -137,7 +137,6 @@ public struct Program: Sendable {
         defer { assert(work[i].function.isDefined || typer.program[m].containsError) }
 
         work[i].function.foldRedundantInstructions()
-        work[i].function.simplifyControlFlow()
         work[i].function.removeCodeAfterNeverReturningCalls()
         work[i].function.removeUnreachableBlocks()
         work[i].function.removedUnusedDefinitions()
@@ -152,6 +151,7 @@ public struct Program: Sendable {
         if !work[i].function.upholdInliningRequirements(in: m, using: &typer) { continue }
 
         // The following passes cannot fail.
+        work[i].function.simplifyControlFlow()
         work[i].function.depolymorphize(emittingInto: m, using: &typer)
         work[i].function.existentializeIfExposed(emittingInto: m, using: &typer)
 

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -136,6 +136,10 @@ public struct Program: Sendable {
         // Make sure there are no silent errors.
         defer { assert(work[i].function.isDefined || typer.program[m].containsError) }
 
+        // Dead code elimination and constant folding are performed early to reduce the amount of
+        // work fed to more expensive passes downstream. One exception is made for control-flow to
+        // limit the scope of non-local updates made during lifetime normalization.
+
         work[i].function.foldRedundantInstructions()
         work[i].function.removeCodeAfterNeverReturningCalls()
         work[i].function.removeUnreachableBlocks()

--- a/Tests/CompilerTests/negative/conditional-sink.diagnostics.expected
+++ b/Tests/CompilerTests/negative/conditional-sink.diagnostics.expected
@@ -1,0 +1,3 @@
+negative/conditional-sink.hylo:8.8-14: error: use of consumed object
+  while x > 0 { _ = x }
+       ~~~~~~

--- a/Tests/CompilerTests/negative/conditional-sink.hylo
+++ b/Tests/CompilerTests/negative/conditional-sink.hylo
@@ -1,0 +1,9 @@
+fun f0(x: sink Int) {
+  // Deinitialization is inserted in the else branch of the condition.
+  if x > 0 { _ = x }
+}
+
+fun f1(x: sink Int) {
+  // Deinitialization is inserted before the loop, revealing an illegal use.
+  while x > 0 { _ = x }
+}

--- a/Tests/CompilerTests/negative/exclusivity-violation.diagnostics.expected
+++ b/Tests/CompilerTests/negative/exclusivity-violation.diagnostics.expected
@@ -1,0 +1,18 @@
+negative/exclusivity-violation.hylo:18.3-13: error: illegal 'inout' access
+  modify(&w)  // error
+  ~~~~~~~~~~
+negative/exclusivity-violation.hylo:20.3-13: error: illegal 'inout' access
+  modify(&x)  // error
+  ~~~~~~~~~~
+negative/exclusivity-violation.hylo:33.3-9: error: illegal 'let' access
+  use(w)      // error
+  ~~~~~~
+negative/exclusivity-violation.hylo:34.3-13: error: illegal 'inout' access
+  modify(&w)  // error
+  ~~~~~~~~~~
+negative/exclusivity-violation.hylo:35.3-9: error: illegal 'let' access
+  use(x)      // error
+  ~~~~~~
+negative/exclusivity-violation.hylo:36.3-13: error: illegal 'inout' access
+  modify(&x)  // error
+  ~~~~~~~~~~

--- a/Tests/CompilerTests/negative/exclusivity-violation.hylo
+++ b/Tests/CompilerTests/negative/exclusivity-violation.hylo
@@ -1,0 +1,45 @@
+subscript either(x: auto Int, y: auto Int) auto -> Int {
+  let { x }
+  inout { &x }
+}
+
+fun use(x: Int) {}
+
+fun modify(x: inout Int) {}
+
+public fun main() {
+  var w = 0
+  var x = 0
+
+  // lifetime of y starts here
+  let y = either[w, x]
+
+  use(w)      // OK
+  modify(&w)  // error
+  use(x)      // OK
+  modify(&x)  // error
+
+  use(y)
+  // lifetime of y ends here
+
+  use(w)      // OK
+  modify(&w)  // OK
+  use(x)      // OK
+  modify(&x)  // OK
+
+  // lifetime of z starts here
+  inout z = either[&w, &x]
+
+  use(w)      // error
+  modify(&w)  // error
+  use(x)      // error
+  modify(&x)  // error
+
+  modify(&z)
+  // lifetime of z ends here
+
+  use(w)      // OK
+  modify(&w)  // OK
+  use(x)      // OK
+  modify(&x)  // OK
+}


### PR DESCRIPTION
This patch fixes #418.

The main interesting commit is da4ae7033706eeb122b845de7ac6de947daa66e9, which refactors the fixed point computation algorithm to remove the assumption that the entry of a function can never be visited twice. This assumption is incorrect in cases where lifetime normalization has to insert implicit deinitialization in the predecessors of a basic block.

In the bug report, this situation was observed with the following function:

```hylo
fun consume_conditionally(c: Bool, x: sink Int) {
  if c { sink let y = x }
}
```

Because `x` is deinitialized in only one branch of the conditional, lifetime normalization inserts a call to `deinit` in the basic block preceding the basic block returning from the function. The former happens to be the function's entry, violating the assumption.

da4ae7033706eeb122b845de7ac6de947daa66e9 also moves control flow simplification *after* lifetime normalization in an effort to limit the scope of non-local updates caused by implicit deinitialization. In the above example, the simplification pass gets rid of the second branch of the conditional expression which because it is empty. As a result, the entry becomes predecessor of the last basic block in the function. By delaying control flow simplification, the basic block representing the second branch is preserved and be modified to deinitialize `x` implicitly.

Incidentally, this patch also fixed #379.