### PR TITLE
Extend Pointer, add PointerToMutable

### DIFF
--- a/StandardLibrary/Sources/Core/Pointer.hylo
+++ b/StandardLibrary/Sources/Core/Pointer.hylo
@@ -1,16 +1,110 @@
-/// A typed memory address whose contents can be read.
+/// A typed pointer whose contents can be read.
 public struct Pointer<Pointee> is Deinitializable {
 
   /// The raw value of this instance.
-  module var value: Builtin.ptr
+  module var base: Builtin.ptr
 
-  /// Creates an instance with the given raw value.
+  /// Creates an instance from its raw value.
   module memberwise init
 
-  /// Creates an instance that does not address any usable storage.
-  public static fun null() -> Self {
-    .new(value: Builtin.zeroinitializer_ptr())
-
+  /// The value at the address represented by `self`.
+  ///
+  /// - Requires: `self` is the address of an object of type `Pointee` and its storage
+  ///     is accessed only through this projection during the projection's lifetime.
+  @inline(always)
+  public subscript unsafe() -> Pointee {
+    yield self.base as* (let Pointee)
   }
 
+  // /// Creates an instance with the same memory representation as `address`.
+  // ///  TODO design int to pointer semantics. https://github.com/hylo-lang/hylo-new/issues/438
+  // public init(bit_pattern address: UInt) {
+  //   &self.base = Builtin.inttoptr_word(address.value)
+  // }
+
+  /// Creates an instance representing the same pointer as `p`.
+  @inline(always)
+  public init(_ p: PointerToMutable<Pointee>) {
+    &self.base = p.base
+  }
+
+  /// Creates an instance referring to the same address as `p`.
+  ///
+  /// Note that dereferencing type punned pointers will cause problems unless the rules for
+  /// `usafe[]` (which see) are followed.
+  @inline(always)
+  public init<Other>(type_punning p: Pointer<Other>) {
+    &self.base = p.base
+  }
+
+  /// Creates an instance referring to the same address as `p`.
+  ///
+  /// Note that dereferencing type punned pointers will cause problems unless the rules for the
+  /// `usafe[]` subscript (which see) are followed.
+  @inline(always)
+  public init<Other>(type_punning p: PointerToMutable<Other>) {
+    &self.base = p.base
+  }
+
+  // /// Projects a copy of `self` as a raw memory address.
+  // /// TODO design raw memory address representation.
+  // @inline(always)
+  // public subscript raw() -> PointerToMutable<Never> {
+  //   yield PointerToMutable<Never>(base: self.base)
+  // }
+
+  // /// Creates an instance with the same memory representation as `address`.
+  // ///  TODO design int to pointer semantics. https://github.com/hylo-lang/hylo-new/issues/438
+  // @inline(always)
+  // public init(bit_pattern address: Int) {
+  //   &self.base = Builtin.inttoptr_word(address.value)
+  // }
+
+  // /// Returns `self` offset forward by `n` array elements of `Pointee` type.
+  // public fun advance(by n: Int) -> Self {
+  //   let offset_in_bytes = MemoryLayout<Pointee>.stride() * n
+  //   return Pointer<Pointee>.new(
+  //     self.base: Builtin.advanced_by_bytes_word(self.base, offset_in_bytes.value))
+  // }
+
+  /// Creates an instance that does not address any usable storage.
+  @inline(always)
+  public static fun null() -> Self {
+    .new(base: Builtin.zeroinitializer_ptr())
+  }
+
+  // MARK: Copyable conformance.
+
+  /// Returns an equivalent instance.
+  @inline(always)
+  public fun copy() -> Self {
+    .new(base: self.base)
+  }
+
+  // MARK: Conformance to Equatable.
+
+  /// Returns `true` iff `other` has an equivalent value.
+  @inline(always)
+  public fun infix== (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_eq_ptr(self.base, other.base))
+  }
+
+  /// Returns `false` iff `other` has an equivalent value.
+  @inline(always)
+  public fun infix!= (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_ne_ptr(self.base, other.base))
+  }
+
+}
+
+public given <T> => Pointer<T> is Movable {}
+
+public given <T> => Pointer<T> is Copyable {}
+
+public given <T> => Pointer<T> is Equatable {}
+
+/// Yields a pointer to `x`.
+@inline(always)
+public subscript pointer<T>(to x: T) -> Pointer<T> {
+  yield Pointer(base: Builtin.address(of: x))
 }

