### PR TITLE
Fix storing the result of a sink subscript

### DIFF
--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -747,10 +747,11 @@ internal struct IREmitter {
     }
 
     // Are we lowering a subscript application?
-    else if program[e].style == .bracketed {
-      // Move the projected result into `target`.
+    else {
       let y = lower(lvalue: e)
-      lowering(e, { $0._emitMove([.inout, .set], y, to: target) })
+      if program[e].style == .bracketed {
+        lowering(e, { $0._emitMove([.inout, .set], y, to: target) })
+      }
     }
 
     // Are we lowering an ordinary call?

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -746,6 +746,13 @@ internal struct IREmitter {
       lower(memberwiseInitialization: e, of: target)
     }
 
+    // Are we lowering a subscript application?
+    else if program[e].style == .bracketed {
+      // Move the projected result into `target`.
+      let y = lower(lvalue: e)
+      lowering(e, { $0._emitMove([.inout, .set], y, to: target) })
+    }
+
     // Are we lowering an ordinary call?
     else {
       lower(call: e, output: target)
@@ -1261,6 +1268,9 @@ internal struct IREmitter {
   /// The callee of `e` is the expression of a function or subscript other than a built-in function
   /// or scalar conversion. If `e` is an ordinary function call, `target` is the place in which the
   /// result of the call is written. Otherwise, it is a poison value.
+  ///
+  /// - Returns: a place holding the result of the call: for a function call, the place into which
+  ///   the callee writes its result; for a subscript call, the resulting projection.
   @discardableResult
   private mutating func lower(call e: Call.ID, output target: IRValue) -> IRValue {
     // Compute the value of the callee, which may be a function or subscript.
@@ -1289,7 +1299,7 @@ internal struct IREmitter {
 
     return lowering(e) { (me) in
       // Form accesses on the parameters right before the call. Note that we won't close these
-      // accesses here because, if the callee is a subscript, then the lifetimes the parameters'
+      // accesses here because, if the callee is a subscript, then the lifetimes of the parameters'
       // accesses have to cover all uses of the projected value, which are not known yet. We'll
       // delay the work until lifetime analysis instead.
       if me.program[e].style == .parenthesized {

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -747,14 +747,12 @@ internal struct IREmitter {
     }
 
     // Are we lowering a subscript application?
-    else {
-      let y = lower(lvalue: e)
-      if program[e].style == .bracketed {
-        lowering(e, { $0._emitMove([.inout, .set], y, to: target) })
-      }
+    else if program[e].style == .bracketed {
+      let y = lower(call: e, output: .poison(.place(.error)))
+      lowering(e, { $0._emitMove([.inout, .set], y, to: target) })
     }
 
-    // Are we lowering an ordinary call?
+    // Otherwise lower a function call.
     else {
       lower(call: e, output: target)
     }

--- a/Tests/CompilerTests/negative/illegal-move-sink-subscript.diagnostics.expected
+++ b/Tests/CompilerTests/negative/illegal-move-sink-subscript.diagnostics.expected
@@ -1,0 +1,9 @@
+negative/illegal-move-sink-subscript.hylo:13.11-16: error: no given instance of 'Movable<S>' in this scope
+  var a = id[y] // Attempt to move the result to new storage.
+          ~~~~~
+negative/illegal-move-sink-subscript.hylo:14.10-13: error: illegal move
+  return a.x
+         ~~~
+negative/illegal-move-sink-subscript.hylo:14.10-13: error: use of uninitialized object
+  return a.x
+         ~~~

--- a/Tests/CompilerTests/negative/illegal-move-sink-subscript.hylo
+++ b/Tests/CompilerTests/negative/illegal-move-sink-subscript.hylo
@@ -1,0 +1,15 @@
+struct S is Deinitializable {
+  var x: Int32
+  memberwise init
+}
+
+/// A `sink` subscript projects an owned value that the caller may move into new storage.
+subscript id(x: sink S) sink -> S {
+  yield &x
+}
+
+fun main() -> Int32 {
+  var y = S(x: 42 as Int32)
+  var a = id[y] // Attempt to move the result to new storage.
+  return a.x
+}

--- a/Tests/CompilerTests/positive/sink-subscript-locally-movable.hylo
+++ b/Tests/CompilerTests/positive/sink-subscript-locally-movable.hylo
@@ -1,0 +1,22 @@
+//! stage:llvm
+// TODO: move test case into ./sink-subscript.hylo once local conformances compile.
+
+struct S is Deinitializable {
+  var x: Int32
+  memberwise init
+}
+
+subscript id(x: sink S) sink -> S { yield &x }
+
+fun test_locally_movable() {
+  // It's OK if S is only Movable at the application of `id`, not within the subscript.
+  given S is Movable {}
+  var y = S(x: 42 as Int32)
+  var a = id[y]
+
+  precondition(a.x == (42 as Int32))
+}
+
+public fun main() {
+  test_locally_movable()
+}

--- a/Tests/CompilerTests/positive/sink-subscript.hylo
+++ b/Tests/CompilerTests/positive/sink-subscript.hylo
@@ -1,4 +1,5 @@
-/// A `sink` subscript projects an owned value that the caller *may* move into its own storage.
+/// A `sink` subscript projects a value that the caller must consume,
+/// e.g. by move assignment to fresh storage or by implicit deinitialization.
 subscript id(x: sink Int32) sink -> Int32 { yield &x }
 subscript id(x: sink Immovable) sink -> Immovable { yield &x }
 

--- a/Tests/CompilerTests/positive/sink-subscript.hylo
+++ b/Tests/CompilerTests/positive/sink-subscript.hylo
@@ -1,0 +1,32 @@
+/// A `sink` subscript projects an owned value that the caller *may* move into its own storage.
+subscript id(x: sink Int32) sink -> Int32 { yield &x }
+subscript id(x: sink Immovable) sink -> Immovable { yield &x }
+
+fun test_movable_can_be_stored() {
+  var x = 42 as Int32
+  var a = id[x]
+  precondition(a == (42 as Int32))
+}
+
+fun test_movable_can_be_projected() {
+  var x = 42 as Int32
+  let a = id[x]
+  precondition(a == (42 as Int32))
+}
+
+fun test_immovable_can_be_projected() {
+  var x = Immovable(x: 42 as Int32)
+  let a = id[x]
+  precondition(a.x == (42 as Int32))
+}
+
+struct Immovable is Deinitializable {
+  var x: Int32
+  memberwise init
+}
+
+fun main() {
+  test_movable_can_be_stored()
+  test_movable_can_be_projected()
+  test_immovable_can_be_projected()
+}


### PR DESCRIPTION
Fixes #502. The problem was that subscripts don't store into their `target` (result) place, and instead just yield the value through the register that's returned by `lower(call:output:)`. The fix involves emitting a non-reified move from the yielded place to the store `target` (the move can be later reified into either set/inout move).