### PR TITLE
Keep track of the logical index of stored properties

### DIFF
--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -57,23 +57,18 @@ extension Program {
   private func llvmName(
     function f: IRFunction.ID, in ctx: borrowing ModuleGenerationContext
   ) -> String {
-    let v = self[ctx.hylo].ir[f].name
-    if case .lowered(let d) = v, let n = externName(of: d) {
-      return n
-    } else {
-      return mangled(v)
-    }
+    llvmName(function: self[ctx.hylo].ir[f].name)
   }
 
-  /// Returns the name of the C function implementing `f` iff `f` was lowered from a declaration
-  /// annotated with `@extern_c_indirect`.
-  private func externCName(
-    of f: IRFunction.ID, in ctx: borrowing ModuleGenerationContext
-  ) -> String? {
-    if case .lowered(let d) = self[ctx.hylo].ir[f].name {
-      return externCName(of: d)
+  /// Returns the name of the function corresponding to `f` in LLVM IR.
+  ///
+  /// The result is the mangled name of `f` unless its declaration has been annotated to specify a
+  /// particular name (e.g., `@extern`).
+  private func llvmName(function f: IRFunction.Name) -> String {
+    if case .lowered(let d) = f, let e = externName(of: d) {
+      return e
     } else {
-      return nil
+      return mangled(f)
     }
   }
 
@@ -671,25 +666,31 @@ extension Program {
   ) -> AnyInstructionIdentity? {
     let s = ctx.ir.at(i)
 
-    // Compute the LLVM types of the whole and its part.
-    let recordHyloType = ctx.ir.result(of: s.record)!.type
-    let w = metadata(of: recordHyloType, in: &ctx.module)
-    let p = typeOfProperty(declaredBy: s.property, withType: s.propertyType, in: &ctx.module)
+    // Compute the LLVM representation of the whole.
+    let wholeTypeInHylo = ctx.ir.result(of: s.record)!.type
+    let wholeType = metadata(of: wholeTypeInHylo, in: &ctx.module)
+    let whole = codegen(s.record, in: &ctx)
+
+    // If the property is a field in a struct, lookup its offset.
+    if let index = storedPropertyIndex(of: s.property, in: s.anchor.scope) {
+      let a = insertGetFieldAddress(
+        at: [index], in: whole, instanceOf: wholeTypeInHylo, in: &ctx)
+      ctx.value[.register(i.erased)] = a
+    }
 
     // If the whole is a witness table, the property is a requirement of the trait for which the
     // table is witnessing a conformance.
-    if let (concept, _) = types.seenAsTraitApplication(recordHyloType) {
+    else if let (concept, _) = types.seenAsTraitApplication(wholeTypeInHylo) {
       // The contents of a witness table follow the ordering of its requirements.
       let index = requirements(of: concept).index(of: s.property)!
-      let whole = codegen(s.record, in: &ctx)
       let part = ctx.module.llvm.insertGetElementPointerInBounds(
-        of: whole, typed: w.llvm,
+        of: whole, typed: wholeType.llvm,
         indices: [0, index], indexType: ctx.module.llvm.i32,
         at: ctx.insertionPoint!)
 
-      let x = ctx.module.llvm.insertLoad(p, from: part, at: ctx.insertionPoint!)
-      let v = FrontEnd.IRValue.register(i.erased)
-      ctx.value[v] = x.v
+      let p = llvmType(property: s.property, usedAsInstanceOf: s.propertyType, in: &ctx.module)
+      let a = ctx.module.llvm.insertLoad(p, from: part, at: ctx.insertionPoint!).v
+      ctx.value[.register(i.erased)] = a
     }
 
     // Otherwise, the property is a public property of some resilient type.
@@ -730,31 +731,11 @@ extension Program {
     _ i: IRSubfield.ID, in ctx: inout FunctionGenerationContext
   ) -> AnyInstructionIdentity? {
     let s = ctx.ir.at(i)
+    let record = ctx.value[s.base]!
+    let typeInHylo = ctx.ir.result(of: s.base)!.type
+    let address = insertGetFieldAddress(at: s.path, in: record, instanceOf: typeInHylo, in: &ctx)
 
-    let i32 = ctx.module.llvm.i32
-    let base = ctx.ir.result(of: s.base)!.type
-    var current = base
-    var indices = [i32.unsafe[].constant(0).v]
-    for p in s.path {
-      // Get the logical index of the property in its concrete representation.
-      let m = metadata(of: current, in: &ctx.module)
-      let i = m.layout.propertyToField[p]
-
-      // Stop if the property has been erased. The resulting path will be that of its container.
-      if i < 0 { break }
-
-      // Otherwise, move to the next component.
-      indices.append(i32.unsafe[].constant(m.layout.propertyToField[p]).v)
-      current = fields(of: current, visibleFrom: ctx.module.hylo)![p]
-    }
-
-    let b = ctx.value[s.base]!
-    let m = metadata(of: base, in: &ctx.module)
-    let x = ctx.module.llvm.insertGetElementPointerInBounds(
-      of: b, typed: m.llvm, indices: indices, at: ctx.insertionPoint!)
-
-    let v = IRValue.register(i.erased)
-    ctx.value[v] = x.v
+    ctx.value[.register(i.erased)] = address
     return ctx.ir.instruction(after: i.erased)
   }
 
@@ -846,29 +827,13 @@ extension Program {
     return nil
   }
 
-  /// Returns the LLVM function corresponding to `f`, declaring it if necessary.
-  ///
-  /// If `f` is a subscript, the result is the function that represents its ramp, which accepts a
-  /// caller plateau and its environment as extra parameters. Slides are declared during the code
-  /// generation of a subscript and are typically never called directly from another context.
+  /// Returns the result of `demandFunction(_:in:)` with the identity of `f`, which is declared in
+  /// the module being compiled.
   private mutating func demandFunction(
     _ f: IRFunction.ID, in ctx: inout ModuleGenerationContext
   ) -> FunctionMetadata {
     let ir = self[ctx.hylo].ir[f]
-    if let existing = ctx.functionMetadata[ir.name] {
-      return existing
-    }
-
-    let name = llvmName(function: f, in: ctx)
-    let signature = ir.signature()
-
-    let p = prototype(signature.head, in: &ctx)
-    let v = ctx.llvm.declareFunction(name, p.signature)
-    setupAttributes(of: v, compiledFrom: f, in: &ctx)
-
-    let m = FunctionMetadata(prototype: p, value: v, isRamp: ir.isSubscript)
-    ctx.functionMetadata[ir.name] = m
-    return m
+    return demandFunction(ir, in: &ctx)
   }
 
   /// Returns the result of `demandFunction(_:in:)` with the identity of `f`, which is declared in
@@ -878,6 +843,30 @@ extension Program {
   ) -> FunctionMetadata {
     let k = self[ctx.hylo].ir.identity(function: f)!
     return demandFunction(k, in: &ctx)
+  }
+
+  /// Returns the LLVM function corresponding to `ir`, declaring it if necessary.
+  ///
+  /// If `ir` is a subscript, the result is the function that represents its ramp, which accepts a
+  /// caller plateau and its environment as extra parameters. Slides are declared during the code
+  /// generation of a subscript and are typically never called directly from another context.
+  private mutating func demandFunction(
+    _ ir: IRFunction, in ctx: inout ModuleGenerationContext
+  ) -> FunctionMetadata {
+    if let existing = ctx.functionMetadata[ir.name] {
+      return existing
+    }
+
+    let name = llvmName(function: ir.name)
+    let signature = ir.signature()
+
+    let p = prototype(signature.head, in: &ctx)
+    let v = ctx.llvm.declareFunction(name, p.signature)
+    setupAttributes(of: v, compiledFrom: ir, in: &ctx)
+
+    let m = FunctionMetadata(prototype: p, value: v, isRamp: ir.isSubscript)
+    ctx.functionMetadata[ir.name] = m
+    return m
   }
 
   /// Returns the prototype of a LLVM IR function corresponding to a Hylo IR function whose
@@ -962,13 +951,13 @@ extension Program {
     }
   }
 
-  /// Configures the attributes of `g`, which is the LLVM function to which `f` compiles.
+  /// Configures the attributes of `g`, which is the LLVM function to which `ir` compiles.
   private mutating func setupAttributes(
-    of g: Function.UnsafeReference, compiledFrom f: IRFunction.ID,
+    of g: Function.UnsafeReference, compiledFrom ir: IRFunction,
     in ctx: inout ModuleGenerationContext
   ) {
-    if isPrivate(self[ctx.hylo].ir[f].name, in: ctx.hylo) {
-      assert(self[ctx.hylo].ir[f].isDefined || externCName(of: f, in: ctx) != nil)
+    if isPrivate(ir.name, in: ctx.hylo) {
+      assert(ir.isDefined || externCName(of: ir.name) != nil)
       ctx.llvm.setLinkage(.private, for: g)
     }
   }
@@ -1138,6 +1127,34 @@ extension Program {
     let w = ctx.llvm.constantAdd(v, iptr.unsafe[].constant(0b11))
     ctx.strings[s] = w
     return w
+  }
+
+  /// Returns a pointer to the field at `path` relative to `record`, which is a pointer to storage
+  /// for an instance of `recordTypeInHylo`.
+  private mutating func insertGetFieldAddress(
+    at path: IndexPath, in record: LLVMValue, instanceOf recordTypeInHylo: AnyTypeIdentity,
+    in ctx: inout FunctionGenerationContext
+  ) -> LLVMValue {
+    let i32 = ctx.module.llvm.i32
+    var current = recordTypeInHylo
+    var indices = [i32.unsafe[].constant(0).v]
+    for p in path {
+      // Get the logical index of the property in its concrete representation.
+      let m = metadata(of: current, in: &ctx.module)
+      let i = m.layout.propertyToField[p]
+
+      // Stop if the property has been erased. The resulting path will be that of its container.
+      if i < 0 { break }
+
+      // Otherwise, move to the next component.
+      indices.append(i32.unsafe[].constant(m.layout.propertyToField[p]).v)
+      current = fields(of: current, visibleFrom: ctx.module.hylo)![p]
+    }
+
+    let m = metadata(of: recordTypeInHylo, in: &ctx.module)
+    let r = ctx.module.llvm.insertGetElementPointerInBounds(
+      of: record, typed: m.llvm, indices: indices, at: ctx.insertionPoint!)
+    return r.v
   }
 
   /// Returns the LLVM values corresponding to `xs`, which are instances of `t`, loaded in memory.
@@ -1568,8 +1585,8 @@ extension Program {
   ) -> TypeMetadata {
     metadata(of: t, in: &ctx) { (program, ctx, t, n) in
       // TODO: Resilience
-      let properties = program.fields(of: t.erased, visibleFrom: ctx.hylo)!
-      return program.metadata(record: n, fields: properties, in: &ctx)
+      let fields = program.fields(of: t.erased, visibleFrom: ctx.hylo)!
+      return program.metadata(record: n, fields: fields, in: &ctx)
     }
   }
 
@@ -1578,9 +1595,9 @@ extension Program {
     of t: Tuple.ID, in ctx: inout ModuleGenerationContext
   ) -> TypeMetadata {
     metadata(of: t, in: &ctx) { (program, ctx, t, n) in
-      let (properties, isOpenEnded) = program.types.members(of: t)
+      let (fields, isOpenEnded) = program.types.members(of: t)
       precondition(!isOpenEnded, "no LLVM representation of type '\(program.show(t))'")
-      return program.metadata(record: n, fields: properties, in: &ctx)
+      return program.metadata(record: n, fields: fields, in: &ctx)
     }
   }
 
@@ -1603,8 +1620,8 @@ extension Program {
         let l = ConcreteLayout(
           fields: [], propertyToField: Array(fs.indices), size: .fixed(s), alignment: a)
         return TypeMetadata(llvm: v, layout: l)
-      } else if let properties = program.fields(of: t.erased, visibleFrom: ctx.hylo) {
-        return program.metadata(record: n, fields: properties, in: &ctx)
+      } else if let fields = program.fields(of: t.erased, visibleFrom: ctx.hylo) {
+        return program.metadata(record: n, fields: fields, in: &ctx)
       } else {
         unimplemented("no LLVM representation of the type '\(program.show(t))'")
       }
@@ -1725,10 +1742,10 @@ extension Program {
       fields: elements, propertyToField: fieldToElement, size: .fixed(size), alignment: a)
   }
 
-  /// Returns the LLVM IR type of the entity declared by `d`, which is a property of an opaque
-  /// record having type `t`.
-  private mutating func typeOfProperty(
-    declaredBy d: DeclarationIdentity, withType t: AnyTypeIdentity,
+  /// Returns the LLVM IR type of the entity declared by `d`, which is a property of a record, used
+  /// as an instance of `t`.
+  private mutating func llvmType(
+    property d: DeclarationIdentity, usedAsInstanceOf t: AnyTypeIdentity,
     in ctx: inout ModuleGenerationContext
   ) -> LLVMType {
     if isFunctionOrVariantDeclaration(d) {

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1390,13 +1390,7 @@ internal struct IREmitter {
     case .member(let d):
       // Emit the receiver.
       let q = lowered(lvalue: program[e].qualification!)
-
-      // Is `d` a stored property of a type whose layout is visible?
-      if let i = storedPropertyIndex(of: d, in: program.parent(containing: e)) {
-        return lowering(e, { $0._subfield(q, at: [i], declaredBy: d) })
-      } else {
-        return lowering(e, { $0._property(d, of: q, withType: t) })
-      }
+      return lowering(e, { $0._property(d, of: q, withType: t) })
 
     case .builtin(.selfAlias):
       return lowering(e, { $0._emitTypeWitness(of: t) })
@@ -1943,29 +1937,6 @@ internal struct IREmitter {
       let rhs = program[s].elements[i]
       visit(lhs, nextTo: rhs, at: path.appending(i), calling: visitor)
     }
-  }
-
-  /// If `d` declares a stored property of a type whose layout is visible in `scopeOfUse`, returns
-  /// that property's index; otherwise, returns `nil`.
-  ///
-  /// The index of a stored property is used in instances of `IndexPath` to represent the location
-  /// of a part relative to the location of a whole. For example, if `S` is a struct with two
-  /// stored properties `x` and `y`, declared in that order, the index of `y` is 1.
-  ///
-  /// If resilience is enabled in the module containing `d`, the layout of the type declared by `d`
-  /// is visible if `d` is the same module as `scopeOfUse` or if `d` is annotated with `@frozen`.
-  /// Layouts are always visible when resilience is disabled.
-  private mutating func storedPropertyIndex(
-    of d: DeclarationIdentity, in scopeOfUse: ScopeIdentity
-  ) -> Int? {
-    guard
-      let v = program.cast(d, to: VariableDeclaration.self),
-      let p = program.parent(containing: v, as: StructDeclaration.self),
-      program.isLayoutVisible(p, in: scopeOfUse)
-    else { return nil }
-
-    let properties = program.storedProperties(of: p)
-    return properties.firstIndex(of: v)
   }
 
   /// Reports the diagnostic `d`.

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -2207,9 +2207,7 @@ internal struct IREmitter {
   }
 
   /// Inserts a `subfield` instruction.
-  internal mutating func _subfield(
-    _ base: IRValue, at path: IndexPath, declaredBy declaration: DeclarationIdentity? = nil
-  ) -> IRValue {
+  internal mutating func _subfield(_ base: IRValue, at path: IndexPath) -> IRValue {
     // The instruction is equivalent to the identity if the path is empty.
     if path.isEmpty { return base }
 
@@ -2219,7 +2217,7 @@ internal struct IREmitter {
     }
 
     let s = IRSubfield(
-      base: base, path: path, subfieldType: subfieldType!, declaration: declaration,
+      base: base, path: path, subfieldType: subfieldType!,
       anchor: currentAnchor)
     return insert(s)!
   }

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -223,40 +223,6 @@ public struct IRFunction: Sendable {
     }
   }
 
-  /// Returns `true` iff `v` cannot be used to modify or update a value.
-  public func isBoundImmutably(_ v: IRValue) -> Bool {
-    switch v {
-    case .parameter(let i):
-      return termParameters[i].access == .let
-    case .register(let i):
-      return isBoundImmutably(i)
-    default:
-      return false
-    }
-  }
-
-  /// Returns `true` iff the result of `i` cannot be used to modify or update a value.
-  public func isBoundImmutably(_ i: AnyInstructionIdentity) -> Bool {
-    switch tag(of: i) {
-    case IRAlloca.self:
-      return false
-    case IRAccess.self:
-      return (at(i) as! IRAccess).capabilities == [.let]
-    case IRCase.self:
-      return isBoundImmutably((at(i) as! IRCase).source)
-    case IRPlaceCast.self:
-      return (at(i) as! IRPlaceCast).access == .let
-    case IRPointerToPlace.self:
-      return (at(i) as! IRPointerToPlace).access == .let
-    case IRProject.self:
-      return (at(i) as! IRProject).access == .let
-    case IRSubfield.self:
-      return isBoundImmutably((at(i) as! IRSubfield).base)
-    default:
-      return true
-    }
-  }
-
   /// Returns `true` iff `v` is a built-in value, using `program` to examine types.
   public func isBuiltinValue(_ v: IRValue, using program: Program) -> Bool {
     if let t = result(of: v) {

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -590,10 +590,9 @@ public struct IRFunction: Sendable {
   /// Returns the instructions that follows `i` in the block containing `i`.
   public func instructions(after i: AnyInstructionIdentity) -> IRBlock.Iterator {
     let b = block(defining: i)
-    return .init(
-      slots: slots,
-      last: blocks[b].last,
-      next: slots.address(after: i.address).map(AnyInstructionIdentity.init(address:)))
+    let l = blocks[b].last
+    let n = slots.address(after: i.address).map(AnyInstructionIdentity.init(address:)) ?? l
+    return .init(slots: slots, last: l, next: n)
   }
 
   /// Returns `true` iff `b` contains an instruction of type `T`.

--- a/Sources/FrontEnd/IR/Instructions/IRSubfield.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRSubfield.swift
@@ -17,20 +17,15 @@ public struct IRSubfield: Instruction {
   /// The type of the subfield being accessed.
   public let subfieldType: AnyTypeIdentity
 
-  /// The declaration of the entity that the subfield represents, if any.
-  public let declaration: DeclarationIdentity?
-
   /// Creates an instance with the given properties.
   public init(
     base: IRValue, path: IndexPath, subfieldType: AnyTypeIdentity,
-    declaration: DeclarationIdentity?,
     anchor: Anchor
   ) {
     self.operands = [base]
     self.anchor = anchor
     self.path = path
     self.subfieldType = subfieldType
-    self.declaration = declaration
   }
 
   /// Creates a copy of `other`, substituting its properties with `properties`.
@@ -39,7 +34,6 @@ public struct IRSubfield: Instruction {
     self.anchor = properties.anchor(other)
     self.path = other.path
     self.subfieldType = other.subfieldType
-    self.declaration = other.declaration
   }
 
   /// The address of the record containing the subfield whose address is computed.

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -280,7 +280,20 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRProperty.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .unique)
+    let s = f.at(i)
+
+    // If the property is referring to a stored property in a struct whose layout is visible, the
+    // instruction behaves like `subfield`.
+    if let index = program.storedPropertyIndex(of: s.property, in: s.anchor.scope) {
+      let field = context.locals[s.record]!.place!.appending(contentsOf: [index])
+      context.locals[.register(i.erased)] = .place(field)
+    }
+
+    // Otherwise, it defines a new place.
+    else {
+      context.declare(i.erased, from: f, initially: .unique)
+    }
+
     return f.instruction(after: i.erased)
   }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+Folding.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+Folding.swift
@@ -15,14 +15,10 @@ extension IRFunction {
   /// Combines `i` with its user if there is only one.
   private mutating func fold(_ i: IRSubfield.ID) {
     let s = at(i)
-    if
-      let u = uses[.register(i.erased)]?.uniqueElement,
-      let t = at(u.user) as? IRSubfield,
-      s.declaration == t.declaration
-    {
+    if let u = uses[.register(i.erased)]?.uniqueElement, let t = at(u.user) as? IRSubfield {
       let folded = IRSubfield(
         base: s.base, path: s.path.appending(contentsOf: t.path),
-        subfieldType: t.subfieldType, declaration: t.declaration, anchor: t.anchor)
+        subfieldType: t.subfieldType, anchor: t.anchor)
       replace(u.user, with: folded)
       remove(i.erased)
     }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -531,7 +531,21 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRProperty.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    context.declare(i.erased, from: f, initially: .initialized)
+    let s = f.at(i)
+
+    // If the property is referring to a stored property in a struct whose layout is visible, the
+    // instruction behaves like `subfield`.
+    if let index = program.storedPropertyIndex(of: s.property, in: s.anchor.scope) {
+      let field = context.locals[s.record]!.place!.appending(contentsOf: [index])
+      context.locals[.register(i.erased)] = .place(field)
+    }
+
+    // Otherwise, it defines a new place.
+    else {
+      assert(isInitialized(place: s.record), "abstract property on uninitialized object")
+      context.declare(i.erased, from: f, initially: .initialized)
+    }
+
     return f.instruction(after: i.erased)
   }
 
@@ -691,16 +705,13 @@ private struct Transfer: AbstractTransferFunction {
     }
   }
 
-  /// Returns the declaration binding `v`, which computes the source of an access in `f`, or `nil`
-  /// if such a declaration cannot be identified.
-  private func binding(declaring v: IRValue, in f: IRFunction) -> VariableDeclaration.ID? {
-    if let d = f.declaration(v) {
-      return program.cast(d, to: VariableDeclaration.self)
-    } else if let r = v.register, let s = f.at(r) as? IRSubfield, let d = s.declaration {
-      return program.cast(d, to: VariableDeclaration.self)
-    } else {
-      return nil
-    }
+  /// Returns the introducer of the binding declared by `d`, if any.
+  private func introducer(binding d: DeclarationIdentity) -> BindingPattern.Introducer? {
+    guard
+      let v = program.cast(d, to: VariableDeclaration.self),
+      let b = program.bindingDeclaration(containing: v)
+    else { return nil }
+    return program[program[b].pattern].introducer.value
   }
 
   /// Returns the introducer of the binding associated with `v`, which computes the source of an
@@ -709,22 +720,23 @@ private struct Transfer: AbstractTransferFunction {
     binding v: IRValue, in f: IRFunction
   ) -> (BindingPattern.Introducer?, IRValue) {
     var s = v
-    while true {
-      // Is `s` attached to a binding declaration?
-      if let b = binding(declaring: s, in: f).flatMap(program.bindingDeclaration(containing:)) {
-        let k = program[program[b].pattern].introducer.value
-        if (k == .let) && (!program.isLocal(b) || program.isMember(b)) {
-          return (.sinklet, s)
-        } else {
-          return (k, s)
-        }
+    while let r = s.register {
+      if let s = f.at(r) as? IRProperty, let i = introducer(binding: s.property) {
+        let presented = (i == .let) && program.isMember(s.property) ? .sinklet : i
+        return (presented, s.record)
+      } else if let next = f.source(r) {
+        s = next
+      } else {
+        break
       }
+    }
 
-      // Should we look further?
-      else if let r = s.register.flatMap(f.source(_:)) { s = r }
-
+    if let d = f.declaration(s), let i = introducer(binding: d) {
+      let presented = (i == .let) && !program.isLocal(d) ? .sinklet : i
+      return (presented, s)
+    } else {
       // No binding declaration.
-      else { return (nil, s) }
+      return (nil, s)
     }
   }
 
@@ -749,7 +761,7 @@ private struct Transfer: AbstractTransferFunction {
 
     case (.some(.sinklet), let source):
       // An `inout` access to a `sink let` binding is always invalid.
-      if (k == .inout) || f.isBoundImmutably(source) { return false }
+      if (k == .inout) || isBoundImmutably(source, in: f) { return false }
 
       // Otherwise validity depends on the sequencing of the access relative to other uses.
       let a = context.locals[s.source]!.place!
@@ -763,7 +775,56 @@ private struct Transfer: AbstractTransferFunction {
       unreachable()
 
     case (_, let source):
-      return !f.isBoundImmutably(source)
+      return !isBoundImmutably(source, in: f)
+    }
+  }
+
+  /// Returns `true` iff `v` cannot be used to modify or update a value.
+  private func isBoundImmutably(_ v: IRValue, in f: IRFunction) -> Bool {
+    switch v {
+    case .parameter(let i):
+      return f.termParameters[i].access == .let
+    case .register(let i):
+      return isBoundImmutably(i, in: f)
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` iff the result of `i` cannot be used to modify or update a value.
+  private func isBoundImmutably(_ i: AnyInstructionIdentity, in f: IRFunction) -> Bool {
+    switch f.tag(of: i) {
+    case IRAlloca.self:
+      return false
+    case IRAccess.self:
+      return (f.at(i) as! IRAccess).capabilities == [.let]
+    case IRCase.self:
+      return isBoundImmutably((f.at(i) as! IRCase).source, in: f)
+    case IRPlaceCast.self:
+      return (f.at(i) as! IRPlaceCast).access == .let
+    case IRPointerToPlace.self:
+      return (f.at(i) as! IRPointerToPlace).access == .let
+    case IRProject.self:
+      return (f.at(i) as! IRProject).access == .let
+    case IRProperty.self:
+      return isBoundImmutably(f.castUnchecked(i, to: IRProperty.self), in: f)
+    case IRSubfield.self:
+      return isBoundImmutably((f.at(i) as! IRSubfield).base, in: f)
+    default:
+      return true
+    }
+  }
+
+  /// Returns `true` iff the result of `i` cannot be used to modify or update a value.
+  private func isBoundImmutably(_ i: IRProperty.ID, in f: IRFunction) -> Bool {
+    if
+      let v = program.cast(f.at(i).property, to: VariableDeclaration.self),
+      let d = program.bindingDeclaration(containing: v),
+      program[program[d].pattern].introducer.value != .let
+    {
+      return isBoundImmutably(f.at(i).record, in: f)
+    } else {
+      return true
     }
   }
 

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1365,7 +1365,7 @@ public struct Program: Sendable {
     }
   }
 
-  /// Returns the name of the C function implementing `d` iff `d` is annotated with
+  /// Returns the name of the C implementation of `d` iff it declares a function annotated with
   /// `@extern_c_indirect`.
   public func externCName(of d: DeclarationIdentity) -> String? {
     annotation("extern_c_indirect", appliedTo: d).flatMap { (a) in
@@ -1374,6 +1374,16 @@ public struct Program: Sendable {
       } else {
         return nil
       }
+    }
+  }
+
+  /// Returns the name of the C implementation of the function named by `f` iff that function's
+  /// declaration is annotated with `@extern_c_indirect`.
+  public func externCName(of f: IRFunction.Name) -> String? {
+    if case .lowered(let d) = f {
+      return externCName(of: d)
+    } else {
+      return nil
     }
   }
 

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -1125,6 +1125,27 @@ public struct Program: Sendable {
     return result
   }
 
+  /// If `d` declares a stored property of a type whose layout is visible in `scopeOfUse`, returns
+  /// that property's index; otherwise, returns `nil`.
+  ///
+  /// The index of a stored property is used in instances of `IndexPath` to represent the location
+  /// of a part relative to the location of a whole. For example, if `S` is a struct with two
+  /// stored properties `x` and `y`, declared in that order, the index of `y` is 1.
+  ///
+  /// If resilience is enabled in the module containing `d`, the layout of the type declared by `d`
+  /// is visible if `d` is the same module as `scopeOfUse` or if `d` is annotated with `@frozen`.
+  /// Layouts are always visible when resilience is disabled.
+  public mutating func storedPropertyIndex(
+    of d: DeclarationIdentity, in scopeOfUse: ScopeIdentity
+  ) -> Int? {
+    guard
+      let v = cast(d, to: VariableDeclaration.self),
+      let p = parent(containing: v, as: StructDeclaration.self),
+      isLayoutVisible(p, in: scopeOfUse)
+    else { return nil }
+    return storedProperties(of: p).firstIndex(of: v)
+  }
+
   /// Returns the binding declaration that contains `d`, if any.
   ///
   /// - Requires: The module containing `s` is scoped.

--- a/Tests/CompilerTests/negative/illegal-sink-let.diagnostics.expected
+++ b/Tests/CompilerTests/negative/illegal-sink-let.diagnostics.expected
@@ -13,3 +13,12 @@ negative/illegal-sink-let.hylo:34.14-15: error: illegal 'set' access
 negative/illegal-sink-let.hylo:36.9-10: error: illegal 'sink' access
     _ = z             // error
         ^
+negative/illegal-sink-let.hylo:45.12-13: error: illegal 'set' access
+    &s.x = 0          // error
+           ^
+negative/illegal-sink-let.hylo:56.16-17: error: illegal 'set' access
+    &t.s.0.x = 0      // error
+               ^
+negative/illegal-sink-let.hylo:57.16-17: error: illegal 'set' access
+    &t.s.0.y = 1      // error
+               ^

--- a/Tests/CompilerTests/negative/illegal-sink-let.hylo
+++ b/Tests/CompilerTests/negative/illegal-sink-let.hylo
@@ -41,4 +41,20 @@ struct S {
     return w.0        // OK (move out)
   }
 
+  static fun g2(s: inout S) {
+    &s.x = 0          // error
+    &s.y = 1          // OK (assignment)
+  }
+
+}
+
+struct T {
+
+  let s: S[2]
+
+  static fun g0(t: inout T) {
+    &t.s.0.x = 0      // error
+    &t.s.0.y = 1      // error
+  }
+
 }

--- a/Tests/CompilerTests/positive/synthesized-deinit.refined-ir.expected
+++ b/Tests/CompilerTests/positive/synthesized-deinit.refined-ir.expected
@@ -28,7 +28,7 @@ fun Deinitializable.deinit<Self: S0>(let %p0: Deinitializable<Self>, sink %p1: S
 
 fun S0.deinit(sink %p0: S0, set %p1: Void) {
 %b0:
-  %r0 = subfield %p0 at 0 as Int
+  %r0 = property "i" of %p0 as Int
   %r1 = access [sink] %r0
   %r2 = assume_state %r1 uninitialized
   %r3 = end %r1


### PR DESCRIPTION
Lowers uses of stored properties with the `property` instruction rather than `subfield` so that we can look up their logical index during code generation.