--- a/StandardLibrary/Sources/Core/PointerToMutable.hylo
+++ b/StandardLibrary/Sources/Core/PointerToMutable.hylo
@@ -1,0 +1,197 @@
+/// A typed pointer whose contents can be read and written.
+public struct PointerToMutable<Pointee> is Deinitializable {
+
+  /// The raw bits of the address.
+  module var base: Builtin.ptr
+
+  /// Creates an instance from its raw value.
+  memberwise init
+
+  /// The value at the address represented by `self`.
+  ///
+  /// - Requires: the address stores an object of type Pointee.
+  @inline(always)
+  public subscript unsafe() auto -> Pointee {
+    /// - Requires: nothing mutates the value's storage during this projection's lifetime.
+    let { yield (self.base as* (let Pointee)) }
+
+    /// - Requires: the value is mutable, and nothing accesses its
+    ///   storage except through this projection during its lifetime.
+    inout { yield &(self.base as* (inout Pointee)) }
+
+    // TODO: https://github.com/hylo-lang/hylo-new/issues/447
+    //       https://github.com/orgs/hylo-lang/discussions/1825#discussioncomment-17956070
+    // set where Pointee is Deinitializable {
+    //   inout s = &self.unsafe[]
+    //   &s.deinit()
+    //   yield &s
+    // }
+  }
+
+  // /// Creates an instance with the same memory representation as `address`.
+  // ///  TODO design int to pointer semantics. https://github.com/hylo-lang/hylo-new/issues/438
+  // public init(bit_pattern address: UInt) { 
+  //   &self.base = Builtin.inttoptr_word(address.value)
+  // }
+
+  /// Creates an instance with mutable access to the memory pointed to by `p`.
+  ///
+  /// - Warning: while this initializer is not in itself unsafe, it should be used with caution.
+  @inline(always)
+  public init(adding_mutation_to p: Pointer<Pointee>) {
+    &self.base = p.base
+  }
+
+  /// Creates an instance referring to the same address as `p`.
+  ///
+  /// Note that dereferencing type-punned pointers will cause problems unless the rules for
+  /// `unsafe[]` (which see) are followed.
+  @inline(always)
+  public init<Other>(type_punning p: PointerToMutable<Other>) {
+    &self.base = p.base
+  }
+
+  // /// Projects a copy of `self` as a raw memory address.
+  // /// TODO design raw memory address representation.
+  // @inline(always)
+  // public subscript raw() -> Pointer<Never> {
+  //   yield Pointer<Never>(base: self.base)
+  // }
+
+  // /// Creates an instance with the same memory representation as `address`.
+  // ///  TODO design int to pointer semantics. https://github.com/hylo-lang/hylo-new/issues/438
+  // @inline(always)
+  // public init(bit_pattern address: Int) {
+  //   &self.base = Builtin.inttoptr_word(address.value)
+  // }
+
+  // /// Returns `self` offset forward by `n` array elements of `Pointee` type.
+  // @inline(always)
+  // public fun advance(by n: Int) -> Self {
+  //   // TODO implement MemoryLayout<T> or equivalent.
+  //   // let offset_in_bytes = Pointee.layout.stride() * n
+  //   // return PointerToMutable<Pointee>.new(
+  //   //   self.base: Builtin.advanced_by_bytes_word(self.base, offset_in_bytes.value))
+  // }
+
+  /// Creates an instance that does not address any usable storage.
+  @inline(always)
+  public static fun null() -> Self {
+    .new(base: Builtin.zeroinitializer_ptr())
+  }
+
+  // /// Returns the result of applying `initialize` to the uninitialized `Pointee` storage.
+  // ///
+  // /// - Requires: the `MemoryLayout<Pointee>.size()` bytes starting at the address are uninitialized
+  // ///   and suitably aligned for `Pointee`.
+  // /// TODO enable after fixing https://github.com/hylo-lang/hylo-new/issues/384
+  // @inline(always)
+  // public fun unsafe_initialize_pointee<E, R>(_ initialize: inout [E](set Pointee) inout -> R) -> R {
+  //   initialize(&(self.base as* (set Pointee)))
+  // }
+
+  // /// Initializes the memory referenced by `count` consecutive bytewise copies of `value`.
+  // @inline(always)
+  // public fun unsafe_initialize(copying_bytes_from source: Pointer<Pointee>, count: Int) {
+  //   var i = 0
+  //   var s = Pointer<Int8>(type_punning: source)
+  //   var d = PointerToMutable<Int8>(type_punning: self)
+
+  //   let byte_count = MemoryLayout<Pointee>.stride() * count
+  //   while i < byte_count {
+  //     d.unsafe_initialize_pointee(s.unsafe[].copy())
+  //     &s = s.advance(by: 1)
+  //     &d = d.advance(by: 1)
+  //     &i += 1
+  //   }
+  // }
+
+
+  // MARK: Copyable conformance.
+
+  /// Returns an equivalent instance.
+  ///
+  /// Because we don't have a `nonmutating` keyword yet, writing to the pointee of a `let`-bound
+  /// `PointerToMutable` is only possible by copying, e.g.  `&p.copy().unsafe[] = x`.
+  @inline(always)
+  public fun copy() -> Self {
+    PointerToMutable(base: self.base)
+  }
+
+  // MARK: Conformance to Equatable.
+
+  /// Returns `true` iff `other` has an equivalent value.
+  @inline(always)
+  public fun infix== (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_eq_ptr(self.base, other.base))
+  }
+
+  /// Returns `false` iff `other` has an equivalent value.
+  @inline(always)
+  public fun infix!= (other: Self) -> Bool {
+    Bool(value: Builtin.icmp_ne_ptr(self.base, other.base))
+  }
+
+}
+
+public given <T> => PointerToMutable<T> is Movable {}
+
+public given <T> => PointerToMutable<T> is Copyable {}
+
+public given <T> => PointerToMutable<T> is Equatable {}
+
+extension <Pointee is Movable> PointerToMutable<Pointee> {
+
+  /// Returns the value at the address represented by `self`, leaving the storage at this address
+  /// uninitialized.
+  ///
+  /// Note: This method should be deprecated once nonmutating subscripts are implemented.
+  @inline(always)
+  public fun unsafe_pointee() -> Pointee {
+    self.base as* (sink Pointee)
+  }
+
+}
+
+extension <Pointee is Movable> PointerToMutable<Pointee> {
+
+  /// Initializes the value at the address represented by `self` to `value`.
+  ///
+  /// - Requires: the `MemoryLayout<Pointee>.size()` bytes starting at the address are uninitialized
+  ///   and suitably aligned for `Pointee`.
+  @inline(always)
+  public fun unsafe_initialize_pointee(value: sink Pointee) {
+    &(self.base as* (set Pointee)) = value
+  }
+
+}
+
+extension <Pointee is Deinitializable> PointerToMutable<Pointee> {
+
+  /// Deinitializes the value at the address represented by `self`.
+  @inline(always)
+  public fun unsafe_deinitialize_pointee() {
+    (self.base as* (sink Pointee)).deinit()
+  }
+
+}
+
+// extension <Pointee is Copyable> PointerToMutable<Pointee>  {
+
+//   /// Initializes the memory referenced by `self` with `count` consecutive copies of `value`.
+//   @inline(always)
+//   public fun unsafe_initialize(repeating value: Pointee, count: Int) {
+//     var i = 0
+//     while i < count {
+//       self.advance(by: i).unsafe_initialize_pointee(value.copy())
+//       &i += 1
+//     }
+//   }
+
+// }
+
+/// Yields a pointer to the mutable `x`.
+@inline(always)
+public subscript pointer<T>(to_mutable x: inout T) -> PointerToMutable<T> {
+  yield PointerToMutable(base: Builtin.address(of: x))
+}

