### PR TITLE
Expose the full bundled standard library, not just the `Sources` subfolder

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -79,7 +79,7 @@ public struct Driver {
   ///
   /// Build systems linking Hylo objects must compile and link this except in freestanding mode.
   public static var standardLibraryCShim: URL {
-    standardLibraryRoot.appending(component: cShimSource)
+    standardLibraryRoot.appending(component: "Sources").appending(component: cShimSource)
   }
 
   /// Creates an instance with the given properties.
@@ -374,9 +374,15 @@ public struct Driver {
   /// Use the `USE_BUNDLED_STANDARD_LIBRARY` compiler flag to control whether the  bundled or local
   /// standard library is used. Defaults to local.
   public mutating func loadStandardLibrary() async throws {
+    #if USE_BUNDLED_STANDARD_LIBRARY
+      let additionalSources: [SourceFile] = []
+    #else
+      let additionalSources = [try SourceFile(contentsOf: generatedStandardLibrarySource)]
+    #endif
+
     try await load(
       Module.standardLibraryName, withSourcesAt: Driver.standardLibraryRoot,
-      additionalSources: [SourceFile(contentsOf: generatedStandardLibrarySource)])
+      additionalSources: additionalSources)
     usesStandardLibrary = true
   }
 

--- a/Sources/hc/CommandLine.swift
+++ b/Sources/hc/CommandLine.swift
@@ -4,6 +4,7 @@ import Foundation
 import FrontEnd
 import SwiftyLLVM
 import Utilities
+import StandardLibrary
 
 /// Disambiguate FrontEnd.Module from SwiftyLLVM.Module.
 private typealias Module = FrontEnd.Module
@@ -225,7 +226,7 @@ private typealias Module = FrontEnd.Module
   /// Executes the command.
   public mutating func run() async throws {
     if printStandardLibraryRoot {
-      print(Driver.standardLibraryRoot.path)
+      print(bundledStandardLibrarySources.path)
       return
     }
 

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -4,20 +4,18 @@ import Foundation
 ///
 /// This folder should be preferred during development. It is the driver's default unless its
 /// sources are built with flag `USE_BUNDLED_STANDARD_LIBRARY` is set.
-public let localStandardLibrarySources = URL(fileURLWithPath: #filePath)
+package let localStandardLibrarySources = URL(fileURLWithPath: #filePath)
   .deletingLastPathComponent()
-  .appendingPathComponent("Sources")
 
 /// The path to the bundled standard library's root folder.
 ///
 /// This folder is intended to be used in distributable builds, in order to bundle the standard
 /// library together with the executable. The driver will pick this folder over the local one if
 /// its sources are compiled with the flag `USE_BUNDLED_STANDARD_LIBRARY` set.
-public let bundledStandardLibrarySources = Bundle.module.url(
-  forResource: "Sources", withExtension: nil)!
+public let bundledStandardLibrarySources = Bundle.module.resourceURL!
 
 /// The bundled path of the source file containing the generated parts of the standard library.
-public let generatedStandardLibrarySource = Bundle.module.url(
+package let generatedStandardLibrarySource = Bundle.module.url(
   forResource: "Generated.hylo", withExtension: nil)!
 
 /// The file name of the standard library's C shim source file within the standard library root.

--- a/Tests/CompilerTests/StandardLibraryLoadingTests.swift
+++ b/Tests/CompilerTests/StandardLibraryLoadingTests.swift
@@ -13,8 +13,7 @@ final class StandardLibraryLoadingTests: XCTestCase {
   func testStandardLibraryLoadingBundled() async throws {
     var driver = try Driver(targetSpecification: .native())
     try await driver.load(
-      Module.standardLibraryName, withSourcesAt: bundledStandardLibrarySources,
-      additionalSources: [SourceFile(contentsOf: generatedStandardLibrarySource)])
+      Module.standardLibraryName, withSourcesAt: bundledStandardLibrarySources)
   }
 
   func testStandardLibraryLoadingLocal() async throws {


### PR DESCRIPTION
The Generated.hylo is placed outside of the StandardLibrary/Sources folder (as its sibling), so it was not included in the root folder that was reported by hc to the build system via `--print-stdlib-root`. This PR changes the path handling to use the parent folder, the whole resource bundle to be the root of the standard library.