### PR TITLE
Enable cross-compilation in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,14 +86,14 @@ jobs:
           #       See also: https://github.com/swiftlang/swift/issues/88237
 
       - name: Build distributable
-        run: swift build -c release --verbose --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY -Xswiftc -cross-module-optimization
+        run: swift build -c release --verbose --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY -Xswiftc -DSWIFTY_LLVM_CROSS_COMPILATION_ENABLED -Xswiftc -cross-module-optimization
         shell: pwsh
 
       - name: Locate distributable
         id: locate-distributable
         run: |
           $ErrorActionPreference = 'Stop'
-          $binPath = (swift build -c release --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY -Xswiftc -cross-module-optimization --show-bin-path).Trim()
+          $binPath = (swift build -c release --product hc --static-swift-stdlib -Xswiftc -DUSE_BUNDLED_STANDARD_LIBRARY -Xswiftc -DSWIFTY_LLVM_CROSS_COMPILATION_ENABLED -Xswiftc -cross-module-optimization --show-bin-path).Trim()
           $binaryName = if ($env:RUNNER_OS -eq 'Windows') { 'hc.exe' } else { 'hc' }
           "bin_path=$binPath" >> $env:GITHUB_OUTPUT
           "binary_path=$(Join-Path $binPath $binaryName)" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
Builds release binaries with SWIFTY_LLVM_CROSS_COMPILATION_ENABLED so hc can target other platforms.