--- a/StandardLibrary/Sources/Core/Runtime/OffsetOfMember.hylo
+++ b/StandardLibrary/Sources/Core/Runtime/OffsetOfMember.hylo
@@ -54,7 +54,7 @@ extension Pointer<UInt8> {
   // and https://github.com/hylo-lang/hylo-new/issues/365
   /// Initializes `self` to the null pointer.
   public init() {
-    &self.value = Builtin.zeroinitializer_ptr()
+    &self.base = Builtin.zeroinitializer_ptr()
   }
 
 }
@@ -89,30 +89,30 @@ extension Pointer<TypeWitnessHeader> {
 
   @inline(always)
   public fun copy() -> Self {
-    .new(value: self.value)
+    .new(base: self.base)
   }
 
   /// Returns the size of an instance.
   @inline(always)
   public fun size() -> Size {
-    (self.value as* let Self.Pointee).size.copy()
+    (self.base as* let Self.Pointee).size.copy()
   }
 
   /// Returns the alignment of an instance.
   @inline(always)
   public fun alignment() -> Alignment {
-    (self.value as* let Self.Pointee).alignment.copy()
+    (self.base as* let Self.Pointee).alignment.copy()
   }
 
   @inline(always)
   public fun infix+ (offset: Int) -> Self {
     let byte_offset = Int(Metatype<TypeWitnessHeader>.stride()) * offset
-    return Self(value: Builtin.advanced_by_bytes_word(self.value, byte_offset.value))
+    return Self(base: Builtin.advanced_by_bytes_word(self.base, byte_offset.value))
   }
 
   @inline(always)
   public fun infix+= (offset: Int) inout {
-    &self.value = (self + offset).value
+    &self.base = (self + offset).base
   }
 
 }
