### PR TITLE
Fix devcontainer setup on Windows without explicit LLVM_BUILD_TYPE

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,4 @@
 ARG HYLO_LLVM_BUILD_TYPE=MinSizeRel
-FROM ghcr.io/hylo-lang/hylo-dev-toolchain:v1.0.2-${HYLO_LLVM_BUILD_TYPE}
+
+# Resolves empty string to MinSizeRel.
+FROM ghcr.io/hylo-lang/hylo-dev-toolchain:v1.0.2-${HYLO_LLVM_BUILD_TYPE:-MinSizeRel}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "SWIFT_VERSION" : "6.3.2",
             "HYLO_LLVM_BUILD_TYPE": "${localEnv:HYLO_LLVM_BUILD_TYPE:MinSizeRel}"
         }
     },
@@ -42,12 +41,6 @@
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
-    "containerEnv": {
-        "HYLO_LLVM_BUILD_TYPE": "${localEnv:HYLO_LLVM_BUILD_TYPE:MinSizeRel}"
-    },
-    "remoteEnv": {
-        "PATH": "/python-venv/bin:/opt/llvm-${containerEnv:HYLO_LLVM_BUILD_TYPE}/bin:${containerEnv:PATH}"
-    },
     // "postCreateCommand": "sudo ./.devcontainer/postCreateCommand.sh",
     // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "ubuntu"


### PR DESCRIPTION
The issue was probably with the default value substitution on the devcontainer side, where an empty string got inputted. I changed the Dockerfile logic to use a default even when an empty string is given.

Fixes https://github.com/hylo-lang/hylo-new/issues/237