### PR TITLE
Fix off-by-one mistake in enum member count representation

### DIFF
--- a/Sources/BackEnd/ModuleGenerationContext.swift
+++ b/Sources/BackEnd/ModuleGenerationContext.swift
@@ -107,14 +107,15 @@ internal struct ModuleGenerationContext: ~Copyable {
     llvm
   }
 
-  /// Returns an unsigned integer type large enough to represent `n`.
-  internal func integerTypeToRepresent(_ n: Int) -> SwiftyLLVM.IntegerType.UnsafeReference {
+  /// Returns an unsigned integer type large enough to represent `n` distinct values.
+  internal func integerTypeToRepresent(count n: Int) -> SwiftyLLVM.IntegerType.UnsafeReference {
+    precondition(n >= 0)
     switch n {
-    case _ where n <= 0xff:
+    case _ where n <= 0x100:
       return llvm.i8
-    case _ where n <= 0xffff:
+    case _ where n <= 0x10000:
       return llvm.i16
-    case _ where n <= 0xffffffff:
+    case _ where n <= 0x1_0000_0000:
       return llvm.i32
     default:
       return llvm.i64

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -1681,7 +1681,7 @@ extension Program {
 
     // Determine the size of the tag.
     assert(cases.count < UInt32.max, "too many enum cases")
-    let tag = ctx.integerTypeToRepresent(cases.count)
+    let tag = ctx.integerTypeToRepresent(count: cases.count)
     let tagSize = ctx.llvm.layout.storageSize(of: tag)
     var fields: [LLVMType] = [
       tag.t,

--- a/Tests/BackEndTests/ModuleGenerationContextTests.swift
+++ b/Tests/BackEndTests/ModuleGenerationContextTests.swift
@@ -1,0 +1,26 @@
+@testable import BackEnd
+import Driver
+import FrontEnd
+import SwiftyLLVM
+import XCTest
+
+final class ModuleGenerationContextTests: XCTestCase {
+
+  func testIntegerTypeToRepresent() throws {
+    var driver = try Driver(targetSpecification: .native())
+    let module = driver.program.demandModule("test")
+    let m = ModuleGenerationContext(
+      compiling: module, into: .init("test", targetMachine: .init(target: driver.target)))
+
+    // A type representing `n` values must accommodate `0` through `n - 1`.
+    XCTAssertEqual(m.integerTypeToRepresent(count: 0).unsafe[].bitWidth, 8)
+    XCTAssertEqual(m.integerTypeToRepresent(count: 2).unsafe[].bitWidth, 8)
+    XCTAssertEqual(m.integerTypeToRepresent(count: 0x100).unsafe[].bitWidth, 8)
+    XCTAssertEqual(m.integerTypeToRepresent(count: 0x101).unsafe[].bitWidth, 16)
+    XCTAssertEqual(m.integerTypeToRepresent(count: 0x10000).unsafe[].bitWidth, 16)
+    XCTAssertEqual(m.integerTypeToRepresent(count: 0x10001).unsafe[].bitWidth, 32)
+    XCTAssertEqual(m.integerTypeToRepresent(count: 0x1_0000_0000).unsafe[].bitWidth, 32)
+    XCTAssertEqual(m.integerTypeToRepresent(count: 0x1_0000_0001).unsafe[].bitWidth, 64)
+  }
+
+}

--- a/Tests/InterpreterTests/TypeLayoutTests.swift
+++ b/Tests/InterpreterTests/TypeLayoutTests.swift
@@ -286,15 +286,15 @@ final class TypeLayoutTests: XCTestCase {
   func testEnumDiscriminator() {
     let i8 = id(MachineType.i(8))
     let i16 = id(MachineType.i(16))
-    XCTAssertEqual(
-      UnrealABI().enumDiscriminator(count: 1, in: &p).underlying,
-      .void)
-    XCTAssertEqual(
-      UnrealABI().enumDiscriminator(count: 2, in: &p).underlying, i8)
-    XCTAssertEqual(
-      UnrealABI().enumDiscriminator(count: 8, in: &p).underlying, i8)
-    XCTAssertEqual(
-      UnrealABI().enumDiscriminator(count: 257, in: &p).underlying, i16)
+    let i32 = id(MachineType.i(32))
+
+    XCTAssertEqual(UnrealABI().enumDiscriminator(count: 1, in: &p).underlying, .void)
+    XCTAssertEqual(UnrealABI().enumDiscriminator(count: 2, in: &p).underlying, i8)
+    XCTAssertEqual(UnrealABI().enumDiscriminator(count: 8, in: &p).underlying, i8)
+    XCTAssertEqual(UnrealABI().enumDiscriminator(count: 256, in: &p).underlying, i8)
+    XCTAssertEqual(UnrealABI().enumDiscriminator(count: 257, in: &p).underlying, i16)
+    XCTAssertEqual(UnrealABI().enumDiscriminator(count: 65536, in: &p).underlying, i16)
+    XCTAssertEqual(UnrealABI().enumDiscriminator(count: 65537, in: &p).underlying, i32)
   }
 
   // TODO: uncomment when raw enum representation gets supported.


### PR DESCRIPTION
There was a confusion whether to represent `n` as a number vs to represent `n` distinct elements. In the latter case, we can use `0` as an extra slot.