@@ -158,19 +158,19 @@ extension Pointer<RecordMemberType> {
 
   @inline(always)
   public fun pointee() -> Pointee {
-    (self.value as* let Self.Pointee).copy()
+    (self.base as* let Self.Pointee).copy()
   }
 
   /// Replaces the pointee with `x`.
   @inline(always)
   public fun set_pointee(x: sink Self.Pointee) {
     // Hack: can't seem to move x, even when take_value implemented manually.
-    &(self.value as* inout Self.Pointee).value = x.value
+    &(self.base as* inout Self.Pointee).base = x.base
   }
 
   @inline(always)
   public fun copy() -> Self {
-    .new(value: self.value)
+    .new(base: self.base)
   }
 
 }
@@ -182,7 +182,7 @@ extension Metatype<TypeWitnessHeader> {
   /// Returns `self`, granting access to details.
   @inline(always)
   public static fun type_info() -> RecordMemberType {
-    return Pointer<RecordMemberType>(value: Builtin.address(of: Subject)).pointee()
+    return Pointer<RecordMemberType>(base: Builtin.address(of: Subject)).pointee()
   }
 
   /// Returns the size in bytes of the `Subject`.
@@ -212,7 +212,7 @@ extension Metatype<RecordMemberType> {
   /// Returns `self`, granting access to details.
   @inline(always)
   public static fun type_info() -> RecordMemberType {
-    return Pointer<RecordMemberType>(value: Builtin.address(of: Subject)).pointee()
+    return Pointer<RecordMemberType>(base: Builtin.address(of: Subject)).pointee()
   }
 
   /// Returns the size in bytes of the `Subject`.
@@ -241,32 +241,32 @@ extension Pointer<RecordMemberType> {
   @inline(always)
   public fun infix+ (offset: Int) -> Self {
     let byte_offset = Int(Metatype<Self.Pointee>.stride()) * offset
-    return Self(value: Builtin.advanced_by_bytes_word(self.value, byte_offset.value))
+    return Self(base: Builtin.advanced_by_bytes_word(self.base, byte_offset.value))
   }
 
   /// Advances `self` in memory by `offset` `Pointee`s.
   @inline(always)
   public fun infix+= (offset: Int) inout {
-    &self.value = (self + offset).value
+    &self.base = (self + offset).base
   }
 
   /// Returns `self` advanced in memory by `-offset` `Pointee`s.
   @inline(always)
   public fun infix- (offset: Int) -> Self {
     let byte_offset = Int(Metatype<Self.Pointee>.stride()) * (0 - offset)
-    return Self(value: Builtin.advanced_by_bytes_word(self.value, byte_offset.value))
+    return Self(base: Builtin.advanced_by_bytes_word(self.base, byte_offset.value))
   }
 
   /// Advances `self` in memory by `-offset` `Pointee`s.
   @inline(always)
   public fun infix-= (offset: Int) inout {
-    &self.value = (self - offset).value
+    &self.base = (self - offset).base
   }
 
   /// Returns `true` iff `other` has an equivalent value.
   @inline(always)
   public fun infix== (other: Self) -> Bool {
-    Bool(value: Builtin.icmp_eq_ptr(self.value, other.value))
+    Bool(value: Builtin.icmp_eq_ptr(self.base, other.base))
   }
 
   /// Returns `false` iff `other` has an equivalent value.
@@ -278,7 +278,7 @@ extension Pointer<RecordMemberType> {
   /// Returns `true` iff `other` follows `self` in memory.
   @inline(always)
   public fun infix< (other: Self) -> Bool {
-    Bool(value: Builtin.icmp_ult_ptr(self.value, other.value))
+    Bool(value: Builtin.icmp_ult_ptr(self.base, other.base))
   }
 
 }
@@ -290,7 +290,7 @@ extension Metatype<Pointer<UInt8>> {
   /// Returns `self`, granting access to details.
   @inline(always)
   public static fun type_info() -> Pointer<TypeWitnessHeader> {
-    return Pointer<Pointer<TypeWitnessHeader>>(value: Builtin.address(of: Subject)).pointee()
+    return Pointer<Pointer<TypeWitnessHeader>>(base: Builtin.address(of: Subject)).pointee()
   }
 
   /// Returns the multiple of bytes to which all instances of `Subject` are aligned.
@@ -308,7 +308,7 @@ extension Metatype<UInt32> {
   /// Returns `self`, granting access to details.
   @inline(always)
   public static fun type_info() -> Pointer<TypeWitnessHeader> {
-    return Pointer<Pointer<TypeWitnessHeader>>(value: Builtin.address(of: Subject)).pointee()
+    return Pointer<Pointer<TypeWitnessHeader>>(base: Builtin.address(of: Subject)).pointee()
   }
 
   /// Returns the multiple of bytes to which all instances of `Subject` are aligned.
@@ -326,7 +326,7 @@ extension Metatype<UInt16> {
   /// Returns `self`, granting access to details.
   @inline(always)
   public static fun type_info() -> Pointer<TypeWitnessHeader> {
-    return Pointer<Pointer<TypeWitnessHeader>>(value: Builtin.address(of: Subject)).pointee()
+    return Pointer<Pointer<TypeWitnessHeader>>(base: Builtin.address(of: Subject)).pointee()
   }
 
   /// Returns the multiple of bytes to which all instances of `Subject` are aligned.
@@ -379,7 +379,7 @@ public fun open_hole_at_start(
   while e != start {
     let e0 = e - 1
     e.set_pointee(e0.pointee().copy())
-    &e.value = e0.value
+    &e.base = e0.base
   }
   &end += 1
 }
@@ -478,7 +478,7 @@ public fun stable_sort_by_decreasing_alignment(
       where_alignment_exceeds: a - (1 as Alignment),
       into_range_from: start, until: &new_end)
 
-    &tail_start.value = (p + 1).value
+    &tail_start.base = (p + 1).base
   }
   else {
     // Drop unretained elements after p
@@ -491,8 +491,8 @@ public fun stable_sort_by_decreasing_alignment(
       return
     }
 
-    &new_end.value = (start + 1).value
-    &tail_start.value = new_end.value
+    &new_end.base = (start + 1).base
+    &tail_start.base = new_end.base
   }
 
   // insert elements after p
@@ -501,7 +501,7 @@ public fun stable_sort_by_decreasing_alignment(
     where_alignment_exceeds: a,
     into_range_from: start, until: &new_end)
 
-  &end.value = new_end.value
+  &end.base = new_end.base
 }
 
 /// Returns the size of a record type would have were its members given

--- a/StandardLibrary/Sources/hylo-project.json
+++ b/StandardLibrary/Sources/hylo-project.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "generator": "cmake/HyloProjectManifest.cmake",
+  "stdlibRoot": "/home/ambrus/CMake/hylo-new/StandardLibrary/Sources",
+  "target": "",
+  "modules": [
+    {
+      "name": "Hylo",
+      "imports": [],
+      "sourceRoot": "Core"
+    }
+  ]
+}

--- a/Tests/CompilerTests/positive/metatype-address.hylo
+++ b/Tests/CompilerTests/positive/metatype-address.hylo
@@ -18,7 +18,7 @@ public fun main() -> Int32 {
   let h = Builtin.address(of: Victim) as* (let Pointer<TypeWitnessHeader>)
 
   // Access as value (`.unsafe[]`).
-  let w = h.value as* (let TypeWitnessHeader)
+  let w = h.base as* (let TypeWitnessHeader)
 
   // `Victim` occupies 6 bytes, so this exits with 0.
   return Int32(value: w.size.value) - (6 as Int32)

--- a/Tests/CompilerTests/positive/runtime-offset-of-member.package/runtime-offset-of-member.hylo
+++ b/Tests/CompilerTests/positive/runtime-offset-of-member.package/runtime-offset-of-member.hylo
@@ -9,7 +9,7 @@ extension Pointer<UInt8> {
   // and https://github.com/hylo-lang/hylo-new/issues/365
   /// Initializes s to the null pointer.
   static fun null_(s: set Self) {
-    &s.value = Builtin.zeroinitializer_ptr()
+    &s.base = Builtin.zeroinitializer_ptr()
   }
 
 }
@@ -20,7 +20,7 @@ extension Metatype<Int> {
 
   /// Returns `self`, granting access to details.
   static fun type_info() -> Pointer<TypeWitnessHeader> {
-    return Pointer<Pointer<TypeWitnessHeader>>(value: Builtin.address(of: Subject)).pointee()
+    return Pointer<Pointer<TypeWitnessHeader>>(base: Builtin.address(of: Subject)).pointee()
   }
 
   /// Returns the size in bytes of the `Subject`.
@@ -46,15 +46,15 @@ extension Pointer<Int> {
 
   public fun infix+ (offset: Int) -> Self {
     let byte_offset = Int(Metatype<Self.Pointee>.stride()) * offset
-    return Self(value: Builtin.advanced_by_bytes_word(self.value, byte_offset.value))
+    return Self(base: Builtin.advanced_by_bytes_word(self.base, byte_offset.value))
   }
 
   public fun infix+= (offset: Int) inout {
-    &self.value = (self + offset).value
+    &self.base = (self + offset).base
   }
 
   fun pointee() -> Pointee {
-    .new(value: (self.value as* let Self.Pointee).value)
+    .new(value: (self.base as* let Self.Pointee).value)
   }
 
   fun at(n: Int) -> Pointee {
@@ -93,13 +93,13 @@ fun verify_offset(
   of_length l: Int,
   to_be x: Int
 ) {
-  let p = Pointer<H>(value: Builtin.address(of: headers))
+  let p = Pointer<H>(base: Builtin.address(of: headers))
   var witnesses: Pointer<TypeWitnessHeader>[10] = (
     p + 0, p + 1, p + 2, p + 3, p + 4, p + 5, p + 6, p + 7, p + 8, p + 9)
 
   let o = __hylo_offset_of_member(
     .new(truncating: i),
-    in: .new(value: Builtin.address(of: witnesses)),
+    in: .new(base: Builtin.address(of: witnesses)),
     of_length: .new(truncating: l))
 
   precondition(o == UInt32(truncating: x))
@@ -164,9 +164,9 @@ fun main() -> Int32 {
     }
     if l > 10 { return -8 }
 
-    let s = Pointer<Int>(value: Builtin.address(of: sizes))
-    let a = Pointer<Int>(value: Builtin.address(of: alignments))
-    let o = Pointer<Int>(value: Builtin.address(of: offsets))
+    let s = Pointer<Int>(base: Builtin.address(of: sizes))
+    let a = Pointer<Int>(base: Builtin.address(of: alignments))
+    let o = Pointer<Int>(base: Builtin.address(of: offsets))
     verify_offsets(
       in: (
         H(s.at(0), a.at(0)),

--- a/Tests/CompilerTests/positive/standard-library.hylo
+++ b/Tests/CompilerTests/positive/standard-library.hylo
@@ -1,0 +1,25 @@
+fun test_pointers() {
+  var x: Int = 3
+  let p: Pointer<Int> = pointer_[to: x]
+  precondition(p.unsafe[] == (3 as Int))
+
+  let r: PointerToMutable<Int> = pointer_[to_mutable: &x]
+  precondition(r.unsafe[] == (3 as Int))
+
+  r.unsafe_deinitialize_pointee()
+  r.unsafe_initialize_pointee(42 as Int)
+  
+  precondition(x == (42 as Int))
+}
+
+subscript pointer_<T>(to x: T) -> Pointer<T> {
+  yield Pointer(base: Builtin.address(of: x))
+}
+
+subscript pointer_<T>(to_mutable x: inout T) -> PointerToMutable<T> {
+  yield PointerToMutable(base: Builtin.address(of: x))
+}
+
+public fun main() {
+  test_pointers()
+}


### PR DESCRIPTION
Pulling implementations from OFE while keeping functions where pointer vs address distinction is important out of scope of this PR.