### PR TITLE
Interpreter: make enum layout consistent with llvm

### DIFF
--- a/Sources/Interpreter/TypeLayoutCache.swift
+++ b/Sources/Interpreter/TypeLayoutCache.swift
@@ -94,22 +94,23 @@ struct TypeLayoutCache {
       layout(.init(c), in: &p)
     }
 
-    let d = layout(abi.enumDiscriminator(count: cases.count, in: &p), in: &p)
+    let discriminator = abi.enumDiscriminator(count: cases.count, in: &p)
+    let discriminatorLayout = layout(discriminator, in: &p).whole
 
-    let payload = TypeLayout.Bytes(
+    let payloadLayout = TypeLayout.Bytes(
       alignment: Int(cases.map(\.alignment).lcm() ?? 1),
       size: cases.map(\.size).max() ?? 0)
 
-    let l = storageLayoutOfRecord(havingMembers: [
-      payload, .init(alignment: d.alignment, size: d.size),
-    ])
+    let bytes = discriminatorLayout.appending(payloadLayout)
+
+    let payloadOffset = bytes.size - payloadLayout.size
 
     let ns = names(enum: t.underlying, in: &p)
     let parts =
-      zip(cases, ns).map { TypeLayout.Part(name: $0.1, type: $0.0.type, offset: l.partOffsets[0]) }
-      + [.init(name: "discriminator", type: d.type, offset: l.partOffsets[1])]
+      zip(cases, ns).map { TypeLayout.Part(name: $0.1, type: $0.0.type, offset: payloadOffset) }
+      + [.init(name: "discriminator", type: discriminator, offset: 0)]
 
-    return .init(whole: l.bytes, type: t, parts: parts, isEnumLayout: true)
+    return .init(whole: bytes, type: t, parts: parts, isEnumLayout: true)
   }
 
   /// Returns the layout for a raw value enum `t`, defined in `p`.

--- a/Tests/InterpreterTests/TypeLayoutTests.swift
+++ b/Tests/InterpreterTests/TypeLayoutTests.swift
@@ -142,14 +142,14 @@ final class TypeLayoutTests: XCTestCase {
     let i8 = id(MachineType.i(8))
     let i16Tuple = p.types.tuple(of: [id(MachineType.i(16))])
 
-    XCTAssertEqual(optional.size, 3)
+    XCTAssertEqual(optional.size, 4)
     XCTAssertEqual(optional.alignment, 2)
     XCTAssertEqual(
       optional.parts,
       [
-        .init(name: "some", type: .init(i16Tuple), offset: 0),
-        .init(name: "none", type: .init(.void), offset: 0),
-        .init(name: "discriminator", type: .init(i8), offset: 2),
+        .init(name: "some", type: .init(i16Tuple), offset: 2),
+        .init(name: "none", type: .init(.void), offset: 2),
+        .init(name: "discriminator", type: .init(i8), offset: 0),
       ])
   }
 
@@ -272,14 +272,14 @@ final class TypeLayoutTests: XCTestCase {
     let i8 = id(MachineType.i(8))
     let i16Tuple = p.types.tuple(of: [id(MachineType.i(16))])
 
-    XCTAssertEqual(optional.size, 3)
+    XCTAssertEqual(optional.size, 4)
     XCTAssertEqual(optional.alignment, 2)
     XCTAssertEqual(
       optional.parts,
       [
-        .init(name: "some", type: .init(i16Tuple), offset: 0),
-        .init(name: "none", type: .init(.void), offset: 0),
-        .init(name: "discriminator", type: .init(i8), offset: 2),
+        .init(name: "some", type: .init(i16Tuple), offset: 2),
+        .init(name: "none", type: .init(.void), offset: 2),
+        .init(name: "discriminator", type: .init(i8), offset: 0),
       ])
   }
 


### PR DESCRIPTION
Fixes #514 

Previously, we were computing enum layout similar to runtime layout algorithm. But #514 suggests that's not the case with enums while LLVM lowering.