### PR TITLE
Fix ambiguous declaration chains when mangling.

### DIFF
--- a/Sources/FrontEnd/IR/Mangling/ManglingContext.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingContext.swift
@@ -22,6 +22,12 @@ internal struct ManglingContext {
   /// A table mapping known symbols to their reserved mangled identifier.
   private var reserved: [MangledSymbol: ReservedSymbol] = [:]
 
+  /// `true` iff the last symbol added to `output` was a declaration.
+  ///
+  /// Used to detect ambiguity when a declaration is followed by a symbol that may be the start of
+  /// another declaration.
+  private var afterDeclaration: Bool = false
+
   /// Creates an instance for mangling symbols in `program`.
   internal init(_ program: Program) {
     output = ""
@@ -51,10 +57,14 @@ internal struct ManglingContext {
   /// Writes `x` to `self.output`.
   private mutating func add<T: TextOutputStreamable>(_ x: T) {
     x.write(to: &output)
+    afterDeclaration = false
   }
 
   /// Writes `string` to `output`, prefixed by its length encoded as a variable-length integer.
   internal mutating func add<T: StringProtocol>(string: T) {
+    if afterDeclaration {
+      add(operator: .declarationEnd)
+    }
     let s = String(string)
 
     if s.isEmpty {
@@ -67,21 +77,25 @@ internal struct ManglingContext {
       add(string)
       stringPosition[s] = stringPosition.count
     }
+    afterDeclaration = false
   }
 
   /// Writes `v` encoded as a variable-length integer to `output`.
   internal mutating func add(integer v: Int) {
     Base64VarUInt(UInt(bitPattern: v)).write(to: &output)
+    afterDeclaration = false
   }
 
   /// Writes `v` encoded as a variable-length integer to `output`.
   internal mutating func add(integer v: UInt32) {
     Base64VarUInt(UInt64(v)).write(to: &output)
+    afterDeclaration = false
   }
 
   /// Writes `v` encoded as a variable-length integer to `output`.
   internal mutating func add(integer v: UInt64) {
     Base64VarUInt(v).write(to: &output)
+    afterDeclaration = false
   }
 
   /// Writes the raw value of `v` encoded as a base 64 digit to `output`.
@@ -97,6 +111,7 @@ internal struct ManglingContext {
   /// Writes `o` to `output`.
   internal mutating func add(operator o: ManglingOperator) {
     o.write(to: &output)
+    afterDeclaration = false
   }
 
   /// Writes the mangled representation of `items` to `output`, calling `addItem` to mangle each
@@ -109,6 +124,11 @@ internal struct ManglingContext {
     for i in items {
       addItem(&self, i)
     }
+  }
+
+  /// Marks the end of a declaration.
+  internal mutating func endDeclaration() {
+    afterDeclaration = true
   }
 
   /// Records `s` in the symbol lookup table if it is not reserved or already recorded.

--- a/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
@@ -76,13 +76,17 @@ internal struct ManglingEncoding: Sendable {
 
   /// Writes the mangled representation of `d` to `output`.
   private mutating func append(decl d: DeclarationIdentity, to output: inout ManglingContext) {
-    if output.addIf(reservedOrRecorded: .node(.init(d))) { return }
+    if output.addIf(reservedOrRecorded: .node(.init(d))) {
+      output.endDeclaration()
+      return
+    }
 
     // First add the qualification of the declaration.
     appendQualification(of: d, to: &output)
     // If this is a scope, then just add it as a scope and finish.
     if let s = program.castToScope(d) {
       append(scope: s, to: &output)
+      output.endDeclaration()
       return
     }
 
@@ -107,6 +111,7 @@ internal struct ManglingEncoding: Sendable {
     }
 
     output.record(symbol: .node(AnySyntaxIdentity(d)))
+    output.endDeclaration()
   }
 
   /// Demangles a (possibly qualified) entity from `source`.
@@ -199,6 +204,10 @@ internal struct ManglingEncoding: Sendable {
       // Stop if we cannot continue, or if we need to continue with something that cannot be a
       // scope or a declaration. Also consider the case that we start another declaration.
       guard let n = source.peekOperator() else { break }
+      if n == .declarationEnd {
+        _ = source.takeOperator()
+        break
+      }
       if n == .reserved || n == .module || n == .lookupRelative || !n.isEntityOperator {
         break
       }

--- a/Sources/FrontEnd/IR/Mangling/ManglingOperator.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingOperator.swift
@@ -18,6 +18,10 @@ internal enum ManglingOperator: String, CaseIterable, Sendable {
   /// Starts a reserved type identifier.
   case reservedType = "tR"
 
+  /// Symbol placed after a declaration end to ensure that whatever comes next does not appear to be
+  /// part of the same qualification.
+  case declarationEnd = "E"
+
   /// Starts an associated type declaration symbol.
   case associatedTypeDeclaration = "taD"
 

--- a/Tests/FrontEndTests/Mangling/ManglingOperatorTests.swift
+++ b/Tests/FrontEndTests/Mangling/ManglingOperatorTests.swift
@@ -40,7 +40,7 @@ final class ManglingOperatorTests: XCTestCase {
   /// Tests that each operator is classified as an entity or type operator, except for the
   /// witness-table operator which is intentionally treated as a special case.
   func testOperatorKinds() {
-    let specialOperators: [ManglingOperator] = [.witnessTable]
+    let specialOperators: [ManglingOperator] = [.declarationEnd, .witnessTable]
     for op in ManglingOperator.allCases {
       XCTAssert(
         op.isEntityOperator || op.isTypeOperator || specialOperators.contains(op),


### PR DESCRIPTION
When mangling parameters, we mangle a type (which can be just ending in a declaration) and immediately after a label. There is no operator after the type, and the string might start with something that might look like the operator for another declaration. When demangling such cases, we might continue to demangle the next label as a declaration (i.e., as part of a qualified entity).

To fix this, we add a "declaration end" each time we might have a string after a declaration. That would ensure that the declaration properly ends and we continue to demangle the string as expected.

This change is backwards compatible. Old manglings (which are not ambiguous) are demangled in the same way.

Fixes #431 