### PR TITLE
Implement generic witness tables

### DIFF
--- a/Docs/Depolmorphization.md
+++ b/Docs/Depolmorphization.md
@@ -8,7 +8,7 @@ Both monomorphization and existentialization essentially consist of creating a c
 In the former case, type arguments are simply substituted for their corresponding parameters.
 In the latter case, the type parameters are transformed into term parameters accepting type witnesses at run-time.
 
-This document describes how Hylo implements depolymorphization.
+The rest of this document describes how Hylo implements existentialization.
 
 > Disclaimer:
 > The syntax of Hylo IR is far from final.
@@ -16,7 +16,7 @@ This document describes how Hylo implements depolymorphization.
 
 ## Existentialization
 
-In a nutshell, existentialization consists of replacing type parameters with term parameters while abstracting over any information that cannot be determined at compile-time.
+Existentialization replaces type parameters with term parameters that provide any information that cannot be determined at compile-time.
 Consider the following example to illustrate this concept:
 
 ```hylo
@@ -26,8 +26,7 @@ fun swap<T is Movable>(a: inout T, b: inout T) {
 ```
 
 The first step to compile this function is to lower it to Hylo IR.
-Recall a conformance constraint such as `T is Movable` is always compiled to term parameter accepting a conformance witness.
-As a result, the signature of the lowered form of `swap(_:_:)` is as follows:
+Because the IR cannot represent constraints directly, Hylo replaces each constraint such as `T is Movable` with a conformance witness parameter:
 
 ```hylo
 fun swap(_:_:)<T>(
@@ -36,11 +35,11 @@ fun swap(_:_:)<T>(
 ```
 
 The function is still polymorphic at this stage, taking a type parameter `T`.
-`%p0` accepts a witness of `T`'s conformance to movable.
+`%p0` accepts a witness of `T`'s conformance to `Movable`.
 `%p1` and `%p2`, correspond to `a` and `b`, respectively.
 Finally, `%p3` denotes the output register of the function, i.e., the place to which its result is written.
 
-Existentialization will produce a copy of this function in which the type parameter `T` is replaced with a term parameters:
+Existentialization then replaces the unconstrained type parameter `T` with a term parameter, `T`'s **type witness**:
 
 ```hylo
 fun swap(_:_:).existentialized(
@@ -48,17 +47,16 @@ fun swap(_:_:).existentialized(
 )
 ```
 
-Rather than taking a type parameter, this function accepts a *type witness* as its first parameter `%p0`.
-This type witness will be used to obtain information about the layout of `T`, as we shall see later.
+The type witness supplies information about `T` not given by conformances, such as its layout.
 The following parameters are the same as those of the polymorphic version, just renamed.
 Finally, occurrences of `T` have been replaced with `?0`, which denotes a *skolem* representing some type unknown at compile time.
 
-> From a more formal perspective, existentialization relies on the observation that a term of type `∀⍺.τ`, where `⍺` is a type variable that may occur in `τ`, can be transformed into a term of type `∃⍺.ω → τ` in which the extra parameter witnesses `⍺`'s properties at runtime.
-> One can then [skolemize](https://en.wikipedia.org/wiki/Skolem_normal_form) existentially quantified variable to get rid of the quantifier, resulting in a term of type `ω → τ` in which each occurrence of `⍺` has been replaced with a skolem (aka rigid variable).
+> Formally, existentialization transforms a term of type `∀⍺.τ`, where `⍺` is a type variable that may occur in `τ`, into a term of type `∃⍺.ω → τ` in which the extra parameter witnesses `⍺`'s properties at runtime.
+> It then [skolemizes](https://en.wikipedia.org/wiki/Skolem_normal_form) the existentially quantified variable to get rid of the quantifier, resulting in a term of type `ω → τ` in which each occurrence of `⍺` has been replaced with a skolem (aka rigid variable).
 >
-> For example, given a function of type `∀⍺.⍺ → ⍺`, we first construct a function `∃⍺.ω → ⍺ → ⍺` before applying skolemization to replace occurrences of `⍺` by some unique skolem `κ` and end up with a term of type `ω → κ → κ`, which is a monomorphic function.
+> For example, given a function of type `∀⍺.⍺ → ⍺`, we construct a function `∃⍺.ω → ⍺ → ⍺`, we then skolemize it, replacing occurrences of `⍺` by with a unique skolem `κ`, and end up with a monomorphic function of type `ω → κ → κ`.
 >
-> Note that nothing in the type system that links `ω` to neither `⍺` nor `κ`.
+> Note that nothing in the type system links `ω` to either `⍺` or `κ`.
 > As a consequence, the compiler cannot verify the type safety of a function after it has been existentialized.
 > This issue is inconvenient but does not invalidate the safety of the source language, since existentialization preserves semantics.
 > Hence, a showing the well-typedness of a polymorphic function provides guarantees about the behavior of its existentialized form, at least in principle.

--- a/Docs/Depolmorphization.md
+++ b/Docs/Depolmorphization.md
@@ -1,4 +1,4 @@
-# Deploymorphization
+# Depolymorphization
 
 A function (or type) is polymorphic iff it accepts type parameters and monomorphic otherwise.
 The implementation (aka definition) of a monomorphic function may feature uses of polymorphic constructs that have to be either *monomorphized* or *existentialized* before IR can be compiled to machine code.

--- a/Docs/Depolmorphization.md
+++ b/Docs/Depolmorphization.md
@@ -1,9 +1,395 @@
 # Deploymorphization
 
 A function (or type) is polymorphic iff it accepts type parameters and monomorphic otherwise.
-The implementation (aka definition) of a monomorphic function may feature uses of polymorphic constructs that have to be either monomorphized or existentialized before IR can be compiled
-to machine code.
-This transformation is referred to as *depolymorphization*.
+The implementation (aka definition) of a monomorphic function may feature uses of polymorphic constructs that have to be either *monomorphized* or *existentialized* before IR can be compiled to machine code.
+These transformations are referred to as *depolymorphization*.
 
 Both monomorphization and existentialization essentially consist of creating a copy of the polymorphic function.
-In the former case, type arguments are simply substituted for their corresponding parameters. In the latter case, the type parameters are transformed into term parameters accepting type witnesses at run-time.
+In the former case, type arguments are simply substituted for their corresponding parameters.
+In the latter case, the type parameters are transformed into term parameters accepting type witnesses at run-time.
+
+This document describes how Hylo implements depolymorphization.
+
+> Disclaimer:
+> The syntax of Hylo IR is far from final.
+> Snippets are intended as illustration rather than specification.
+
+## Existentialization
+
+In a nutshell, existentialization consists of replacing type parameters with term parameters while abstracting over any information that cannot be determined at compile-time.
+Consider the following example to illustrate this concept:
+
+```hylo
+fun swap<T is Movable>(a: inout T, b: inout T) {
+  var x = a ; a = b ; b = x
+}
+```
+
+The first step to compile this function is to lower it to Hylo IR.
+Recall a conformance constraint such as `T is Movable` is always compiled to term parameter accepting a conformance witness.
+As a result, the signature of the lowered form of `swap(_:_:)` is as follows:
+
+```hylo
+fun swap(_:_:)<T>(
+  let %p0: Movable<T>, inout %p1: T, inout %p2: T, set %p3: Void
+)
+```
+
+The function is still polymorphic at this stage, taking a type parameter `T`.
+`%p0` accepts a witness of `T`'s conformance to movable.
+`%p1` and `%p2`, correspond to `a` and `b`, respectively.
+Finally, `%p3` denotes the output register of the function, i.e., the place to which its result is written.
+
+Existentialization will produce a copy of this function in which the type parameter `T` is replaced with a term parameters:
+
+```hylo
+fun swap(_:_:).existentialized(
+  let %p0: Type, let %p1: Movable<?0>, inout %p2: ?0, inout %p3: ?0, set %p4: Void
+)
+```
+
+Rather than taking a type parameter, this function accepts a *type witness* as its first parameter `%p0`.
+This type witness will be used to obtain information about the layout of `T`, as we shall see later.
+The following parameters are the same as those of the polymorphic version, just renamed.
+Finally, occurrences of `T` have been replaced with `?0`, which denotes a *skolem* representing some type unknown at compile time.
+
+> From a more formal perspective, existentialization relies on the observation that a term of type `∀⍺.τ`, where `⍺` is a type variable that may occur in `τ`, can be transformed into a term of type `∃⍺.ω → τ` in which the extra parameter witnesses `⍺`'s properties at runtime.
+> One can then [skolemize](https://en.wikipedia.org/wiki/Skolem_normal_form) existentially quantified variable to get rid of the quantifier, resulting in a term of type `ω → τ` in which each occurrence of `⍺` has been replaced with a skolem (aka rigid variable).
+>
+> For example, given a function of type `∀⍺.⍺ → ⍺`, we first construct a function `∃⍺.ω → ⍺ → ⍺` before applying skolemization to replace occurrences of `⍺` by some unique skolem `κ` and end up with a term of type `ω → κ → κ`, which is a monomorphic function.
+>
+> Note that nothing in the type system that links `ω` to neither `⍺` nor `κ`.
+> As a consequence, the compiler cannot verify the type safety of a function after it has been existentialized.
+> This issue is inconvenient but does not invalidate the safety of the source language, since existentialization preserves semantics.
+> Hence, a showing the well-typedness of a polymorphic function provides guarantees about the behavior of its existentialized form, at least in principle.
+> No formal theorem has been proven at the time of this writing.
+
+### Existentializing definitions
+
+Notice that the existentialized form of `swap(_:_:)` is monomorphic, as it no longer accepts any type argument.
+As a result, it can be compiled to LLVM and ultimately machine code.
+Naturally, the definition of the function should also be modified to eliminate uses of the type parameter.
+The details of this transformation are discussed below, using `swap(_:_:)` as a running example.
+
+> From a formal perspective, the mechanisms discussed below describe to the transformations applied to a polymorphic term of type `∀⍺.τ` to produce an monomorphic term of type `ω → τ[⍺ ↦ κ]`.
+
+#### Stack allocations
+
+Storage allocated on the stack is represented by `alloca` instructions in the IR.
+If the type of the allocated storage is concrete and not hidden behind a resilience boundary, the compiler can compute the size and alignment of the allocation at compile-time.
+Otherwise, the size of the allocation is read from a type witness at run-time.
+
+To illustrate, consider the allocation of `x` in the original polymorphic definition of `swap`, which is lowered to the following alloca:
+
+```hylo
+%r0 = alloca T, #preferred
+```
+
+As the function's definition gets existentialized, the compiler will conclude that `?0`'s layout is abstract and thus transform the allocation so that it uses the corresponding type witness instead.
+In our running example, recall that this witness is passed to `%p0`:
+
+```hylo
+%r1 = access [let] %p0
+%r0 = alloca %r1 as ?0, #preferred
+```
+
+A less trivial case arises when the allocation is for a generic type instantiated using a skolem.
+For instance, assume the following instruction was existentialized under the same conditions:
+
+```hylo
+%r0 = alloca T[2], #preferred
+```
+
+Because `%p0` is a witness of `T` (i.e., `?0` in the existentialized signature) and not `T[2]`, the compiler has to first construct a type witness of the latter before it can replace the `alloca`:
+
+```hylo
+%r3 = access [let] %p0
+%r2 = type_witness (<T> T[2])(%r3)
+%r1 = access [let] %r2
+%r0 = alloca %r1 as ?0, #preferred
+```
+
+Here, `%r2` is assigned to a type witness constructed at run-time.
+The semantics of the `type_witness` are discussed later.
+For now, it suffices to understand that it serves to apply a type constructor (i.e., `<T> T[2]`) to the witness of `?0` that is passed to `%p0`.
+Finally, the resulting new type witness is used to transform the `alloca`, as in the previous example.
+
+Note that the more occurrence of a type parameter in a type expression does not determine whether or not that expression denotes a type whose layout is abstract.
+For example, the type `Pointer<T>` does not have an abstract layout because it contains no stored property whose layout depends on `T`.
+Therefore, no change is necessary to existentialize an `alloca` creating a place for storing instances of `Pointer<T>`.
+
+> A non-generic type may also have an abstract layout if it is defined beyond a resilience boundary.
+> In this case, however, the first lowering phase will already have generated `alloca` instructions parameterized by type witnesses.
+
+#### Function calls
+
+Consider the following use of `swap(_:_:)`, in a monomorphic call site:
+
+```hylo
+public fun main() {
+  var m = 2
+  var n = 4
+  swap(&n, &m)
+}
+```
+
+The use elaborates to `swap<Int>` during typing and is compiled to a type application during lowering.
+Specifically, the emitter produces the following IR:
+
+```hylo
+%r0 = type_apply swap(_:_:)<Int>
+%r1 = apply %r0(%w, %m, %n) => %u
+```
+
+`%r0` is the result of applying the lowered form of `swap(_:_:)` to `Int`.
+It occurs as the callee in the second line, which assumes that `%w` is a `let` access on the evidence that `Int` is `Movable`, that `%m` and `%n` are `inout` accesses to the places whose contents are exchanged, and that `%u` is a `set` access to a place for storing a unit value (i.e., the result of the call).
+
+Existentializing this sequence of instructions requires three modifications to the `apply` instruction at the end.
+First, we should substitute a reference to the existentialized form of `swap(_:_:)` for `%r0`.
+Second, we should pass a type witness of `Int` to the additional parameter this function accepts.
+Finally, we should remove the `type_apply` instruction.
+The resulting IR will be as follows:
+
+```hylo
+%r2 = type_witness Int()
+%r3 = access [let] %r2
+%r4 = place_cast %w as let Movable<?0>
+%r5 = place_cast %m as inout ?0
+%r6 = place_cast %n as inout ?0
+%r1 = apply swap(_:_:).existentialized(%r3, %r4, %r5, %r6) => %u
+```
+
+`%r2` is assigned to a value witnessing the properties of the type `Int`, which is used as a type constructor of arity 0.
+This value is passed to the first parameter of the call in the last line, applies the existentialized form of `swap(_:_:)` rather than its type application.
+The casts whose results are assigned to `%r4`, `%r5`, and `%r6` only serve to appease the type system so that the arguments' types match the parameters'.
+
+No other change is necessary.
+When the existentialized form of `swap(_:_:)` is eventually compiled to LLVM, the code generator will conclude that its parameters should be taken by reference since the size of a skolem is unknown at compile-time.
+
+#### Accesses to stored properties
+
+The way in which the stored properties of a type are laid out in memory depends on the sizes and alignment requirements of these properties.
+If the layout of a type is concrete and not hidden behind a resilience boundary, then the address of a particular stored property can be computed at compile time.
+Otherwise, this address must be computed at run-time by reading layout properties from a type witness.
+
+Hylo IR uses a relatively abstract instruction, called `property`, to express raw accesses to these properties.
+While this instruction abstracts over byte offset computation, it still distinguishes between compile-time and run-time address computation.
+To illustrate, consider an overload of `swap(_:_:)` that would operate on the elements of a pair.
+
+```hylo
+struct Pair<A, B> {
+  var first: A
+  var second: B
+}
+
+fun swap<T is Movable>(elements_of pair: Pair<T, T>) {
+  swap(&p.first, &p.second)
+}
+```
+
+The lowered form of `swap(elements_of:)`'s polymorphic definition, the `first` and `second` properties of the pair are accessed as follows:
+
+```hylo
+%r0 = property "first" of %pair as T
+```
+
+Here, `%pair` denotes the pair passed as an argument and `T` is the type of the property whose address is taken.
+As already discussed, `T` will be replaced by `?0` in the function's existentialized form.
+Just like with `allocate` instructions, the compiler will eventually conclude that `?0` is abstract and transform the instruction accordingly.
+Specifically, the property access will be modified to include a run-time witness of the type whose property is being accessed.
+
+```hylo
+%r1 = access [let] %p0
+%r2 = access [let] %p0
+%r3 = type_witness (<T, U> Pair<T, U>)(%r1, %r2)
+%r4 = access [let] %r3
+%r0 = property "first" of (%pair : %r4) as ?0
+```
+
+`%p0` and `%p1` are both accesses to the place containing the witness of `?0`, which are passed to a type constructor to form a witness of `Pair<?0, ?0>`.
+At run-time, this type witness will be used to determine the byte offset of the pair's `first` property.
+
+Accesses to members of a tuple or buffer are transformed similarly, only for another instruction.
+For example, should `Pair` be defined as an alias for `{T, U}` in source code, then the above example would be lowered as follows:
+
+```hylo
+%r1 = access [let] %p0
+%r2 = type_witness (<T> {T, T})(%r1)
+%r3 = access [let] %r2
+%r0 = subfield [0] of (%pair : %r3) as ?0
+```
+
+*The reason why the type constructor takes only one argument here is explained later, along with the discussion that examines the construction of run-time type witnesses.*
+
+#### Witness tables
+
+Before we delve into the details of witness table existentialization, we should first discuss how conformance declarations are lowered from source to IR.
+
+Consider the following program:
+
+```hylo
+trait P {
+  fun foo() -> Int
+  fun bar() -> Int { 1 - self.foo() }
+}
+
+given wa: Bool is P {
+  fun foo() -> Int { if self { 1 } else { 0 } }
+  fun bar() -> Int { if self { 0 } else { 1 } }
+}
+```
+
+A conformance declaration can be understood as a subscript that projects a value witnessing the conformance of a type to a trait.
+In the above example, `wa` declares a conformance of `Bool` to `P`, which can be seen as a subscript projecting an instance of `P<Bool>`.
+The value of this instance is a *witness table* describing how `P`'s requirements are implemented.
+
+Unsurprisingly, then, a conformance declaration is lowered like a subscript:
+
+```hylo
+fun wa() <: let P<Bool> {
+%b0:
+  %r0 = witness_table {
+    $implementation[P.foo for Self: Bool],
+    $implementation[P.bar for Self: Bool]
+  } as P<Bool>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r4 = return
+}
+
+fun $implementation[P.bar for Self: Bool](
+  let %p0: P<Bool>, let %p1: Bool, set %p2: Int
+) {
+  ...
+  %r3 = apply wa.bar(%r1) => %r2
+  ...
+}
+
+fun wa.bar(let %p0: Bool, set %p1: Int) { ... }
+```
+
+The instruction `witness_table` creates a witness table gathering the functions implementing the trait's requirements.
+Notice that these functions, which are called *implementation interfaces*, have a signature slightly different from those statisfying the trait requirements in the original source.
+Specifically, they accept an additional parameter of type `P<Bool>`, which denotes the witness itself.
+The reason for this mechanism will become more obvious later.
+For now, one can think of an implementation as a method of the witness that forwards calls to some other function.
+For instance, the implementation interface `$implementation[P.foo for Self: Bool]` simply forwards its arguments to `wa.foo`.
+
+At call site, using a method inherited by conformance involves two steps.
+The first is to obtain a witness table, either by applying a conformance declaration or reading a parameter.
+The second is to obtain the implementation contained in that table.
+For example, `true.foo[]` would be lowered as follows:
+
+```hylo
+%r0 = project w[]
+%r1 = property "foo" of %r0 as [Void](let P<Bool>, self: let Bool) <: let Int
+%r2 = access [let] %r0
+%r5 = apply %r1(%r2, %b) => %n
+```
+
+The first line assigns `%r0` to the witness table projected by the application of the conformance declaration.
+The next assigns `%r1` to the implementation of `foo` in that table.
+This function is finally called in the last line, assuming `%b` is a `let` access to a place storing `true` and `%n` is a set access to the storage in which the result of the call `foo` should be written.
+Notice that the witness table itself is passed as the first argument.
+
+We are now ready to examine how this mechanism interacts with existentialization.
+Implementation interfaces are there to provide a uniform way to refer to an implementation, regardless of the way it is defined in sources.
+To illustrate, imagine `wa` did not define `bar`, relying instead on the default implementation defined in the trait.
+The implementation interface of `bar` would change accordingly:
+
+```hylo
+fun $implementation[P.bar for Self: Bool](let %p0: P<Bool>, let %p1: Bool, set %p2: Int) {
+  ...
+  %r4 = apply P.bar.existentialized(%r10, %r11, %r12) => %r13
+  ...
+}
+
+fun P.bar<Self>(
+  let %p0: P<Self>, let %p1: Self, set %p2: Int
+) { ... }
+
+fun P.bar.existentialized(
+  let %p0: Type, let %p1: P<?0>, let %p2: ?0, set %p3: Int
+) { ... }
+```
+
+In this scenario, the default implementation of `bar` defined along with the trait is in fact generic over the `Self` parameter of that trait.
+As a result, it has to be existentialized (or monomorphized) before it can be used to construct a witness table instantiated with `Bool`.
+However, since existentialization will extend the parameter list of the polymorphic function, the resulting function's signature won't match the type expected at call sites.
+The implementation interface addresses this issue by supplying the extra argument.
+
+One complication arises when the conformance declaration is itself generic.
+For instance, consider the following example:
+
+```hylo
+given wb: <T> => T is P {
+  fun foo() -> Int { 0 }
+}
+```
+
+The implementation of `foo` in `wb` is generic over `T`.
+Yet, the signature of the trait requitement did not change and neither did the type of the implementation expected at call sites.
+While existentialization can produce a monomorphic version of this polymorphic function, calling it will require a type witness of the type argument instantiating the conformance.
+Unlike in the previous case, however, this type witness is not constant and thus we cannot simply modify the implementation interface.
+
+In fact, the type witness that should be passed to the existentialized form of `foo` is first passed to the existentialized form of the conformance declaration.
+To illustrate, let us examine a use of `wb` lowered to IR:
+
+```hylo
+%r0 = type_witness Bool()
+%r1 = access [let] %r2
+%r2 = project wb.existentialized[%r1]
+%r3 = property "foo" of %r2 as [Void](let P<Bool>, self: let Bool) let -> Int
+%r4 = access [let] %r0
+%r5 = apply %r3(%r4, %b) => %n
+```
+
+The function assigned to `%r3` is expected to have the same signature as in the previous example, meaning that its interface can't forward a type witness from its own parameters.
+Instead, the type witness can be captured into the witness table projected by the application of `wb`.
+Then, since a witness table is passed as the first argument of a call to an implementation interface, the latter can extract the captured witness and forward it.
+The following snippet illustrates:
+
+```hylo
+fun wb.existentialized(let %p0: Type) let <: P<?0> {
+%b0:
+  %r5 = access [let] %p0
+  %r0 = witness_table {
+    $implementation[P.foo for Self: ?0].existentialized.applied_0,
+    $implementation[P.bar for Self: ?0].existentialized.applied_0
+  } + [%r5] as P<?0>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r6 = end %r5
+  %r4 = return
+}
+
+fun $implementation[P.foo for Self: ?0].existentialized.applied_0(
+  let %p0: P<?0>, let %p1: ?0, set %p2: Int
+) {
+%b0:
+  %r0 = witness_table_stash %p0 as {Type}
+  ...
+  %r6 = apply $implementation[P.foo for Self: ?0].existentialized(%r2, %r3, %r4) => %r5
+  ...
+}
+
+fun $implementation[P.foo for Self: ?0].existentialized(
+  let %p0: Type, let %p1: P<?0>, let %p2: ?0, set %p3: Int
+) { ... }
+```
+
+The existentialization of `foo`'s implementation interface results in the last function, which accepts a type witness of the trait's `Self` parameter as its first argument.
+The second function represents this interface partially applied to its first argument.
+The value of the witness is read from the witness table using the `witness_table_stash` instruction, which projects the place containing the captures of a witness table.
+Finally, the witness table is filled with the partially applied interfaces, along with a capture of the type witness passed to the conformance declaration.
+
+Note that nothing in the type system guarantees the safety of these functions.
+Instead, the sole argument justifying their correctness is that they are all the product of a mechanical transformation.
+In particular, unlike the type of a lambda, the type of a witness table does not describe the shape of its captures.
+Consequently, `witness_table_stash` unsafely assumes the shape of the table's captures.
+
+The lifetimes of a table's captures are guaranteed to exceed the lifetime of the table itself because witness tables do not yet support copying or relocation.
+This limitation should be lifted in the future, requiring a mechanism to ensure the liveness of a table's captures.
+No design has been finalized yet, but a promising approach would be to require captures to be `Regular` and make them part of escaping tables.

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -208,6 +208,8 @@ extension Program {
       return incorporate(ctx.ir.castUnchecked(i, to: IRUnreachable.self), in: &ctx)
     case IRWitnessTable.self:
       return incorporate(ctx.ir.castUnchecked(i, to: IRWitnessTable.self), in: &ctx)
+    case IRWitnessTableStash.self:
+      return incorporate(ctx.ir.castUnchecked(i, to: IRWitnessTableStash.self), in: &ctx)
     case IRYield.self:
       return incorporate(ctx.ir.castUnchecked(i, to: IRYield.self), in: &ctx)
     case let s:
@@ -764,26 +766,80 @@ extension Program {
   ) -> AnyInstructionIdentity? {
     let s = ctx.ir.at(i)
 
-    let entries = s.operands.map { (x) in
-      codegen(x, in: &ctx)
+    // A witness table is composed of a field for each requirement of the trait whose conformance
+    // is witnessed (i.e., the table's entries), followed by the table's captures.
+    let abstractTableType = metadata(of: s.witnessType, in: &ctx.module)
+    let entriesType = StructType.UnsafeReference(abstractTableType.llvm)!
+    let entriesSize = ctx.module.llvm.layout.storageSize(of: entriesType)
+
+    let storageAlignment = abstractTableType.layout.alignment
+    var storageSize = entriesSize
+
+    if !s.captures.isEmpty {
+      let p = types.demand(MachineType.ptr).erased
+      let r = record(fields: Array(repeating: p, count: s.captures.count), in: &ctx.module)
+
+      // Captures are represented as a sequence of pointers laid out contiguously in the order in
+      // which they appear in the instruction.
+      assert(r.propertyToField.elementsEqual(0 ..< s.captures.count))
+      assert(storageAlignment & (r.alignment - 1) == 0)
+      storageSize += r.size.fixed!
     }
 
-    let tableType = metadata(of: s.witnessType, in: &ctx.module)
+    // Allocate storage for the entire table.
+    let tableRawType = ctx.module.llvm.arrayType(storageSize, ctx.module.llvm.i8)
+    let storage = ctx.module.llvm.insertAlloca(tableRawType, atEntryOf: ctx.result.value)
+    ctx.module.llvm.setAlignment(storageAlignment, for: storage)
 
-    unimplemented(if: !entries.allSatisfy(\.unsafe[].isConstant),
-      """
-      Runtime-defined IRWitnessTable operand. https://github.com/hylo-lang/hylo-new/issues/342
+    // Store the entries.
+    let entries = s.entries.map({ (x) in codegen(x, in: &ctx) })
+    let requirements = ctx.module.llvm.structConstant(of: entriesType, aggregating: entries)
+    ctx.module.llvm.insertStore(
+      requirements, to: storage, alignedAt: storageAlignment,
+      at: ctx.insertionPoint!)
 
-      In:
-      \(show(ctx.ir))
+    let table = ctx.module.llvm.insertGetElementPointerInBounds(
+      of: storage, typed: tableRawType,
+      indices: [0], indexType: ctx.module.llvm.i32,
+      at: ctx.insertionPoint!)
 
-      """)
+    // Store the captures, if any.
+    if !s.captures.isEmpty {
+      // The computation of an individual capture's offset is justified by the assertions made
+      // during the computation of the storage's size and alignment.
+      let stride = ctx.module.llvm.layout.pointerSize
+      for (i, c) in s.captures.enumerated() {
+        let x0 = codegen(c, in: &ctx)
+        let x1 = ctx.module.llvm.insertGetElementPointerInBounds(
+          of: table, typed: tableRawType,
+          indices: [entriesSize + (i * stride)], indexType: ctx.module.llvm.i32,
+          at: ctx.insertionPoint!)
+        ctx.module.llvm.insertStore(x0, to: x1, at: ctx.insertionPoint!)
+      }
+    }
 
-    let table = ctx.module.llvm.structConstant(
-      of: StructType.UnsafeReference(tableType.llvm)!, aggregating: entries)
+    ctx.value[.register(i.erased)] = table.v
+    return ctx.ir.instruction(after: i.erased)
+  }
 
-    let v = IRValue.register(i.erased)
-    ctx.value[v] = table.v
+  /// Generates the LLVM IR code corresponding to `i`.
+  internal mutating func incorporate(
+    _ i: IRWitnessTableStash.ID, in ctx: inout FunctionGenerationContext
+  ) -> AnyInstructionIdentity? {
+    let s = ctx.ir.at(i)
+
+    let abstractTableTypeInHylo = ctx.ir.result(of: s.source)!.type
+    let abstractTableType = metadata(of: abstractTableTypeInHylo, in: &ctx.module)
+    let entriesType = StructType.UnsafeReference(abstractTableType.llvm)!
+    let entriesSize = ctx.module.llvm.layout.storageSize(of: entriesType)
+
+    let x0 = codegen(s.source, in: &ctx)
+    let x1 = ctx.module.llvm.insertGetElementPointerInBounds(
+      of: x0, typed: ctx.module.llvm.i8,
+      indices: [entriesSize], indexType: ctx.module.llvm.i32,
+      at: ctx.insertionPoint!)
+
+    ctx.value[.register(i.erased)] = x1.v
     return ctx.ir.instruction(after: i.erased)
   }
 
@@ -848,9 +904,7 @@ extension Program {
     }
 
     let name = llvmName(function: ir.name)
-    let signature = ir.signature()
-
-    let p = prototype(signature.head, in: &ctx)
+    let p = prototype(ir.signature.head(), in: &ctx)
     let v = ctx.llvm.declareFunction(name, p.signature)
     setupAttributes(of: v, compiledFrom: ir, in: &ctx)
 
@@ -1605,10 +1659,9 @@ extension Program {
         fs.append(ctx.llvm.functionPointer.t, count: rs.members.count)
 
         let v = ctx.llvm.structType(named: n, fs)
-        let s = ctx.llvm.layout.storageSize(of: v)
-        let a = ctx.llvm.layout.preferredAlignment(of: v)
+        let a = ctx.dynamicAllocationAlignment()
         let l = ConcreteLayout(
-          fields: [], propertyToField: Array(fs.indices), size: .fixed(s), alignment: a)
+          fields: [], propertyToField: Array(fs.indices), size: .dynamic, alignment: a)
         return TypeMetadata(llvm: v, layout: l)
       } else if let fields = program.fields(of: t.erased, visibleFrom: ctx.hylo) {
         return program.metadata(record: n, fields: fields, in: &ctx)

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -585,7 +585,7 @@ extension Program {
   ///
   /// Code dominated by `i` is compiled into a different function that is passed as a callback to
   /// the subscript. The call to this subscript returns the identifier of the basic block to which
-  /// control-flow should be transferred, if any.
+  /// control flow should be transferred, if any.
   ///
   /// This method extends `ctx.factoredOut` with the basic blocks that have been compiled into the
   /// callback. These basic blocks cannot have been visited yet, since they are dominated by `i`.

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -1667,7 +1667,7 @@ extension Program {
   ) -> TypeMetadata {
     // Trivial if there are less than two cases.
     if cases.count <= 1 {
-      return metadata(record: name, fields: Array(contentsOf: cases.uniqueElement), in: &ctx)
+      return metadata(record: name, fields: Array(unwrapping: cases.uniqueElement), in: &ctx)
     }
 
     // Otherwise, construct a pair leading with the tag.

--- a/Sources/BackEnd/Program+LLVM.swift
+++ b/Sources/BackEnd/Program+LLVM.swift
@@ -581,10 +581,9 @@ extension Program {
 
   /// Generates the LLVM IR code corresponding to `i`.
   ///
-  /// The instruction is compiled as a direct call iff the subscriptsubscript being applied is an
-  /// addressor. Otherwise, code dominated by `i` is compiled into a different function that is
-  /// passed as a callback to the subscript. The call to this subscript returns the identifier of
-  /// the basic block to which control-flow should be transferred, if any.
+  /// Code dominated by `i` is compiled into a different function that is passed as a callback to
+  /// the subscript. The call to this subscript returns the identifier of the basic block to which
+  /// control-flow should be transferred, if any.
   ///
   /// This method extends `ctx.factoredOut` with the basic blocks that have been compiled into the
   /// callback. These basic blocks cannot have been visited yet, since they are dominated by `i`.
@@ -593,15 +592,6 @@ extension Program {
     _ i: IRProject.ID, in ctx: inout FunctionGenerationContext
   ) -> AnyInstructionIdentity? {
     let s = ctx.ir.at(i)
-
-    // Is the callee an addressor?
-    if let n = seenAsAddressor(s.callee, in: ctx) {
-      let f = demandFunction(named: n, in: &ctx.module)
-      let x = insertArguments(s.arguments, mappedWith: f.prototype.mapping, in: &ctx)
-      let y = ctx.module.llvm.insertCall(f.value, on: x, at: ctx.insertionPoint!)
-      _ = y
-      fatalError()
-    }
 
     // Otherwise, compile the plateau following the project instruction.
     let (plateau, captures, covered) = definePlateau(dominatedBy: i, in: &ctx)
@@ -1752,23 +1742,6 @@ extension Program {
       return ctx.llvm.functionPointer.t
     } else {
       return metadata(of: t, in: &ctx).llvm
-    }
-  }
-
-  /// Returns `v` iff identifies a subscript known to have a slide that compiles to a no-op.
-  private func seenAsAddressor(
-    _ v: FrontEnd.IRValue, in ctx: borrowing FunctionGenerationContext
-  ) -> IRFunction.Name? {
-    switch v {
-    case .function(let f, _):
-      if case .remote(_, _, let b) = self[ctx.module.hylo].ir.functions[f]?.output {
-        return b ? f : nil
-      } else {
-        return nil
-      }
-
-    default:
-      return nil
     }
   }
 

--- a/Sources/BackEnd/SubscriptDecomposition.swift
+++ b/Sources/BackEnd/SubscriptDecomposition.swift
@@ -570,8 +570,8 @@ extension Program {
     // Other dominating definitions may have to be redefined as well.
     for v in prologue.definitions {
       guard let i = v.register else { continue }
-      switch ctx.ir.tag(of: i) {
-      case IRAlloca.self, IRProject.self:
+      switch ctx.ir.relevanceInSlideOrPlateau(i) {
+      case .captured:
         assert(ctx.value[v] != nil, "instruction should have been redefined")
       default:
         _ = incorporate(i, in: &ctx)
@@ -601,7 +601,7 @@ extension IRFunction {
   /// Returns the relevance of `i`, which is an instruction in the prologue of a slide or plateau.
   fileprivate func relevanceInSlideOrPlateau(_ i: AnyInstructionIdentity) -> InstructionRelevance {
     switch tag(of: i) {
-    case IRAlloca.self, IRProject.self:
+    case IRAlloca.self, IRProject.self, IRWitnessTable.self:
       return .captured
 
     case

--- a/Sources/FrontEnd/Diagnostic.swift
+++ b/Sources/FrontEnd/Diagnostic.swift
@@ -293,7 +293,7 @@ extension Program {
         note = .init(.note, "is that an unmatched block comment delimiter?", at: site)
       }
 
-      return .init(.error, message, at: site, notes: Array(contentsOf: note))
+      return .init(.error, message, at: site, notes: Array(unwrapping: note))
     } else {
       return .init(.error, "undefined symbol '\(n)'", at: site)
     }

--- a/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
+++ b/Sources/FrontEnd/IR/IREmitter+Deploymorphization.swift
@@ -18,6 +18,8 @@ extension IREmitter {
       switch f.tag(of: i) {
       case IRTypeApply.self:
         depolymorphize(f.castUnchecked(i, to: IRTypeApply.self), in: &f, reusing: &witnesses)
+      case IRWitnessTable.self:
+        depolymorphize(f.castUnchecked(i, to: IRWitnessTable.self), in: &f, reusing: &witnesses)
       default:
         continue
       }
@@ -52,7 +54,42 @@ extension IREmitter {
       unimplemented("first class function deploymorphization")
     }
   }
-  
+
+  /// Replaces uses of `i` its existentialized form.
+  private mutating func depolymorphize(
+    _ i: IRWitnessTable.ID, in f: inout IRFunction,
+    reusing witnesses: inout [AnyTypeIdentity: IRValue]
+  ) {
+    // Nothing to do if the witness table isn't generic.
+    let s = f.at(i)
+    if s.arguments.isEmpty { return }
+    unimplemented(if: !s.captures.isEmpty, "captures in generic witness table")
+
+    let ws = lowering(before: i.erased, in: &f) { (me) in
+      me._emitAccessTypeWitnesses(for: s.arguments, reusing: &witnesses)
+    }
+
+    let entries = s.entries.map { (e) in
+      // Is the entry implementing a function requirement?
+      guard case .function(let n, _) = e else { return e }
+
+      // Is the entry polymorphic?
+      let maybePoly = program[module].ir[program[module].ir.identity(function: n)!]
+      if !maybePoly.isMonomorphic {
+        let p = definePartialApplicationExistentializing(maybePoly)
+        return functionReference(to: p)
+      } else {
+        return e
+      }
+    }
+
+    let new = IRWitnessTable(
+      instantiatedWith: [:], aggregating: entries, capturing: ws,
+      as: s.witnessType,
+      at: s.anchor)
+    f.replace(i.erased, with: new)
+  }
+
   /// Replaces uses of `i`, which is a type application of the polymorphic function `c`, with their
   /// existentialized forms.
   private mutating func depolymorphize(
@@ -69,10 +106,8 @@ extension IREmitter {
     // Create an array with a type witness for each of the type argument passed to `i`. These
     // witnesses will be concatenated with the term arguments of each use application of `c`
     // instantiated by `i`.
-    let witnesses = lowering(before: i.erased, in: &f) { (e) in
-      application.arguments.values.map { (a) in
-        e._emitTypeWitness(of: a.erased, reusing: &witnesses)
-      }
+    let ws = lowering(before: i.erased, in: &f) { (me) in
+      me._emitAccessTypeWitnesses(for: application.arguments, reusing: &witnesses)
     }
 
     // Update the uses of the type application.
@@ -82,12 +117,12 @@ extension IREmitter {
         // `i` is used as a callee in an ordinary function application.
         depolymorphize(
           polymorphicApplyUser: u.user, with: mono,
-          passing: witnesses, to: poly.termParameters, in: &f)
+          passing: ws, to: poly.signature.termParameters, in: &f)
 
       case IRProject.self where u.index == 0:
         depolymorphize(
           polymorphicProjectUser: u.user, with: mono,
-          passing: witnesses, to: poly.termParameters, in: &f)
+          passing: ws, to: poly.signature.termParameters, in: &f)
 
       default:
         unimplemented()
@@ -184,17 +219,71 @@ extension IREmitter {
     // The existentialized form of the function takes the generic parameter as type witnesses
     // before the term parameters of the polymorphic form.
     var ps: [IRParameter] = .init(
-      minimumCapacity: poly.typeParameters.count + poly.termParameters.count)
-    for p in poly.typeParameters {
-      let t = program.types.demand(TypeWitness()).erased
+      minimumCapacity: poly.signature.typeParameters.count + poly.signature.termParameters.count)
+    let t = program.types.demand(TypeWitness()).erased
+    for p in poly.signature.typeParameters {
       let d = program.types[p].declaration.map(DeclarationIdentity.init(_:))
       ps.append(.init(type: t, access: .let, declaration: d))
     }
 
-    ps.append(contentsOf: poly.termParameters)
-    let mono = IRFunction(
-      name: n, anchor: poly.anchor, output: poly.output, typeParameters: [], termParameters: ps)
+    ps.append(contentsOf: poly.signature.termParameters)
+    let s = IRFunction.Signature(
+      typeParameters: [], termParameters: ps, output: poly.signature.output)
+    let mono = IRFunction(name: n, anchor: poly.anchor, signature: s)
     return program[module].ir.addFunction(mono)
+  }
+
+  /// Returns a partial application of `poly`, which is the generic interface of an implementation
+  /// stored in a witness table, to the type arguments captured by that witness table.
+  ///
+  /// When a generic conformance declaration is existentialized, the entries stored in the witness
+  /// table that is projected must be partially applied to the existentialized arguments to present
+  /// the right interface. Consider the following to illustrate:
+  ///
+  ///     trait P { fun f() }
+  ///     given w: <T> => T is P { fun f() {} }
+  ///
+  /// The implementation of `f` defined in `w` is generic over `T`, meaning that it has to be
+  /// existentialized along with `w`. However, the resulting existentialized form takes one more
+  /// term parameter than the signature of `f` advertises. Hence, we have to construct another
+  /// function reading the argument to this parameter from the captures of the existentialized
+  /// witness table, which is passed as the first argument.
+  private mutating func definePartialApplicationExistentializing(
+    _ poly: IRFunction
+  ) -> IRFunction.ID {
+    // Existentialize the polymorphic function.
+    let mono = demandExistentialized(poly)
+
+    // Declare the function forwarding the call to the existentialized function.
+    let types = poly.signature.typeParameters
+    let terms = poly.signature.termParameters
+    var applied = IRFunction(
+      name: .applied(program[module].ir[mono].name, 0), // TODO compute a discriminator
+      anchor: poly.anchor,
+      signature: .init(typeParameters: [], termParameters: terms, output: poly.signature.output))
+
+    // Define the body of that function.
+    let entry = applied.addBlock()
+    lowering(.end(of: entry), anchoredTo: poly.anchor, in: &applied) { (me) in
+      let t = me.program.types.demand(TypeWitness()).erased
+      let u = me.program.types.tuple(of: Array(repeating: t, count: types.count))
+      let stash = me._witness_table_stash(of: .parameter(0), as: u)
+
+      let callee = me.functionReference(to: mono)
+      var arguments: [IRValue] = []
+      for i in 0 ..< types.count { arguments.append(me._subfield(stash, at: [i])) }
+      for i in 0 ..< terms.count { arguments.append(.parameter(i)) }
+
+      if poly.isSubscript {
+        unimplemented()
+      } else {
+        let r = arguments.removeLast()
+        me._apply(callee, arguments, into: r, argumentAccesses: .formAndClose)
+      }
+      me._return()
+    }
+
+    return program[module].ir.addFunction(applied)
   }
 
   /// Emits the existentialized definition of `poly` into its existentialized form, adding the
@@ -203,8 +292,8 @@ extension IREmitter {
   /// `poly` is a polymorphic function whose implementation is defined in the current module. Its
   /// existentialized form has not been defined yet, although it may have been declared.
   internal mutating func existentialize(_ poly: IRFunction) {
-    let m = demandExistentialized(poly)
-    existentialize(poly, into: m)
+    let mono = demandExistentialized(poly)
+    existentialize(poly, into: mono)
   }
 
   /// Emits the existentialized definition of `poly` into `m`.
@@ -216,7 +305,7 @@ extension IREmitter {
     assert(poly.isDefined && !target.isDefined, "existentialization already completed")
 
     /// The type parameters of the function being existentialized.
-    let parameters = poly.typeParameters
+    let parameters = poly.signature.typeParameters
 
     /// A table mapping type parameters from the source to their corresponding term parameters in
     /// the existentialized translation.
@@ -228,7 +317,7 @@ extension IREmitter {
     for b in poly.blocks.addresses {
       properties[b] = target.addBlock()
     }
-    for i in poly.termParameters.indices {
+    for i in poly.signature.termParameters.indices {
       properties[IRValue.parameter(i)] = .parameter(i + parameters.count)
     }
 
@@ -253,7 +342,7 @@ extension IREmitter {
             if ps.isEmpty {
               properties[.register(i)] = me.insert(s)!
             } else {
-              let w = me._emitTypeWitness(of: s.storage, reusing: &witnesses)
+              let w = me._emitAccessTypeWitness(of: s.storage, reusing: &witnesses)
               properties[.register(i)] = me._alloca(w, as: s.storage, alignment: s.alignment)
             }
           }

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -1144,7 +1144,7 @@ internal struct IREmitter {
   ) -> LoweredCallee {
     LoweredCallee(
       value: functionReference(to: f),
-      typeArguments: [:], arguments: Array(contentsOf: receiver),
+      typeArguments: [:], arguments: Array(unwrapping: receiver),
       result: r)
   }
 
@@ -1177,7 +1177,7 @@ internal struct IREmitter {
       let t = program.types.demand(s)
       let v = IRValue.bundle(f, t, candidates)
       return LoweredCallee(
-        value: v, typeArguments: [:], arguments: Array(contentsOf: receiver), result: r)
+        value: v, typeArguments: [:], arguments: Array(unwrapping: receiver), result: r)
     }
   }
 

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -264,7 +264,7 @@ internal struct IREmitter {
   /// insertion context is configured to generate IR into its lowered form.
   private mutating func lowerDefinition(_ d: ConformanceDeclaration.ID) {
     insertionContext.anchor = program.anchor(introducerOf: d)
-    let (_, w, _) = currentFunction.output.remote!
+    let (_, w) = currentFunction.output.remote!
 
     // If the conformance is a nested given, we can simply extract the witness from the parameter
     // accepting a witness of a conformance to the enclosing trait.
@@ -660,7 +660,7 @@ internal struct IREmitter {
 
   /// Generates the IR of `s`.
   private mutating func lower(_ s: Yield.ID) -> ControlFlow {
-    let (k, _, _) = currentFunction.output.remote!
+    let (k, _) = currentFunction.output.remote!
     let v = lowered(lvalue: program[s].value)
     lowering(s) { (me) in
       let x = me._access([k], from: v)
@@ -1668,7 +1668,7 @@ internal struct IREmitter {
       terms.append(IRParameter(type: u, access: .let, declaration: nil))
     }
 
-    return (terms, .remote(.let, witness.head, isAddressor: false))
+    return (terms, .remote(.let, witness.head))
   }
 
   /// Returns the term parameters and return type of `d`'s lowered representation.
@@ -1739,7 +1739,7 @@ internal struct IREmitter {
       terms.append(IRParameter(type: t, access: .set, declaration: nil))
       return (terms, .indirect)
     } else {
-      return (terms, .remote(program.types[shape].effect, t, isAddressor: false))
+      return (terms, .remote(program.types[shape].effect, t))
     }
   }
 

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -942,7 +942,7 @@ internal struct IREmitter {
     ///   - typeArguments Type arguments partially instantiating the callee.
     ///   - usings Term arguments passed to the callee's contextual term parameters.
     ///   - receiver The value to which the callee is bound, if any.
-    ///   - result The argument to the calle's output parameter if it is an ordinary function.
+    ///   - result The argument to the callee's output parameter if it is an ordinary function.
     init(
       _ value: IRValue,
       instantiatedWith typeArguments: TypeArguments = [:],
@@ -3253,7 +3253,7 @@ internal struct IREmitter {
   }
 
   /// Returns the type arguments passed to the implementation `m` satisfying a trait requirement in
-  /// in the context of `d`, which declares a witness of tyoe `w`.
+  /// in the context of `d`, which declares a witness of type `w`.
   private mutating func argumentsInstantiating(
     implementation m: DeclarationIdentity,
     in d: ConformanceDeclaration.ID, declaring w: AnyTypeIdentity

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -63,7 +63,7 @@ internal struct IREmitter {
     defining(f, at: program[module].ir[f].anchor) { (me) in
       // The first parameter of `f` is a witness of `Deinitializable` and the second parameter is
       // the instance to deinitialize.
-      let abstract = me.currentFunction.termParameters[1].type
+      let abstract = me.currentFunction.signature.termParameters[1].type
       let concrete = me.program.types.substitute(a, in: abstract)
 
       // Is the receiver trivial to deinitialize?
@@ -264,12 +264,12 @@ internal struct IREmitter {
   /// insertion context is configured to generate IR into its lowered form.
   private mutating func lowerDefinition(_ d: ConformanceDeclaration.ID) {
     insertionContext.anchor = program.anchor(introducerOf: d)
-    let (_, w) = currentFunction.output.remote!
+    let (_, declaredWitness) = currentFunction.signature.output.remote!
 
     // If the conformance is a nested given, we can simply extract the witness from the parameter
     // accepting a witness of a conformance to the enclosing trait.
     if program.isRequirement(d) {
-      let x0 = _property(.init(d), of: .parameter(0), withType: w)
+      let x0 = _property(.init(d), of: .parameter(0), withType: declaredWitness)
       let x1 = _access([.let], from: x0)
       _yield(x1)
       _return()
@@ -284,24 +284,30 @@ internal struct IREmitter {
     let table = program.implementations(definedBy: d)
     let concept = program.types[table.concept].declaration
     let requirements = program.requirements(of: table.concept)
+    unimplemented(if: !requirements.types.isEmpty, "associated types")
 
-    var members: [IRValue] = .init(minimumCapacity: requirements.all.count)
+    var entries: [IRValue] = .init(minimumCapacity: requirements.all.count)
     let incompleteTable: () -> Never = { [s = program.spanForDiagnostic(about: d)] in
       fatalError("incomplete witness table at \(s)")
     }
 
     for r in requirements.conformances {
       let implementation = table.conformance(implementing: r) ?? incompleteTable()
-      members.append(_emit(witness: implementation))
+      entries.append(_emit(witness: implementation))
     }
 
     for r in requirements.members {
+      unimplemented(
+        if: program.types.hasContext(program.type(assignedTo: r)),
+        "generic trait requirement")
+
       // Declare the interface function.
       let implementation = table.member(implementing: r) ?? incompleteTable()
       let interface = demandLoweredDeclaration(
-        implementationOf: r, synthesized: implementation.isSynthetic,
-        for: d, table.arguments)
-      members.append(functionReference(to: interface))
+        implementationOf: r, synthesized: implementation.isSynthetic, for: d, table.arguments)
+
+      // Add the interface to the witness table.
+      entries.append(functionReference(to: interface))
 
       // Emit the definition of the interface function.
       switch implementation {
@@ -313,37 +319,47 @@ internal struct IREmitter {
         // The implementation is defined in the trait itself.
         defining(interface, at: program.anchor(introducerOf: d)) { (me) in
           let defaultImplementation = me.demandLoweredDeclaration(functionOrConformance: m)
-          let x0 = me.functionReference(to: defaultImplementation)
-          let x1 = me._type_apply(x0, to: table.arguments)
-          me._emitCallToRequirementImplementation(x1, [.parameter(0)])
+          let callee = me.functionReference(to: defaultImplementation)
+          me._emitCallRequirementImplementation(
+            callee, with: [.parameter(0)], instantiatedWith: table.arguments)
+        }
+
+      case .direct(let m):
+        // The implementations is defined either in the conformance declaration directly or in the
+        // declaration of the conforming type.
+        let ts = argumentsInstantiating(implementation: m, in: d, declaring: declaredWitness)
+        defining(interface, at: program.anchor(introducerOf: d)) { (me) in
+          me.associate(.init(d), with: .parameter(0))
+          let result = me.currentFunction.returnRegister ?? .poison(.place(.error))
+          let callee = me.loweredCallee(
+            referringTo: m, boundTo: nil, appliedBy: nil,
+            writingResultTo: result)
+          me._emitCallRequirementImplementation(
+            callee.value, with: callee.arguments, instantiatedWith: ts)
         }
 
       default:
-        // The implementations is defined outside the trait.
+        // The implementations is inherited by a trait or extension.
         defining(interface, at: program.anchor(introducerOf: d)) { (me) in
-          unimplemented(
-            if: me.program.types.hasContext(me.program.type(assignedTo: r)),
-            "generic trait requirement")
           me.associate(.init(d), with: .parameter(0))
-
           let result = me.currentFunction.returnRegister ?? .poison(.place(.error))
           let callee = me.loweredCallee(
             referringTo: implementation, qualifiedBy: nil, appliedBy: nil,
             writingResultTo: result, at: me.currentAnchor)
-          me._emitCallToRequirementImplementation(callee.value, callee.arguments)
+          me._emitCallRequirementImplementation(
+            callee.value, with: callee.arguments, instantiatedWith: callee.typeArguments)
         }
       }
     }
 
-    precondition(requirements.types.isEmpty, "not implemented")
-
-    let x0 = _alloca(w.erased)
-    let x1 = _witnesstable(type: w.erased, operands: members)
-    _emitInitialize(x0, with: x1)
-    let x2 = _access([.let], from: x0)
-    _yield(x2)
-    _end(IRAccess.self, openedBy: x2)
-    _emitDeinitialize(x0)
+    // The witness table may be generic.
+    let ts = TypeArguments.init(
+      mapping: currentFunction.signature.typeParameters, to: \.erased)
+    let x0 = _witness_table(
+      instantiatedWith: ts, aggregating: entries, capturing: [], as: declaredWitness)
+    let x1 = _access([.let], from: x0)
+    _yield(x1)
+    _end(IRAccess.self, openedBy: x1)
     _return()
   }
 
@@ -413,7 +429,7 @@ internal struct IREmitter {
     _ definition: [StatementIdentity], of d: T.ID
   ) {
     // Setup the function's parameters.
-    for (i, p) in currentFunction.termParameters.enumerated() {
+    for (i, p) in currentFunction.signature.termParameters.enumerated() {
       let v = IRValue.parameter(i)
 
       // Update the local bindings of the function.
@@ -660,7 +676,7 @@ internal struct IREmitter {
 
   /// Generates the IR of `s`.
   private mutating func lower(_ s: Yield.ID) -> ControlFlow {
-    let (k, _) = currentFunction.output.remote!
+    let (k, _) = currentFunction.signature.output.remote!
     let v = lowered(lvalue: program[s].value)
     lowering(s) { (me) in
       let x = me._access([k], from: v)
@@ -1123,7 +1139,8 @@ internal struct IREmitter {
         }
       }
 
-      // The member is inherited by conformance.
+      // The member is declared in a type or conformance declaration and it implements a trait
+      // requirement for a conformance declaration.
       else {
         let interface = program.withTyper(typing: module, { (tp) in tp.typeOfInterface(for: m) })
         return lowering(at: anchor) { (me) in
@@ -1202,10 +1219,7 @@ internal struct IREmitter {
 
     // Otherwise, construct a bundle reference that will be reified later.
     else {
-      let types = accumulatedGenericParameters(visibleFrom: .init(node: f))
-      let (terms, output) = prototype(function: .init(f), usedMutably: usedMutably)
-
-      let s = IRFunction.Signature(types: types, terms: terms, output: output)
+      let s = prototype(function: .init(f), usedMutably: usedMutably)
       let t = program.types.demand(s)
       let v = IRValue.bundle(f, t, candidates)
       return LoweredCallee(v, boundTo: receiver, writingResultTo: r)
@@ -1523,17 +1537,13 @@ internal struct IREmitter {
       return i
     }
 
-    let types = accumulatedGenericParameters(visibleFrom: program.castToScope(d)!)
-    let anchor = program.anchorForDiagnostics(about: d)
-    let (terms, output) = prototype(functionOrConformance: d)
-    return program[module].ir.addFunction(
-      IRFunction(
-        name: name, anchor: anchor, output: output,
-        typeParameters: types, termParameters: terms))
+    let a = program.anchorForDiagnostics(about: d)
+    let s = prototype(functionOrConformance: d)
+    return program[module].ir.addFunction(IRFunction(name: name, anchor: a, signature: s))
   }
 
-  /// Returns the identity of the function lowering the implementation of `requirement` for the
-  /// `conformance` with the given `arguments`, declaring it if necessary.
+  /// Returns the identity of the function lowering the implementation of `requirement` belonging
+  /// to `conformance`, which defines a witness applied to `arguments`.
   private mutating func demandLoweredDeclaration(
     implementationOf requirement: DeclarationIdentity, synthesized isSynthesized: Bool,
     for conformance: ConformanceDeclaration.ID, _ arguments: TypeArguments
@@ -1546,12 +1556,15 @@ internal struct IREmitter {
     if let i = program[module].ir.functions.index(forKey: name) {
       return i
     } else {
-      let anchor = program.anchorForDiagnostics(about: conformance)
-      let (terms, output) = prototype(functionOrConformance: requirement)
+      let signature = prototype(functionOrConformance: requirement)
+      let signatureWithContext = IRFunction.Signature(
+        typeParameters: accumulatedGenericParameters(visibleFrom: .init(node: conformance)),
+        termParameters: signature.termParameters,
+        output: signature.output)
+
+      let a = program.anchorForDiagnostics(about: conformance)
       return program[module].ir.addFunction(
-        IRFunction(
-          name: name, anchor: anchor, output: output,
-          typeParameters: [], termParameters: terms))
+        IRFunction(name: name, anchor: a, signature: signatureWithContext))
     }
   }
 
@@ -1578,10 +1591,11 @@ internal struct IREmitter {
     let o = program.types.dealiased(program.types[e].inhabitant)
     ps.append(.init(type: o, access: .set, declaration: nil))
 
-    let anchor = program.anchorForDiagnostics(about: d)
-    return program[module].ir.addFunction(
-      IRFunction(
-        name: name, anchor: anchor, output: .indirect, typeParameters: ts, termParameters: ps))
+    let newFunction = IRFunction(
+      name: name,
+      anchor: program.anchorForDiagnostics(about: d),
+      signature: .init(typeParameters: ts, termParameters: ps, output: .indirect))
+    return program[module].ir.addFunction(newFunction)
   }
 
   /// Returns the IR variable lowering the global binding `d`, declaring it if necessary.
@@ -1600,13 +1614,14 @@ internal struct IREmitter {
     // Declare the global's initializer.
     let t = program.types.dealiased(program.type(assignedTo: d))
     let o = IRParameter(type: t, access: .set, declaration: nil)
-    let i = IRFunction(
-      name: .initializer(d), anchor: program.anchorForDiagnostics(about: d),
-      output: .indirect, typeParameters: [], termParameters: [o])
-    let f = program[module].ir.addFunction(i)
+    let newFunction = IRFunction(
+      name: .initializer(d),
+      anchor: program.anchorForDiagnostics(about: d),
+      signature: .init(typeParameters: [], termParameters: [o], output: .indirect))
+    let initializer = program[module].ir.addFunction(newFunction)
 
     // Declare the global itself.
-    let n = program[module].ir[f].name
+    let n = program[module].ir[initializer].name
     let g = IRGlobal(name: name, storageType: t, alignment: .preferred, initializer: .function(n))
     program[module].ir.addGlobal(g)
     return g
@@ -1633,7 +1648,7 @@ internal struct IREmitter {
   /// Returns the term parameters and return type of `d`'s lowered representation.
   private mutating func prototype(
     functionOrConformance d: DeclarationIdentity, applying substitutions: TypeArguments = .init()
-  ) -> ([IRParameter], IRFunction.Output) {
+  ) -> IRFunction.Signature {
     if let n = program.cast(d, to: ConformanceDeclaration.self) {
       return prototype(conformance: n, applying: substitutions)
     } else {
@@ -1648,9 +1663,9 @@ internal struct IREmitter {
   /// additional parameter accepting an instance of the containing trait.
   private mutating func prototype(
     conformance d: ConformanceDeclaration.ID, applying substitutions: TypeArguments = .init()
-  ) -> ([IRParameter], IRFunction.Output) {
+  ) -> IRFunction.Signature {
     let witness = program.types.contextAndHead(program.type(assignedTo: d))
-
+    let types = accumulatedGenericParameters(visibleFrom: program.castToScope(d)!)
     var terms: [IRParameter] = []
 
     // If the conformance declares an abstract given, accept a witness of conformance of the
@@ -1668,7 +1683,7 @@ internal struct IREmitter {
       terms.append(IRParameter(type: u, access: .let, declaration: nil))
     }
 
-    return (terms, .remote(.let, witness.head))
+    return .init(typeParameters: types, termParameters: terms, output: .remote(.let, witness.head))
   }
 
   /// Returns the term parameters and return type of `d`'s lowered representation.
@@ -1679,9 +1694,10 @@ internal struct IREmitter {
   private mutating func prototype(
     function d: DeclarationIdentity, usedMutably: Bool,
     applying substitutions: TypeArguments = .init(),
-  ) -> ([IRParameter], IRFunction.Output) {
+  ) -> IRFunction.Signature {
     let typeOfDeclaration = program.types.contextAndHead(program.type(assignedTo: d))
     let shape = program.types.seenAsTermAbstraction(typeOfDeclaration.head)!
+    let types = accumulatedGenericParameters(visibleFrom: program.castToScope(d)!)
     var terms: [IRParameter] = []
 
     // Parameters of memberwise initializers have no explicit declarations.
@@ -1737,9 +1753,10 @@ internal struct IREmitter {
     let t = program.types.dealiased(s)
     if program.types[shape].style == .parenthesized {
       terms.append(IRParameter(type: t, access: .set, declaration: nil))
-      return (terms, .indirect)
+      return .init(typeParameters: types, termParameters: terms, output: .indirect)
     } else {
-      return (terms, .remote(program.types[shape].effect, t))
+      let output = IRFunction.Output.remote(program.types[shape].effect, t)
+      return .init(typeParameters: types, termParameters: terms, output: output)
     }
   }
 
@@ -2256,10 +2273,16 @@ internal struct IREmitter {
     insert(IRSwitch(scrutinee: scrutinee, successors: successors, anchor: currentAnchor))
   }
 
-  /// Inserts a `type_apply` instruction.
+  /// Inserts a `type_apply` instruction iff `arguments` is not empty.
+  ///
+  /// If `arguments` is not empty, then `callee` is a type abstraction (e.g., a generic function)
+  /// whose parameters correspond to the keys in `arguments`, and the result is the application of
+  /// this abstraction. Otherwise, the result is `callee`.
   internal mutating func _type_apply(
     _ callee: IRValue, to arguments: TypeArguments
   ) -> IRValue {
+    if arguments.isEmpty { return callee }
+
     // The callee must have a universal type.
     guard
       let t = currentFunction.result(of: callee),
@@ -2269,6 +2292,7 @@ internal struct IREmitter {
     // Compute the type substitution.
     let a = program.types.dealiased(arguments)
     let typeOfApplication = program.types.application(of: u, to: a)
+    assert(!arguments.values.contains(.error), "invalid type arguments")
     assert(!program.types.hasContext(typeOfApplication), "illegal partial type application")
 
     let s = IRTypeApply(
@@ -2294,12 +2318,25 @@ internal struct IREmitter {
     insert(IRUnreachable(anchor: currentAnchor))
   }
 
-  /// Inserts a `witnesstable` instruction.
-  internal mutating func _witnesstable(
-    type: AnyTypeIdentity, operands: [IRValue]
+  /// Inserts a `witness_table` instruction.
+  internal mutating func _witness_table(
+    instantiatedWith arguments: TypeArguments,
+    aggregating entries: [IRValue], capturing captures: [IRValue],
+    as type: AnyTypeIdentity
   ) -> IRValue {
-    let t = program.types.dealiased(type)
-    let s = IRWitnessTable(witnessType: t, operands: operands, anchor: currentAnchor)
+    let s = IRWitnessTable(
+      instantiatedWith: arguments, aggregating: entries, capturing: captures,
+      as: program.types.dealiased(type),
+      at: currentAnchor)
+    return insert(s)!
+  }
+
+  /// Inserts a `witness_table_stash` instruction.
+  internal mutating func _witness_table_stash(
+    of witness: IRValue, as stashType: AnyTypeIdentity
+  ) -> IRValue {
+    let t = program.types.dealiased(stashType)
+    let s = IRWitnessTableStash(source: witness, stashType: t, anchor: currentAnchor)
     return insert(s)!
   }
 
@@ -2476,7 +2513,7 @@ internal struct IREmitter {
     let f = demandLoweredDeclaration(functionOrConformance: .init(d))
     let g = functionReference(to: f)
 
-    if program[module].ir[f].termParameters.isEmpty && applyNullary {
+    if program[module].ir[f].signature.termParameters.isEmpty && applyNullary {
       return _project(g, [], afterFormingAccesses: false)
     } else {
       return g
@@ -2503,22 +2540,26 @@ internal struct IREmitter {
     return _subfield(x, at: p!)
   }
 
-  /// Generates the IR for forwarding the arguments of the current function to `f`.
+  /// Generates IR for forwarding the arguments of the current function to `implementation`.
   ///
   /// This method is called during the construction of a witness table to generate the definition
-  /// of the current function, which is an interface function wrapping a call to `f`.
-  private mutating func _emitCallToRequirementImplementation(
-    _ f: IRValue, _ arguments: [IRValue]) {
-    // Gather the parameters.
+  /// of the current function, which is an interface function wrapping a call to `implementation`.
+  private mutating func _emitCallRequirementImplementation(
+    _ implementation: IRValue, with arguments: [IRValue],
+    instantiatedWith conformerArguments: TypeArguments
+  ) {
+    let signature = program.types.contextAndHead(currentFunction.result(of: implementation)!.type)
+    let shape = program.types.cast(signature.head, to: Arrow.self)!
+
+    // Gather term arguments that should be forwarded to the implementation.
     var operands = Array(arguments)
-    for i in 1 ..< currentFunction.termParameters.count {
+    for i in 1 ..< currentFunction.signature.termParameters.count {
       operands.append(.parameter(i))
     }
 
-    let t = currentFunction.resultAsTermAbstraction(of: f, in: program) ?? badOperand()
-    var ps = program.types[t].inputs
+    var ps = program.types[shape].inputs
     if !currentFunction.isSubscript {
-      ps.append(.init(access: .set, type: program.types[t].output))
+      ps.append(.init(access: .set, type: program.types[shape].output))
     }
 
     for (i, p) in ps.enumerated() {
@@ -2528,12 +2569,13 @@ internal struct IREmitter {
     }
 
     // Do the call.
+    let callee = _type_apply(implementation, to: conformerArguments)
     if currentFunction.isSubscript {
-      let x0 = _project(f, operands, afterFormingAccesses: true)
+      let x0 = _project(callee, operands, afterFormingAccesses: true)
       _yield(x0)
     } else {
       let x0 = operands.removeLast()
-      _apply(f, operands, into: x0, argumentAccesses: .form)
+      _apply(callee, operands, into: x0, argumentAccesses: .form)
     }
 
     _return()
@@ -2578,9 +2620,7 @@ internal struct IREmitter {
     }
 
     // Type arguments always apply first.
-    if !types.isEmpty {
-      result = _type_apply(result, to: types)
-    }
+    result = _type_apply(result, to: types)
 
     // Witnesses referring to a nullary conformance declaration have to be applied. In this case
     // the type of `result` should have the form `() -> P<T>`, where `P<T>` is the type of the
@@ -2709,7 +2749,7 @@ internal struct IREmitter {
     _assume_state(x0, initialized: true)
   }
 
-  /// Generates the IR deinitializing `s` and returns `true` iff `s` is deinitializable; otherwise,
+  /// Generates IR deinitializing `s` and returns `true` iff `s` is deinitializable; otherwise,
   /// inserts a trap and returns `false`.
   ///
   /// This method deinitializes values in one of two ways, thereafter referred to as "whole" and
@@ -2737,8 +2777,8 @@ internal struct IREmitter {
     return _emitDeinitialize(s, instanceOf: t)
   }
 
-  /// Generates the IR deinitializing `s`, which is an instance of `t`, and returns `true` iff `s`
-  /// is deinitializable; otherwise, inserts a trap and returns `false`.
+  /// Generates IR deinitializing `s`, which is an instance of `t`, and returns `true` iff `s` is
+  /// deinitializable; otherwise, inserts a trap and returns `false`.
   ///
   /// This method implements the specification of `_emitDeinitialize(_:)`, using `t` to determine
   /// whether it should apply membewise initialization or find an instance of `Deinitializable`.
@@ -2755,8 +2795,8 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR deinitializing `s`, which is an instance of `t`, and returns `true` iff `s`
-  /// is deinitializable; otherwise, inserts a trap and returns `false`.
+  /// Generates IR deinitializing `s`, which is an instance of `t`, and returns `true` iff `s` is
+  /// deinitializable; otherwise, inserts a trap and returns `false`.
   ///
   /// This method implements parts of `_emitDeinitialize(_:)`, covering whole deinitialization.
   private mutating func _emitDeinitializeWhole(
@@ -2785,7 +2825,7 @@ internal struct IREmitter {
           let (x, _) = program.types.seenAsBaseTypeApplication(t)
           if program.declaration(whereStructOrEnum: x) != nil {
             _emitDeinitializeWhole(
-              structOrEnum: s, instanceOf: t,
+              structOrEnum: s,
               applyingDeinitializerSynthesizedFor: w, declaredBy: conformance)
             return true
           }
@@ -2821,8 +2861,8 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR deinitializing `s`, which is an instance of `t`, using the conformance to
-  /// `Deinitializable` expressed by `w`.
+  /// Generates IR deinitializing `s`, which is an instance of `t`, using `w`, which expresses a
+  /// witness of the conformance of `t` to `Deinitializable`.
   private mutating func _emitDeinitializeWhole(
     _ s: IRValue, instanceOf t: AnyTypeIdentity, usingNonTrivialConformance w: WitnessExpression
   ) {
@@ -2839,33 +2879,32 @@ internal struct IREmitter {
     insertionContext.function!.closeOpenEndedRegions(in: xs)
   }
 
-  /// Generates the IR deinitializing `s`, which is an instance of `t`, generating and applying a
-  /// synthesized memberwise deinitializer associated with the conformance witnessed by `w` and
-  /// declared by `conformance`.
+  /// Generates IR deinitializing `s`, applying a synthesized memberwise deinitializer associated
+  /// with the conformance witnessed by `w` and declared by `d`.
   private mutating func _emitDeinitializeWhole(
-    structOrEnum s: IRValue, instanceOf t: AnyTypeIdentity,
+    structOrEnum s: IRValue,
     applyingDeinitializerSynthesizedFor w: WitnessExpression,
-    declaredBy conformance: ConformanceDeclaration.ID
+    declaredBy d: ConformanceDeclaration.ID
   ) {
-    let requirement = program.standardLibraryDeclaration(.deinitializableDeinit)
-    let receiver = program.withTyper(typing: module) { (tp) in
-      tp.typeOfSelf(in: .init(uncheckedFrom: requirement.erased))!
-    }
+    let witness = program.types.dealiased(w.type)
+    let witnessArguments = program.types.select(witness, \TypeApplication.arguments)!
+    let conformerArguments = argumentsFromConformanceWitness(witness)
 
-    let a = TypeArguments.init(
-      mapping: [program.types.castUnchecked(receiver, to: GenericParameter.self)], to: [t])
-    let f = demandLoweredDeclaration(
-      implementationOf: requirement, synthesized: true, for: conformance, a)
-    implementSynthesizedDeinitializer(f, for: a)
+    // Define a synthesized memberwise deinitializer for `t`.
+    let deinitializer = demandLoweredDeclaration(
+      implementationOf: program.standardLibraryDeclaration(.deinitializableDeinit),
+      synthesized: true, for: d, witnessArguments)
+    implementSynthesizedDeinitializer(deinitializer, for: witnessArguments)
 
     let (table, xs) = _recordingInsertions({ $0._emit(witness: w) })
     let x0 = _alloca(.void)
-    let x1 = functionReference(to: f)
-    _apply(x1, [table, s], into: x0, argumentAccesses: .formAndClose)
+    let x1 = functionReference(to: deinitializer)
+    let x2 = _type_apply(x1, to: conformerArguments)
+    _apply(x2, [table, s], into: x0, argumentAccesses: .formAndClose)
     insertionContext.function!.closeOpenEndedRegions(in: xs)
   }
 
-  /// Generates the IR deinitializing `s`, which is an instance of `t`, and returns `true` iff each
+  /// Generates IR deinitializing `s`, which is an instance of `t`, and returns `true` iff each
   /// individual part of `s` is deinitializable; otherwise, inserts a trap and returns `false`.
   ///
   /// This method implements part of `_emitDeinitialize(_:)`, covering memberwise deinitialization
@@ -2888,7 +2927,7 @@ internal struct IREmitter {
     return true
   }
 
-  /// Generates the IR deinitializing each individual part of `s`, which is an instance of the type
+  /// Generates IR deinitializing each individual part of `s`, which is an instance of the type
   /// declared by `d` whose type parameters are assigned in `a`.
   private mutating func _emitDeinitializeMemberwise(
     _ s: IRValue, instanceOf d: DeclarationIdentity, instantiatedWith a: TypeArguments
@@ -2907,7 +2946,7 @@ internal struct IREmitter {
     }
   }
 
-  /// Generates the IR deinitializing each individual part of `s`, which is an instance of the type
+  /// Generates IR deinitializing each individual part of `s`, which is an instance of the type
   /// declared by `d` whose type parameters are assigned in `a`.
   private mutating func _emitDeinitializeMemberwise(
     _ s: IRValue, instanceOf d: StructDeclaration.ID, instantiatedWith a: TypeArguments
@@ -2923,7 +2962,7 @@ internal struct IREmitter {
     _ = _emitDeinitialize(x, instanceOf: t)
   }
 
-  /// Generates the IR deinitializing each individual part of `s`, which is an instance of the type
+  /// Generates IR deinitializing each individual part of `s`, which is an instance of the type
   /// declared by `d` whose type parameters are assigned in `a`.
   private mutating func _emitDeinitializeMemberwise(
     _ s: IRValue, instanceOf d: EnumDeclaration.ID, instantiatedWith a: TypeArguments
@@ -3046,12 +3085,14 @@ internal struct IREmitter {
   /// updated whenever generating a witness for `t` requires new IR. Instructions for allocating
   /// and initializing storage for new witnesses are emitted in the entry of the current function
   /// whereas the return value is always an access emitted at the current insertion point.
-  internal mutating func _emitTypeWitness(
+  internal mutating func _emitAccessTypeWitness(
     of t: AnyTypeIdentity, reusing witnesses: inout [AnyTypeIdentity: IRValue]
   ) -> IRValue {
     // Trivial if the witness is already available.
     if let a = witnesses[t] {
       return _access([.let], from: a)
+    } else {
+      assert(program.types.tag(of: t) != GenericParameter.self)
     }
 
     // Instructions for allocating/initializing the witness are emitted in the entry.
@@ -3073,13 +3114,21 @@ internal struct IREmitter {
     // Otherwise, we have to construct a new type witness.
     else {
       let u = program.types.demand(UniversalType(parameters: Array(ps), head: t))
-      let v = ps.map({ (p) in _emitTypeWitness(of: p.erased, reusing: &witnesses) })
+      let v = ps.map({ (p) in _emitAccessTypeWitness(of: p.erased, reusing: &witnesses) })
       let a = _type_witness(u, v)
       witnesses[t.erased] = a
 
       swap(&insertionContext.point, &p)
       return _access([.let], from: a)
     }
+  }
+
+  /// Generates IR for accessing run-time witnesses of each type argument in `a`, caching results
+  /// into `witnesses`.
+  internal mutating func _emitAccessTypeWitnesses(
+    for a: TypeArguments, reusing witnesses: inout [AnyTypeIdentity: IRValue]
+  ) -> [IRValue] {
+    a.values.map({ (t) in _emitAccessTypeWitness(of: t.erased, reusing: &witnesses) })
   }
 
   /// Information necessary to emit the deinitialization of an instance.
@@ -3145,8 +3194,7 @@ internal struct IREmitter {
   /// Returns a reference to the given lowered function.
   internal mutating func functionReference(to f: IRFunction.ID) -> IRValue {
     let d = program[module].ir[f]
-    let s = d.signature()
-    return .function(d.name, program.types.demand(s))
+    return .function(d.name, program.types.demand(d.signature))
   }
 
   /// Returns the type arguments defined in the type of `q`, which occurs as qualification for a
@@ -3180,6 +3228,41 @@ internal struct IREmitter {
       return result
     } else {
       return [:]
+    }
+  }
+
+  /// Returns the type arguments of the type whose a conformance to some trait is witnessed by an
+  /// instance of `w`.
+  private mutating func argumentsFromConformanceWitness(_ w: AnyTypeIdentity) -> TypeArguments {
+    let t = program.types.dealiased(w)
+    let u = program.types.seenAsTraitApplication(t)!.arguments.values[0]
+
+    switch program.types.tag(of: u) {
+    case AssociatedType.self:
+      let a = program.types.castUnchecked(u, to: AssociatedType.self)
+      return argumentsFromConformanceWitness(program.types[a].qualification.type)
+    case TypeApplication.self:
+      let a = program.types.castUnchecked(u, to: TypeApplication.self)
+      return program.types[a].arguments
+    case GenericParameter.self:
+      let a = program.types.castUnchecked(u, to: GenericParameter.self)
+      return [a: u]
+    default:
+      return [:]
+    }
+  }
+
+  /// Returns the type arguments passed to the implementation `m` satisfying a trait requirement in
+  /// in the context of `d`, which declares a witness of tyoe `w`.
+  private mutating func argumentsInstantiating(
+    implementation m: DeclarationIdentity,
+    in d: ConformanceDeclaration.ID, declaring w: AnyTypeIdentity
+  ) -> TypeArguments {
+    if program.isContained(m, in: .init(node: d)) {
+      let ps = accumulatedGenericParameters(visibleFrom: .init(node: d))
+      return TypeArguments(mapping: ps, to: \.erased)
+    } else {
+      return argumentsFromConformanceWitness(w)
     }
   }
 

--- a/Sources/FrontEnd/IR/IREmitter.swift
+++ b/Sources/FrontEnd/IR/IREmitter.swift
@@ -330,7 +330,7 @@ internal struct IREmitter {
           let callee = me.loweredCallee(
             referringTo: implementation, qualifiedBy: nil, appliedBy: nil,
             writingResultTo: result, at: me.currentAnchor)
-          me._emitCallToRequirementImplementation(callee.value, Array(callee.arguments))
+          me._emitCallToRequirementImplementation(callee.value, callee.arguments)
         }
       }
     }
@@ -906,18 +906,41 @@ internal struct IREmitter {
     /// The IR values in the representation of `self.`
     private let operands: [IRValue]
 
+    /// If `self` is bound, the index of the value in `operands` denoting its receiver; otherwise,
+    /// the length of `operands`.
+    let receiver: IRValue?
+
     /// The type arguments notionally applied to the callee.
     let typeArguments: TypeArguments
 
     /// Creates an instance with the given properties.
-    init<T: Sequence<IRValue>>(
-      value: IRValue, typeArguments: TypeArguments, arguments: T, result: IRValue
+    private init(operands: [IRValue], receiver: IRValue?, typeArguments: TypeArguments) {
+      self.operands = operands
+      self.receiver = receiver
+      self.typeArguments = typeArguments
+    }
+
+    /// Creates an instance representing a use of `value`.
+    ///
+    /// - Parameters:
+    ///   - typeArguments Type arguments partially instantiating the callee.
+    ///   - usings Term arguments passed to the callee's contextual term parameters.
+    ///   - receiver The value to which the callee is bound, if any.
+    ///   - result The argument to the calle's output parameter if it is an ordinary function.
+    init(
+      _ value: IRValue,
+      instantiatedWith typeArguments: TypeArguments = [:],
+      appliedTo usings: [IRValue] = [],
+      boundTo receiver: IRValue? = nil,
+      writingResultTo result: IRValue
     ) {
-      var vs: [IRValue] = .init(minimumCapacity: arguments.underestimatedCount + 2)
+      var vs: [IRValue] = .init(minimumCapacity: usings.underestimatedCount + 2)
       vs.append(value)
       vs.append(result)
-      vs.append(contentsOf: arguments)
+      vs.append(contentsOf: usings)
+
       self.operands = vs
+      self.receiver = receiver
       self.typeArguments = typeArguments
     }
 
@@ -931,21 +954,27 @@ internal struct IREmitter {
       operands[1]
     }
 
+    /// The arguments passed to the callee's contextual term parameters.
+    var usings: ArraySlice<IRValue> {
+      operands[2...]
+    }
+
     /// The term arguments notionally applied to the callee.
     ///
     /// This property includes the using parameters passed to `value` and, if `value` is a bound
     /// member, the receiver of that member.
-    var arguments: ArraySlice<IRValue> {
-      operands[2...]
+    var arguments: Array<IRValue> {
+      var xs = Array(operands[2...])
+      if let r = receiver { xs.append(r) }
+      return xs
     }
 
     /// Returns `self` notionally applied to `a`.
     ///
     /// `a` is appended to the term arguments of `self`. The result denotes a function partially
     /// applied to `a` and possibly expecting more arguments.
-    consuming func partiallyApplied(to a: IRValue) -> LoweredCallee {
-      let xs = Array(arguments, terminatedBy: a)
-      return .init(value: value, typeArguments: typeArguments, arguments: xs, result: result)
+    consuming func applied(to a: IRValue) -> LoweredCallee {
+      .init(operands: operands.appending(a), receiver: receiver, typeArguments: typeArguments)
     }
 
     /// Returns `self` notionally applied to `a`.
@@ -954,9 +983,9 @@ internal struct IREmitter {
     /// applied to `a` and possibly expecting more arguments.
     ///
     /// - Requires: `self.typeArguments` is disjoint from `a`.
-    consuming func partiallyApplied(to a: TypeArguments) -> LoweredCallee {
+    consuming func instantiated(with a: TypeArguments) -> LoweredCallee {
       let ts = typeArguments.extended(with: a)
-      return .init(value: value, typeArguments: ts, arguments: arguments, result: result)
+      return .init(operands: operands, receiver: receiver, typeArguments: ts)
     }
 
     /// Returns `self` notionally applied to `a`.
@@ -965,11 +994,11 @@ internal struct IREmitter {
     /// applied to `a` and possibly expecting more arguments.
     ///
     /// - Requires: `self.typeArguments` is disjoint from `a`.
-    consuming func partiallyApplied<S: Sequence<(GenericParameter.ID, AnyTypeIdentity)>>(
-      to a: S
+    consuming func instantiated<S: Sequence<(GenericParameter.ID, AnyTypeIdentity)>>(
+      with a: S
     ) -> LoweredCallee {
       let ts = typeArguments.extended(with: a)
-      return .init(value: value, typeArguments: ts, arguments: arguments, result: result)
+      return .init(operands: operands, receiver: receiver, typeArguments: ts)
     }
 
   }
@@ -1048,7 +1077,7 @@ internal struct IREmitter {
       // The callee refers to a function directly.
       let f = loweredCallee(referringTo: d, boundTo: nil, appliedBy: c, writingResultTo: r)
       if let q = qualification {
-        return f.partiallyApplied(to: argumentsFromQualification(q, instantiating: f.value))
+        return f.instantiated(with: argumentsFromQualification(q, instantiating: f.value))
       } else {
         return f
       }
@@ -1062,7 +1091,7 @@ internal struct IREmitter {
       // the receiver's expression.
       let output = currentFunction.result(of: receiver)!.type
       if let ts = program.types.select(output, \TypeApplication.arguments) {
-        return f.partiallyApplied(to: ts)
+        return f.instantiated(with: ts)
       } else {
         return f
       }
@@ -1078,12 +1107,19 @@ internal struct IREmitter {
 
         return lowering(at: anchor) { (me) in
           // References to members in extensions are expressed using a witness representing the
-          // type and term arguments passed to parameters declared on the extension itself.
+          // type and term arguments passed to parameters introduced by the extension.
           let (e, ts, xs) = me._emit(decompose: w)
           assert(e.value == .reference(.init(parent)))
-          let ys = xs + target.arguments
+
+          // We don't use `LoweredCallee.applied(to:)` because the type and using parameters of the
+          // extension, which were read from the witness, occur before those of the target, which
+          // where extracted from the callee's expression.
           return LoweredCallee(
-            value: target.value, typeArguments: ts, arguments: ys, result: target.result)
+            target.value,
+            instantiatedWith: ts.extended(with: target.typeArguments),
+            appliedTo: xs + target.usings,
+            boundTo: target.receiver,
+            writingResultTo: target.result)
         }
       }
 
@@ -1093,8 +1129,7 @@ internal struct IREmitter {
         return lowering(at: anchor) { (me) in
           let x0 = me._emit(witness: w)
           let x1 = me._property(m, of: x0, withType: interface)
-          let xs = Array(x0, prependedTo: Array(contentsOf: receiver))
-          return LoweredCallee(value: x1, typeArguments: [:], arguments: xs, result: r)
+          return LoweredCallee(x1, appliedTo: [x0], boundTo: receiver, writingResultTo: r)
         }
       }
 
@@ -1142,10 +1177,7 @@ internal struct IREmitter {
     boundTo receiver: IRValue?,
     writingResultTo r: IRValue
   ) -> LoweredCallee {
-    LoweredCallee(
-      value: functionReference(to: f),
-      typeArguments: [:], arguments: Array(unwrapping: receiver),
-      result: r)
+    LoweredCallee(functionReference(to: f), boundTo: receiver, writingResultTo: r)
   }
 
   /// Generates the IR for using `f` as a callee that is optionally bound to `receiver`.
@@ -1176,8 +1208,7 @@ internal struct IREmitter {
       let s = IRFunction.Signature(types: types, terms: terms, output: output)
       let t = program.types.demand(s)
       let v = IRValue.bundle(f, t, candidates)
-      return LoweredCallee(
-        value: v, typeArguments: [:], arguments: Array(unwrapping: receiver), result: r)
+      return LoweredCallee(v, boundTo: receiver, writingResultTo: r)
     }
   }
 
@@ -1185,15 +1216,16 @@ internal struct IREmitter {
   private mutating func loweredCallee(
     _ e: New.ID, appliedBy c: Call.ID?, writingResultTo r: IRValue
   ) -> LoweredCallee {
-    // When the callee is a new expression (e.g., `T.new(x)`), then `result` is passed as the first
+    // When the callee is a new expression (e.g., `T.new(x)`), the `result` is passed as the `self`
     // argument of the underlying initializer. The return type of the initializer is a unit value.
     let x = lowering(e, { (me) in me._alloca(.void) })
     let f = loweredCallee(program[e].target, appliedBy: c, writingResultTo: r)
 
     // The qualification may define type arguments.
     let ts = argumentsFromQualification(program[e].qualification, instantiating: f.value)
-    let xs = Array(f.arguments, terminatedBy: f.result)
-    return LoweredCallee(value: f.value, typeArguments: ts, arguments: xs, result: x)
+    return LoweredCallee(
+      f.value, instantiatedWith: f.typeArguments.extended(with: ts),
+      appliedTo: Array(f.usings), boundTo: f.result, writingResultTo: x)
   }
 
   /// Generates the IR for using `e` as the callee of `c` or a synthesized call.
@@ -1213,7 +1245,7 @@ internal struct IREmitter {
       return (p, program.types[t].inhabitant)
     }
 
-    let mono = poly.partiallyApplied(to: ts)
+    let mono = poly.instantiated(with: ts)
     assert(
       context.parameters.elementsEqual(mono.typeArguments.parameters),
       "invalid type arguments")
@@ -1245,11 +1277,11 @@ internal struct IREmitter {
     case .termApplication(let f, let a):
       let x = loweredCallee(f, output: result, at: site, in: scope)
       let y = lowering(at: site, in: scope, { (me) in me._emit(witness: a) })
-      return x.partiallyApplied(to: y)
+      return x.applied(to: y)
 
     case .typeApplication(let f, let a):
       let poly = loweredCallee(f, output: result, at: site, in: scope)
-      return poly.partiallyApplied(to: a)
+      return poly.instantiated(with: a)
 
     default:
       fatalError("not implemented")
@@ -1268,14 +1300,9 @@ internal struct IREmitter {
     let callee = f.typeArguments.isEmpty
       ? f.value : lowering(program[e].callee, { $0._type_apply(f.value, to: f.typeArguments) })
 
-    // At this point the callee must be a monomorphic term abstraction.
-    let t = currentFunction.result(of: callee)!
-    let u = program.types.seenAsTermAbstraction(t.type)!
-    let parameters = program.types[u].inputs
-
     // There's at least one operand per argument, more if the callee accepts using parameters.
-    var arguments = Array<IRValue>(minimumCapacity: f.arguments.count + program[e].arguments.count)
-    arguments.append(contentsOf: f.arguments)
+    var arguments = f.arguments
+    arguments.reserveCapacity(arguments.count + program[e].arguments.count)
 
     // We compute lvalues first and query accesses next, so that mutable accesses passed down to
     // the call are not formed prematurely. This behavior supports calls to mutating methods in
@@ -1283,9 +1310,6 @@ internal struct IREmitter {
     for a in program[e].arguments {
       arguments.append(lowered(lvalue: a.value))
     }
-
-    assert(!program.types.hasContext(t.type))
-    assert(arguments.count == parameters.count)
 
     return lowering(e) { (me) in
       // Form accesses on the parameters right before the call. Note that we won't close these
@@ -2043,14 +2067,16 @@ internal struct IREmitter {
     _ callee: IRValue, _ arguments: [IRValue], into result: IRValue,
     argumentAccesses: ArgumentAccessHandling
   ) {
-    let t = currentFunction.resultAsTermAbstraction(of: callee, in: program) ?? badOperand()
-    assert(program.types[t].inputs.count == arguments.count)
+    let t = currentFunction.result(of: callee)!.type
+    let u = program.types.seenAsTermAbstraction(t)!
+    assert(!program.types.hasContext(t))
+    assert(program.types[u].inputs.count == arguments.count)
 
     var xs = arguments
     var last = result
 
     if argumentAccesses != .identity {
-      _emitArgumentAccesses(&xs, toApplyOrProject: callee, typed: t)
+      _emitArgumentAccesses(&xs, toApplyOrProject: callee, typed: u)
       last = _access([.set], from: result)
     }
 
@@ -2171,17 +2197,19 @@ internal struct IREmitter {
   internal mutating func _project(
     _ callee: IRValue, _ arguments: consuming [IRValue], afterFormingAccesses formAccesses: Bool
   ) -> IRValue {
-    let t = currentFunction.resultAsTermAbstraction(of: callee, in: program) ?? badOperand()
-    assert(program.types[t].inputs.count == arguments.count)
+    let t = currentFunction.result(of: callee)!.type
+    let u = program.types.seenAsTermAbstraction(t)!
+    assert(!program.types.hasContext(t))
+    assert(program.types[u].inputs.count == arguments.count)
 
     if formAccesses {
-      _emitArgumentAccesses(&arguments, toApplyOrProject: callee, typed: t)
+      _emitArgumentAccesses(&arguments, toApplyOrProject: callee, typed: u)
     }
 
-    let o = program.types.dealiased(program.types[t].output)
+    let o = program.types.dealiased(program.types[u].output)
     let s = IRProject(
       callee: callee, arguments: arguments,
-      access: program.types[t].effect,
+      access: program.types[u].effect,
       projectee: o,
       anchor: currentAnchor)
     return insert(s)!

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -109,25 +109,35 @@ public struct IRFunction: Sendable {
   }
 
   /// The types of an IR function's parameters and return value.
+  @Archivable
   public struct Signature: Equatable, Sendable {
 
-    /// The generic type parameters that the function accepts.
-    public let context: [GenericParameter.ID]
+    /// The generic type parameters that the function takes.
+    public let typeParameters: [GenericParameter.ID]
 
-    /// The types of the term parameters and return value.
-    public let head: Arrow
+    /// The term parameters that the function takes.
+    public let termParameters: [IRParameter]
 
-    /// Creates the signature of a function accepting the given parameters and returning results
-    /// as described by `output`.
-    public init(types: [GenericParameter.ID], terms: [IRParameter], output: Output) {
-      self.context = types
+    /// The way in which the function returns its result.
+    public let output: Output
 
-      let ps = terms.map({ (p) in Parameter(access: p.access, type: p.type) })
+    /// Creates an instance with the given properties.
+    public init(
+      typeParameters: [GenericParameter.ID], termParameters: [IRParameter], output: Output
+    ) {
+      self.typeParameters = typeParameters
+      self.termParameters = termParameters
+      self.output = output
+    }
+
+    /// Returns the types of the term parameters and return value.
+    public func head() -> Arrow {
+      let ps = termParameters.map({ (p) in Parameter(access: p.access, type: p.type) })
       switch output {
       case .indirect:
-        self.head = Arrow(style: .parenthesized, inputs: ps.dropLast(), output: ps.last!.type)
+        return Arrow(style: .parenthesized, inputs: ps.dropLast(), output: ps.last!.type)
       case .remote(let k, let o):
-        self.head = Arrow(style: .bracketed, effect: k, inputs: ps, output: o.erased)
+        return Arrow(style: .bracketed, effect: k, inputs: ps, output: o.erased)
       }
     }
 
@@ -140,13 +150,7 @@ public struct IRFunction: Sendable {
   public let anchor: Anchor
 
   /// The way in which the function returns its result.
-  public let output: Output
-
-  /// The generic type parameters of the function.
-  public let typeParameters: [GenericParameter.ID]
-
-  /// The parameters of the function.
-  public let termParameters: [IRParameter]
+  public let signature: Signature
 
   /// A mapping from a source declaration to their its lowered definition.
   private var bindings: BidirectionalDictionary<DeclarationIdentity, IRValue>
@@ -164,15 +168,10 @@ public struct IRFunction: Sendable {
   public private(set) var passedMandatoryInlining: Bool
 
   /// Creates an instance with the given properties.
-  public init(
-    name: Name, anchor: Anchor,
-    output: Output, typeParameters: [GenericParameter.ID], termParameters: [IRParameter],
-  ) {
+  public init(name: Name, anchor: Anchor, signature: Signature) {
     self.name = name
     self.anchor = anchor
-    self.output = output
-    self.typeParameters = typeParameters
-    self.termParameters = termParameters
+    self.signature = signature
     self.slots = []
     self.blocks = []
     self.uses = [:]
@@ -187,12 +186,12 @@ public struct IRFunction: Sendable {
 
   /// `true` iff the function has no generic type parameters.
   public var isMonomorphic: Bool {
-    typeParameters.isEmpty
+    signature.typeParameters.isEmpty
   }
 
   /// `true` iff the function is a subscript.
   public var isSubscript: Bool {
-    output != .indirect
+    signature.output != .indirect
   }
 
    /// `true` iff the function returns a unit value (i.e., an instance of `Hylo.Void`).
@@ -202,7 +201,7 @@ public struct IRFunction: Sendable {
 
   /// The register in which the function writes its result, if any.
   public var returnRegister: IRValue? {
-    (output == .indirect) ? .parameter(termParameters.count - 1) : nil
+    (signature.output == .indirect) ? .parameter(signature.termParameters.count - 1) : nil
   }
 
   /// The entry block of `self`.
@@ -313,11 +312,6 @@ public struct IRFunction: Sendable {
     } else {
       return nil
     }
-  }
-
-  /// Returns the type of `self`, computing it using `p`.
-  public func signature() -> Signature {
-    .init(types: typeParameters, terms: termParameters, output: output)
   }
 
   /// Returns the tag of `i`.
@@ -432,7 +426,7 @@ public struct IRFunction: Sendable {
   public func isParameter(_ v: IRValue, _ k: AccessEffect) -> Bool {
     switch v {
     case .parameter(let i):
-      return termParameters[i].access == k
+      return signature.termParameters[i].access == k
     default:
       return false
     }
@@ -444,7 +438,7 @@ public struct IRFunction: Sendable {
     case .register(let i):
       return tag(of: i) == IRAlloca.self
     case .parameter(let i):
-      return termParameters[i].access == .sink
+      return signature.termParameters[i].access == .sink
     default:
       return false
     }
@@ -456,7 +450,7 @@ public struct IRFunction: Sendable {
   public func result(of v: IRValue) -> (type: AnyTypeIdentity, isPlace: Bool)? {
     switch v {
     case .parameter(let i):
-      return resolved(.place(termParameters[i].type))
+      return resolved(.place(signature.termParameters[i].type))
     case .register(let i):
       return resolved(at(i).type)
     case .integer(_, let t):
@@ -840,9 +834,7 @@ public struct IRFunction: Sendable {
   /// its instructions) but leaving a valid function declaration behind. The moved definition can
   /// moved back into `self` using `take(definition:)`.
   public mutating func move() -> IRFunction {
-    var other = IRFunction(
-      name: name, anchor: anchor, output: output,
-      typeParameters: typeParameters, termParameters: termParameters)
+    var other = IRFunction(name: name, anchor: anchor, signature: signature)
 
     swap(&self.bindings, &other.bindings)
     swap(&self.slots, &other.slots)
@@ -880,18 +872,18 @@ extension IRFunction: Showable {
   public func show(using printer: inout TreePrinter) -> String {
     var result = "fun \(printer.show(name))"
 
-    if !typeParameters.isEmpty {
-      result.append("<\(printer.show(typeParameters))>")
+    if !signature.typeParameters.isEmpty {
+      result.append("<\(printer.show(signature.typeParameters))>")
     }
 
     result.append("(")
-    for (i, p) in termParameters.enumerated() {
+    for (i, p) in signature.termParameters.enumerated() {
       if (i != 0) { result.append(", ") }
       result.append("\(p.access) \(printer.show(IRValue.parameter(i))): \(printer.show(p.type))")
     }
     result.append(")")
 
-    if case .remote(let k, let t) = self.output {
+    if case .remote(let k, let t) = signature.output {
       result.append(" \(k) <: \(printer.show(t))")
     }
 
@@ -923,7 +915,7 @@ extension IRFunction.Name: Showable {
 
     case .initializer(let d):
       let n = printer.program.debugName(of: .init(d))
-      return "\(n)$initializer"
+      return "\(n).initializer"
 
     case .synthesized(let d, let a):
       let xs = a.elements.map({ (p, v) in "\(printer.show(p)): \(printer.show(v))" })
@@ -936,16 +928,16 @@ extension IRFunction.Name: Showable {
       return "$implementation[\(n) for \(list: xs)]"
 
     case .existentialized(let n):
-      return "\(printer.show(n))$existentialized"
+      return "\(printer.show(n)).existentialized"
 
     case .applied(let n, let i):
-      return "\(printer.show(n))$applied_\(i)"
+      return "\(printer.show(n)).applied_\(i)"
 
     case .slide(let n, let i):
-      return "\(printer.show(n))$slide_\(i)"
+      return "\(printer.show(n)).slide_\(i)"
 
     case .plateau(let n, let i):
-      return "\(printer.show(n))$plateau_\(i)"
+      return "\(printer.show(n)).plateau_\(i)"
     }
   }
 
@@ -1024,9 +1016,7 @@ extension IRFunction: Archivable {
   public init<A>(from archive: inout ReadableArchive<A>, in context: inout Any) throws {
     self.name = try archive.read(Name.self, in: &context)
     self.anchor = try archive.read(Anchor.self, in: &context)
-    self.output = try archive.read(Output.self, in: &context)
-    self.typeParameters = try archive.read([GenericParameter.ID].self, in: &context)
-    self.termParameters = try archive.read([IRParameter].self, in: &context)
+    self.signature = try archive.read(Signature.self, in: &context)
     self.passedMandatoryInlining = try archive.read(Bool.self)
     self.slots = []
     self.blocks = []
@@ -1063,9 +1053,7 @@ extension IRFunction: Archivable {
   public func write<A>(to archive: inout WriteableArchive<A>, in context: inout Any) throws {
     try archive.write(name, in: &context)
     try archive.write(anchor, in: &context)
-    try archive.write(output, in: &context)
-    try archive.write(typeParameters, in: &context)
-    try archive.write(termParameters, in: &context)
+    try archive.write(signature, in: &context)
     try archive.write(passedMandatoryInlining, in: &context)
 
     // Write the number of basic blocks in the function. Note that the function cannot contain any

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -27,6 +27,9 @@ public struct IRFunction: Sendable {
     /// The identity of the existentialiezd form of a polymorphic function.
     indirect case existentialized(IRFunction.Name)
 
+    /// The identity of a function underlying a closure.
+    indirect case applied(IRFunction.Name, Int)
+
     /// The identity of a slide resulting from subscript decomposition.
     indirect case slide(IRFunction.Name, Int)
 
@@ -46,6 +49,8 @@ public struct IRFunction: Sendable {
         return d == x
       case .existentialized(let n):
         return n.isLoweredForm(of: d)
+      case .applied:
+        return false
       case .slide(let n, _):
         return n.isLoweredForm(of: d)
       case .plateau(let n, _):
@@ -917,18 +922,24 @@ extension IRFunction.Name: Showable {
       return printer.program.debugName(of: d)
 
     case .initializer(let d):
-      return "\(printer.program.debugName(of: .init(d)))$init"
+      let n = printer.program.debugName(of: .init(d))
+      return "\(n)$initializer"
 
     case .synthesized(let d, let a):
       let xs = a.elements.map({ (p, v) in "\(printer.show(p)): \(printer.show(v))" })
-      return "\(printer.program.debugName(of: d))$synthesized<\(list: xs)>"
+      let n = printer.program.debugName(of: d)
+      return "$synthesized[\(n) for \(list: xs)]"
 
     case .implementation(let d, _, let a):
       let xs = a.elements.map({ (p, v) in "\(printer.show(p)): \(printer.show(v))" })
-      return "\(printer.program.debugName(of: d))<\(list: xs)>"
+      let n = printer.program.debugName(of: d)
+      return "$implementation[\(n) for \(list: xs)]"
 
     case .existentialized(let n):
       return "\(printer.show(n))$existentialized"
+
+    case .applied(let n, let i):
+      return "\(printer.show(n))$applied_\(i)"
 
     case .slide(let n, let i):
       return "\(printer.show(n))$slide_\(i)"

--- a/Sources/FrontEnd/IR/IRFunction.swift
+++ b/Sources/FrontEnd/IR/IRFunction.swift
@@ -63,12 +63,12 @@ public struct IRFunction: Sendable {
     case indirect
 
     /// The result is projected.
-    case remote(AccessEffect, AnyTypeIdentity, isAddressor: Bool)
+    case remote(AccessEffect, AnyTypeIdentity)
 
     /// The payload of `self` iff it denotes a projection.
-    public var remote: (AccessEffect, AnyTypeIdentity, Bool)? {
-      if case .remote(let k, let t, let b) = self {
-        return (k, t, b)
+    public var remote: (AccessEffect, AnyTypeIdentity)? {
+      if case .remote(let k, let t) = self {
+        return (k, t)
       } else {
         return nil
       }
@@ -121,7 +121,7 @@ public struct IRFunction: Sendable {
       switch output {
       case .indirect:
         self.head = Arrow(style: .parenthesized, inputs: ps.dropLast(), output: ps.last!.type)
-      case .remote(let k, let o, _):
+      case .remote(let k, let o):
         self.head = Arrow(style: .bracketed, effect: k, inputs: ps, output: o.erased)
       }
     }
@@ -188,15 +188,6 @@ public struct IRFunction: Sendable {
   /// `true` iff the function is a subscript.
   public var isSubscript: Bool {
     output != .indirect
-  }
-
-  /// `true` iff the function is an addressor (i.e., a subscript with an empty slide).
-  public var isAddressor: Bool {
-    if case .remote(_, _, let a) = output {
-      return a
-    } else {
-      return false
-    }
   }
 
    /// `true` iff the function returns a unit value (i.e., an instance of `Hylo.Void`).
@@ -895,8 +886,7 @@ extension IRFunction: Showable {
     }
     result.append(")")
 
-    if case .remote(let k, let t, let b) = self.output {
-      if b { result = "@addressor\n\(result)" }
+    if case .remote(let k, let t) = self.output {
       result.append(" \(k) <: \(printer.show(t))")
     }
 

--- a/Sources/FrontEnd/IR/IRParameter.swift
+++ b/Sources/FrontEnd/IR/IRParameter.swift
@@ -2,7 +2,7 @@ import Archivist
 
 /// A parameter in a Hylo IR function.
 @Archivable
-public struct IRParameter: Sendable {
+public struct IRParameter: Equatable, Sendable {
 
   /// The type of the parameter.
   public let type: AnyTypeIdentity

--- a/Sources/FrontEnd/IR/Instructions/IRWitnessTable.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRWitnessTable.swift
@@ -1,6 +1,16 @@
 import Archivist
 
 /// Creates a witness table.
+///
+///     witness_table
+///       ['<' <arguments... : type> '>']
+///       ['[' <captures... : value> ']']
+///       (<entries... : value>) as <witness : type>
+///
+/// `witness_table` assembles an object witnessing of the conformance of a type to some trait by
+/// gathering `entries`, `aruguments`, and `captures`, which list the implementations the trait's
+/// requirements, the type arguments instantiating generic entries, and the values copied into the
+/// table's stash, respectively.
 @Archivable
 public struct IRWitnessTable: Instruction {
 
@@ -10,13 +20,26 @@ public struct IRWitnessTable: Instruction {
   /// The region of the code corresponding to this instruction.
   public let anchor: Anchor
 
-  /// The type of the witness produced by this instruction.
+  /// The type arguments of the table iff it is generic.
+  public let arguments: TypeArguments
+
+  /// The number of entries in the table.
+  public let entryCount: Int
+
+  /// The type of the witness represented by the table.
   public let witnessType: AnyTypeIdentity
 
   /// Creates an instance with the given properties.
-  public init(witnessType: AnyTypeIdentity, operands: [IRValue], anchor: Anchor) {
-    self.operands = operands
+  public init(
+    instantiatedWith arguments: TypeArguments,
+    aggregating entries: [IRValue], capturing captures: [IRValue],
+    as witnessType: AnyTypeIdentity,
+    at anchor: Anchor
+  ) {
+    self.operands = entries + captures
     self.anchor = anchor
+    self.arguments = arguments
+    self.entryCount = entries.count
     self.witnessType = witnessType
   }
 
@@ -24,12 +47,29 @@ public struct IRWitnessTable: Instruction {
   public init(_ other: Self, substituting properties: IRSubstitutionTable) {
     self.operands = other.operands.map({ (o) in properties[o] })
     self.anchor = properties.anchor(other)
+    self.arguments = other.arguments
+    self.entryCount = other.entryCount
     self.witnessType = other.witnessType
+  }
+
+  /// The implementations populating the table.
+  public var entries: ArraySlice<IRValue> {
+    operands[..<entryCount]
+  }
+
+  /// The values captured in the table.
+  public var captures: ArraySlice<IRValue> {
+    operands[entryCount...]
   }
 
   /// The type of the instruction's result.
   public var type: IRType {
-    .value(witnessType)
+    .place(witnessType)
+  }
+
+  /// `true`.
+  public var isExtendingOperandLifetimes: Bool {
+    true
   }
 
 }
@@ -38,7 +78,18 @@ extension IRWitnessTable: Showable {
 
   /// Returns a textual representation of `self` using `printer`.
   public func show(using printer: inout TreePrinter) -> String {
-    "witnesstable {\(printer.show(operands))} as \(printer.show(witnessType))"
+    var result = "witness_table "
+
+    // Type arguments, if any.
+    if !arguments.isEmpty { result.append("<\(printer.show(arguments.values))>") }
+    // Entries.
+    result.append("{\(printer.show(entries))}")
+    // Captures, if any.
+    if !captures.isEmpty { result.append("+[\(printer.show(captures))]") }
+    // Type.
+    result.append(" as \(printer.show(witnessType))")
+
+    return result
   }
 
 }

--- a/Sources/FrontEnd/IR/Instructions/IRWitnessTableStash.swift
+++ b/Sources/FrontEnd/IR/Instructions/IRWitnessTableStash.swift
@@ -1,0 +1,49 @@
+import Archivist
+
+/// Accesses the captures of a witness table.
+@Archivable
+public struct IRWitnessTableStash: Instruction {
+
+  /// The operands of the instruction.
+  public let operands: [IRValue]
+
+  /// The region of the code corresponding to this instruction.
+  public let anchor: Anchor
+
+  /// The type of the stash being accessed.
+  public let stashType: AnyTypeIdentity
+
+  /// Creates an instance with the given properties.
+  public init(source: IRValue, stashType: AnyTypeIdentity, anchor: Anchor) {
+    self.operands = [source]
+    self.anchor = anchor
+    self.stashType = stashType
+  }
+
+  /// Creates a copy of `other`, substituting its properties with `properties`.
+  public init(_ other: Self, substituting properties: IRSubstitutionTable) {
+    self.operands = [properties[other.source]]
+    self.anchor = properties.anchor(other)
+    self.stashType = other.stashType
+  }
+
+  /// The witness table whose stash is being accessed.
+  public var source: IRValue {
+    operands[0]
+  }
+
+  /// The type of the value loaded by this instruction.
+  public var type: IRType {
+    .place(stashType)
+  }
+
+}
+
+extension IRWitnessTableStash: Showable {
+
+  /// Returns a textual representation of `self` using `printer`.
+  public func show(using printer: inout TreePrinter) -> String {
+    "witness_table_stash \(printer.show(source)) as \(printer.show(stashType))"
+  }
+
+}

--- a/Sources/FrontEnd/IR/Instructions/InstructionTag.swift
+++ b/Sources/FrontEnd/IR/Instructions/InstructionTag.swift
@@ -57,6 +57,7 @@ public struct InstructionTag: Sendable {
     IRTypeWitness.self,
     IRUnreachable.self,
     IRWitnessTable.self,
+    IRWitnessTableStash.self,
     IRYield.self,
   ]
 

--- a/Sources/FrontEnd/IR/Mangling/Base64VarUInt.swift
+++ b/Sources/FrontEnd/IR/Mangling/Base64VarUInt.swift
@@ -15,9 +15,7 @@ public struct Base64VarUInt: Hashable {
   /// The numeric value, in the range `0 ..< UInt64.max`.
   public let rawValue: UInt64
 
-  /// Creates an instance representing `n`.
-  ///
-  /// - Requires: `n >= 0`
+  /// Creates an instance representing `n`, which is in the range `0 ..< UInt64.max`.
   public init<T: BinaryInteger>(_ n: T) {
     self.rawValue = UInt64.init(n)
   }

--- a/Sources/FrontEnd/IR/Mangling/DemangledSymbol.swift
+++ b/Sources/FrontEnd/IR/Mangling/DemangledSymbol.swift
@@ -148,6 +148,9 @@ internal indirect enum DemangledEntity: Hashable, Sendable {
   /// An IRFunction with `name == .existentialized`.
   case existentialized(DemangledEntity)
 
+  /// An IRFunction with `name == .applied`.
+   case applied(DemangledEntity, Int)
+
   /// An IRFunction with `name == .slide`.
    case slide(DemangledEntity, Int)
 
@@ -213,6 +216,8 @@ extension DemangledEntity: CustomStringConvertible {
       return "\(e) implements \(c)<\(args)>"
     case .existentialized(let e):
       return "some \(e)"
+    case .applied(let e, let n):
+      return "applied \(e) \(n)"
     case .slide(let e, let n):
       return "slide \(e) \(n)"
     case .plateau(let e, let n):

--- a/Sources/FrontEnd/IR/Mangling/DemangledSymbol.swift
+++ b/Sources/FrontEnd/IR/Mangling/DemangledSymbol.swift
@@ -149,7 +149,7 @@ internal indirect enum DemangledEntity: Hashable, Sendable {
   case existentialized(DemangledEntity)
 
   /// An IRFunction with `name == .applied`.
-   case applied(DemangledEntity, Int)
+  case applied(DemangledEntity, Int)
 
   /// An IRFunction with `name == .slide`.
    case slide(DemangledEntity, Int)

--- a/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
@@ -138,9 +138,9 @@ internal struct ManglingEncoding: Sendable {
       case .extensionDeclaration:
         demangled = takeExtensionDeclaration(from: &source)
       case .functionDeclaration:
-        demangled = takeFunctionDeclaration(from: &source)
+        demangled = takeFunctionDeclaration(static: false, from: &source)
       case .staticFunctionDeclaration:
-        demangled = takeStaticFunctionDeclaration(from: &source)
+        demangled = takeFunctionDeclaration(static: true, from: &source)
       case .functionBundleDeclaration:
         demangled = takeFunctionBundleDeclaration(from: &source)
       case .initializerDeclaration:
@@ -436,35 +436,18 @@ internal struct ManglingEncoding: Sendable {
       return
     }
 
-    if program.isStatic(d) {
-      output.add(operator: .staticFunctionDeclaration)
-    } else {
-      output.add(operator: .functionDeclaration)
-    }
-
+    output.add(operator: program.isStatic(d) ? .staticFunctionDeclaration : .functionDeclaration)
     append(name: n, to: &output)
     append(typeOf: d, to: &output)
   }
 
   /// Demangles a function declaration from `source`.
   private static func takeFunctionDeclaration(
-    from source: inout DemanglingContext
+    static isStatic: Bool, from source: inout DemanglingContext
   ) -> DemangledEntity {
     if let n = takeName(from: &source) {
       let t = takeType(from: &source)
-      return .functionDeclaration(name: n, type: t, isStatic: false)
-    } else {
-      return .error
-    }
-  }
-
-  /// Demangles a static function declaration from `source`.
-  private static func takeStaticFunctionDeclaration(
-    from source: inout DemanglingContext
-  ) -> DemangledEntity {
-    if let n = takeName(from: &source) {
-      let t = takeType(from: &source)
-      return .functionDeclaration(name: n, type: t, isStatic: true)
+      return .functionDeclaration(name: n, type: t, isStatic: isStatic)
     } else {
       return .error
     }

--- a/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingEncoding.swift
@@ -151,6 +151,12 @@ internal struct ManglingEncoding: Sendable {
         demangled = takeImplementationDeclaration(from: &source)
       case .existentializedDeclaration:
         demangled = takeExistentializedDeclaration(from: &source)
+      case .appliedDeclaration:
+        demangled = takeTaggedEntity(from: &source, { (e, i) in .applied(e, i) })
+      case .slideDeclaration:
+        demangled = takeTaggedEntity(from: &source, { (e, i) in .slide(e, i) })
+      case .plateauDeclaration:
+        demangled = takeTaggedEntity(from: &source, { (e, i) in .plateau(e, i) })
       case .genericParameterDeclaration:
         demangled = takeUnqualifiedEntity(from: &source)
       case .importDeclaration:
@@ -550,15 +556,23 @@ internal struct ManglingEncoding: Sendable {
     case .existentialized(let s):
       output.add(operator: .existentializedDeclaration)
       append(function: s, to: &output)
+    case .applied(let s, let n):
+      append(.appliedDeclaration, tagging: s, with: n, to: &output)
     case .slide(let s, let n):
-      output.add(operator: .slideDeclaration)
-      append(function: s, to: &output)
-      output.add(integer: n)
+      append(.slideDeclaration, tagging: s, with: n, to: &output)
     case .plateau(let s, let n):
-      output.add(operator: .plateauDeclaration)
-      append(function: s, to: &output)
-      output.add(integer: n)
+      append(.plateauDeclaration, tagging: s, with: n, to: &output)
     }
+  }
+
+  /// Writes an application of `o` tagging `n` with `i` to `output`.
+  private mutating func append(
+    _ o: ManglingOperator, tagging n: IRFunction.Name, with i: Int,
+    to output: inout ManglingContext
+  ) {
+    output.add(operator: .plateauDeclaration)
+    append(function: n, to: &output)
+    output.add(integer: i)
   }
 
   /// Demangles an initializer declaration from `source`.
@@ -600,28 +614,12 @@ internal struct ManglingEncoding: Sendable {
     .existentialized(takeEntity(from: &source))
   }
 
-  /// Demangles a slide declaration from `source`.
-  private static func slideDeclaration(
-    from source: inout DemanglingContext
+  /// Returns the result of `make` applied to a demangled entity followed by a tag.
+  private static func takeTaggedEntity(
+    from source: inout DemanglingContext, _ make: (DemangledEntity, Int) -> DemangledEntity
   ) -> DemangledEntity {
     let e = takeEntity(from: &source)
-     if let i = source.takeInt() {
-       return .slide(e, i)
-     } else {
-       return .error
-     }
-  }
-
-  /// Demangles a plateau declaration from `source`.
-  private static func plateauDeclaration(
-    from source: inout DemanglingContext
-  ) -> DemangledEntity {
-    let e = takeEntity(from: &source)
-     if let i = source.takeInt() {
-       return .plateau(e, i)
-     } else {
-       return .error
-     }
+    return source.takeInt().map({ (i) in make(e, i) }) ?? .error
   }
 
   /// Writes the mangled representation of `s` to `output`.

--- a/Sources/FrontEnd/IR/Mangling/ManglingOperator.swift
+++ b/Sources/FrontEnd/IR/Mangling/ManglingOperator.swift
@@ -60,6 +60,9 @@ internal enum ManglingOperator: String, CaseIterable, Sendable {
   /// Starts an existentialized function declaration symbol.
   case existentializedDeclaration = "eF"
 
+  /// Starts the declaration of a partially applied function symbol.
+  case appliedDeclaration = "aF"
+
   /// Starts a slide declaration symbol.
   case slideDeclaration = "lF"
 
@@ -235,6 +238,7 @@ internal enum ManglingOperator: String, CaseIterable, Sendable {
     .synthesizedFunctionDeclaration,
     .implementationDeclaration,
     .existentializedDeclaration,
+    .appliedDeclaration,
     .slideDeclaration,
     .plateauDeclaration,
     .genericParameterDeclaration,

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+Depolymorphization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+Depolymorphization.swift
@@ -7,7 +7,7 @@ extension IRFunction {
   /// by another depolymorphized function.
   internal mutating func depolymorphize(emittingInto m: Module.ID, using typer: inout Typer) {
     assert(isDefined)
-    if !isMonomorphic { return }
+    guard isMonomorphic else { return }
 
     typer.program.withEmitter(insertingIn: m) { (emitter) in
       emitter.depolymorphize(&self)

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+ExclusivityAnalysis.swift
@@ -7,7 +7,7 @@ extension IRFunction {
     emittingInto m: Module.ID, using typer: inout Typer
   ) -> Bool {
     var initial = Transfer.Context()
-    for (i, t) in termParameters.enumerated() {
+    for (i, t) in signature.termParameters.enumerated() {
       addParameter(t, offset: i, to: &initial)
     }
 

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -638,7 +638,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRYield.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    let (k, _, _) = f.output.remote!
+    let (k, _) = f.output.remote!
     passArgument(k, f.at(i).projectee, insertingDeinitializationBefore: i.erased, in: &f)
     return f.instruction(after: i.erased)
   }

--- a/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
+++ b/Sources/FrontEnd/IR/Transforms/IRFunction+LifetimeNormalization.swift
@@ -20,7 +20,7 @@ extension IRFunction {
     emittingInto m: Module.ID, using typer: inout Typer
   ) -> Bool {
     var initial = Transfer.Context()
-    for (i, t) in termParameters.enumerated() {
+    for (i, t) in signature.termParameters.enumerated() {
       addParameter(t, offset: i, to: &initial)
     }
 
@@ -638,7 +638,7 @@ private struct Transfer: AbstractTransferFunction {
   private mutating func interpret(
     _ i: IRYield.ID, from f: inout IRFunction
   ) -> AnyInstructionIdentity? {
-    let (k, _) = f.output.remote!
+    let (k, _) = f.signature.output.remote!
     passArgument(k, f.at(i).projectee, insertingDeinitializationBefore: i.erased, in: &f)
     return f.instruction(after: i.erased)
   }
@@ -783,7 +783,7 @@ private struct Transfer: AbstractTransferFunction {
   private func isBoundImmutably(_ v: IRValue, in f: IRFunction) -> Bool {
     switch v {
     case .parameter(let i):
-      return f.termParameters[i].access == .let
+      return f.signature.termParameters[i].access == .let
     case .register(let i):
       return isBoundImmutably(i, in: f)
     default:

--- a/Sources/FrontEnd/Module.swift
+++ b/Sources/FrontEnd/Module.swift
@@ -192,12 +192,10 @@ public struct Module: Sendable {
     internal mutating func declare(_ f: IRFunction) -> (inserted: Bool, identity: IRFunction.ID) {
       let inserted = modify(&functions[f.name]) { (slot) in
         if let g = slot {
-          assert(f.signature() == g.signature())
+          assert(f.signature == g.signature)
           return false
         } else {
-          let g = IRFunction(
-            name: f.name, anchor: f.anchor, output: f.output,
-            typeParameters: f.typeParameters, termParameters: f.termParameters)
+          let g = IRFunction(name: f.name, anchor: f.anchor, signature: f.signature)
           slot = .some(g)
           return true
         }

--- a/Sources/FrontEnd/Program.swift
+++ b/Sources/FrontEnd/Program.swift
@@ -521,6 +521,8 @@ public struct Program: Sendable {
     switch tag(of: d) {
     case BindingDeclaration.self:
       return isPrivate(castUnchecked(d, to: BindingDeclaration.self), in: m)
+    case ConformanceDeclaration.self:
+      return isPrivate(castUnchecked(d, to: ConformanceDeclaration.self), in: m)
     case FunctionDeclaration.self:
       return isPrivate(castUnchecked(d, to: FunctionDeclaration.self), in: m)
     case FunctionBundleDeclaration.self:
@@ -550,9 +552,7 @@ public struct Program: Sendable {
       return isPrivate(d, in: m)
     case .existentialized(let g):
       return isPrivate(g, in: m)
-    case .slide:
-      return true
-    case .plateau:
+    case .applied, .slide, .plateau:
       return true
     }
   }

--- a/Sources/FrontEnd/Typer/Typer.swift
+++ b/Sources/FrontEnd/Typer/Typer.swift
@@ -440,7 +440,7 @@ public struct Typer {
 
   /// Type checks `d`.
   private mutating func check(_ d: ConformanceDeclaration.ID) {
-    let typeOfWitness = declaredType(of: d)
+    let declarationType = declaredType(of: d)
 
     check(program[d].contextParameters)
 
@@ -457,13 +457,13 @@ public struct Typer {
     // The type of the declaration has the form `<T...> A... ==> P<B...>` where `P<B...>` is the
     // type of the declared witness and the rest forms a context. Requirements are resolved as
     // members of the type `B` where type parameters occur as skolems.
-    let typeOfWitnessSansContext = program.types.contextAndHead(typeOfWitness).head
+    let typeOfWitnessSansContext = program.types.contextAndHead(declarationType).head
     guard let witness = program.types.seenAsTraitApplication(typeOfWitnessSansContext) else {
-      assert(typeOfWitness[.hasError])
+      assert(declarationType[.hasError])
       return
     }
 
-    let conformer = witness.arguments.values[0]
+    let conformer = program.types.dealiased(witness.arguments.values[0])
     let qualification = demand(Metatype(inhabitant: conformer)).erased
 
     // The expected types of implementations satisfying the concept's requirements are computed by

--- a/Sources/FrontEnd/Typer/WitnessTable.swift
+++ b/Sources/FrontEnd/Typer/WitnessTable.swift
@@ -16,6 +16,18 @@ public struct WitnessTable: Hashable, Sendable {
   private var associatedTypes: [Int: AnyTypeIdentity]
 
   /// A table from member requirement to its implementation.
+  ///
+  /// Each value describes how to refer to the implementation of the corresponding requirement in
+  /// the context of the conformance declaration for which this table is described. The following
+  /// cases are possible:
+  ///
+  /// - `.synthetic`: the implementation is synthesized by the compiler.
+  /// - `.direct`: the implementation is defined either in the conformance declaration directly or
+  ///   in the declaration of the conforming type.
+  /// - `.inherited`: the implementation is inherited by conformance or extension.
+  ///
+  /// In the latter case, the witness of the payload describes the qualification of the target,
+  /// which is referred to statically.
   private var members: [Int: DeclarationReference]
 
   /// Creates an empty instance.

--- a/Sources/FrontEnd/Types/TypeStore.swift
+++ b/Sources/FrontEnd/Types/TypeStore.swift
@@ -311,18 +311,14 @@ public struct TypeStore: Sendable {
   /// Returns the canonical representation of a tuple containing the given elements.
   ///
   /// The result is `.void` if `elements` is empty. Otherwise, it is an instance of `Tuple`.
-  public mutating func tuple<S: Sequence<AnyTypeIdentity>>(of elements: S) -> AnyTypeIdentity {
-    let xs = elements.reversed()
-
-    if xs.count == 0 {
-      return .void
-    } else {
-      var result = demand(Tuple.empty)
-      for e in elements.reversed() {
-        result = demand(Tuple.cons(head: e, tail: result.erased))
-      }
-      return result.erased
+  public mutating func tuple<S: Sequence>(
+    of elements: S
+  ) -> AnyTypeIdentity where S.Element: TypeIdentity{
+    var result = demand(Tuple.empty)
+    for e in elements.reversed() {
+      result = demand(Tuple.cons(head: e.erased, tail: result.erased))
     }
+    return result.erased
   }
 
   /// Returns the canonical representation of a tuple of `count` instances of `element`.

--- a/Sources/FrontEnd/Types/TypeStore.swift
+++ b/Sources/FrontEnd/Types/TypeStore.swift
@@ -97,8 +97,8 @@ public struct TypeStore: Sendable {
 
   /// Returns the unique type corresponding to the given signature, creating it if necessary.
   internal mutating func demand(_ s: IRFunction.Signature) -> AnyTypeIdentity {
-    let t = demand(s.head).erased
-    return introduce(parameters: s.context, into: t)
+    let t = demand(s.head()).erased
+    return introduce(parameters: s.typeParameters, into: t)
   }
 
   /// Returns the tag of `n`.

--- a/Sources/Utilities/Array+Extensions.swift
+++ b/Sources/Utilities/Array+Extensions.swift
@@ -21,7 +21,7 @@ extension Array {
   }
 
   /// Creates an array with the contents of `e`, if any.
-  public init(contentsOf e: Element?) {
+  public init(unwrapping e: Element?) {
     if let x = e {
       self = [x]
     } else {

--- a/Tests/CompilerTests/CompilerTests.swift
+++ b/Tests/CompilerTests/CompilerTests.swift
@@ -8,7 +8,7 @@ import Subprocess
 import XCTest
 
 /// `true` iff intermediate compilation artifacts shall be saved for successful tests.
-private let alwaysSaveArtifacts: Bool = false
+private let alwaysSaveArtifacts: Bool = true
 
 /// The driver for generated compiler tests.
 ///
@@ -389,8 +389,7 @@ final class CompilerTests: XCTestCase {
     if t.containsError { return }
     let refinedIR = driver.program.show(driver.program[m].ir)
     artifacts.record(refinedIR, for: .refinedIR)
-    assertArtifact(.refinedIR, expected: expectedArtifacts[.refinedIR],
-      observed: refinedIR)
+    assertArtifact(.refinedIR, expected: expectedArtifacts[.refinedIR], observed: refinedIR)
     if stage == .lowering { return }
 
     // LLVM Lowering.

--- a/Tests/CompilerTests/positive/generic-witness-table.hylo
+++ b/Tests/CompilerTests/positive/generic-witness-table.hylo
@@ -1,0 +1,12 @@
+//! exit-status:42
+
+trait P {
+  fun f() -> Int32
+  fun g() -> Int32 { self.f() + (2 as Int32) }
+}
+
+given <T> => T is P { fun f() -> Int32 { 40 } }
+
+public fun main() -> Int32 {
+  ().g()
+}

--- a/Tests/CompilerTests/positive/synthesized-deinit.refined-ir.expected
+++ b/Tests/CompilerTests/positive/synthesized-deinit.refined-ir.expected
@@ -1,20 +1,13 @@
 fun S0.$<ConformanceDeclaration at synthesized-deinit:8.14>() let <: Deinitializable<S0> {
 %b0:
-  %r0 = alloca Deinitializable<S0>, #preferred
-  %r1 = witnesstable {Deinitializable.deinit<Self: S0>} as Deinitializable<S0>
-  %r2 = access [set] %r0
-  %r3 = store %r1 to %r2
-  %r4 = end %r2
-  %r5 = access [let] %r0
-  %r6 = yield %r5
-  %r7 = end %r5
-  %r8 = access [sink] %r0
-  %r9 = assume_state %r8 uninitialized
-  %r10 = end %r8
-  %r11 = return
+  %r0 = witness_table {$implementation[Deinitializable.deinit for Self: S0]} as Deinitializable<S0>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r4 = return
 }
 
-fun Deinitializable.deinit<Self: S0>(let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
+fun $implementation[Deinitializable.deinit for Self: S0](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
   %r0 = place_cast %p1 as sink S0
   %r1 = access [sink] %r0
@@ -40,21 +33,14 @@ fun S0.deinit(sink %p0: S0, set %p1: Void) {
 
 fun S1.$<ConformanceDeclaration at synthesized-deinit:13.14>() let <: Deinitializable<S1> {
 %b0:
-  %r0 = alloca Deinitializable<S1>, #preferred
-  %r1 = witnesstable {Deinitializable.deinit<Self: S1>} as Deinitializable<S1>
-  %r2 = access [set] %r0
-  %r3 = store %r1 to %r2
-  %r4 = end %r2
-  %r5 = access [let] %r0
-  %r6 = yield %r5
-  %r7 = end %r5
-  %r8 = access [sink] %r0
-  %r9 = assume_state %r8 uninitialized
-  %r10 = end %r8
-  %r11 = return
+  %r0 = witness_table {$implementation[Deinitializable.deinit for Self: S1]} as Deinitializable<S1>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r4 = return
 }
 
-fun Deinitializable.deinit<Self: S1>(let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
+fun $implementation[Deinitializable.deinit for Self: S1](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
   %r0 = place_cast %p1 as sink S1
   %r1 = access [sink] %r0
@@ -76,7 +62,7 @@ fun S1.deinit(sink %p0: S1, set %p1: Void) {
   %r6 = access [let] %r4
   %r7 = access [sink] %p0
   %r8 = access [set] %r5
-  %r9 = apply Deinitializable.deinit$synthesized<Self: S1>(%r6, %r7) => %r8
+  %r9 = apply $synthesized[Deinitializable.deinit for Self: S1](%r6, %r7) => %r8
   %r10 = end %r8
   %r11 = end %r7
   %r12 = end %r6
@@ -84,34 +70,29 @@ fun S1.deinit(sink %p0: S1, set %p1: Void) {
   %r3 = return
 }
 
-fun Deinitializable.deinit$synthesized<Self: S2>(let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
+fun $synthesized[Deinitializable.deinit for Self: S1](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
-  %r0 = access [sink] %p1
-  %r1 = assume_state %r0 uninitialized
-  %r2 = end %r0
-  %r3 = access [set] %p2
-  %r4 = assume_state %r3 initialized
-  %r5 = end %r3
-  %r6 = return
+  %r0 = place_cast %p1 as sink S1
+  %r1 = place_cast %r0 as sink Void
+  %r2 = access [sink] %r1
+  %r3 = assume_state %r2 uninitialized
+  %r4 = end %r2
+  %r5 = access [set] %p2
+  %r6 = assume_state %r5 initialized
+  %r7 = end %r5
+  %r8 = return
 }
 
 fun S2.$<ConformanceDeclaration at synthesized-deinit:17.14>() let <: Deinitializable<S2> {
 %b0:
-  %r0 = alloca Deinitializable<S2>, #preferred
-  %r1 = witnesstable {Deinitializable.deinit$synthesized<Self: S2>} as Deinitializable<S2>
-  %r2 = access [set] %r0
-  %r3 = store %r1 to %r2
-  %r4 = end %r2
-  %r5 = access [let] %r0
-  %r6 = yield %r5
-  %r7 = end %r5
-  %r8 = access [sink] %r0
-  %r9 = assume_state %r8 uninitialized
-  %r10 = end %r8
-  %r11 = return
+  %r0 = witness_table {$synthesized[Deinitializable.deinit for Self: S2]} as Deinitializable<S2>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r4 = return
 }
 
-fun Deinitializable.deinit$synthesized<Self: S2>(let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
+fun $synthesized[Deinitializable.deinit for Self: S2](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
   %r0 = access [sink] %p1
   %r1 = assume_state %r0 uninitialized
@@ -122,7 +103,16 @@ fun Deinitializable.deinit$synthesized<Self: S2>(let %p0: Deinitializable<Self>,
   %r6 = return
 }
 
-fun Deinitializable.deinit$synthesized<Self: S3>(let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
+fun S3.$<ConformanceDeclaration at synthesized-deinit:19.14>() let <: Deinitializable<S3> {
+%b0:
+  %r0 = witness_table {$synthesized[Deinitializable.deinit for Self: S3]} as Deinitializable<S3>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r4 = return
+}
+
+fun $synthesized[Deinitializable.deinit for Self: S3](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
   %r0 = place_cast %p1 as sink S3
   %r1 = place_cast %r0 as sink {Int, {S0, S1}}
@@ -161,21 +151,14 @@ fun Deinitializable.deinit$synthesized<Self: S3>(let %p0: Deinitializable<Self>,
 
 fun E0.$<ConformanceDeclaration at synthesized-deinit:26.12>() let <: Deinitializable<E0> {
 %b0:
-  %r0 = alloca Deinitializable<E0>, #preferred
-  %r1 = witnesstable {Deinitializable.deinit<Self: E0>} as Deinitializable<E0>
-  %r2 = access [set] %r0
-  %r3 = store %r1 to %r2
-  %r4 = end %r2
-  %r5 = access [let] %r0
-  %r6 = yield %r5
-  %r7 = end %r5
-  %r8 = access [sink] %r0
-  %r9 = assume_state %r8 uninitialized
-  %r10 = end %r8
-  %r11 = return
+  %r0 = witness_table {$implementation[Deinitializable.deinit for Self: E0]} as Deinitializable<E0>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r4 = return
 }
 
-fun Deinitializable.deinit<Self: E0>(let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
+fun $implementation[Deinitializable.deinit for Self: E0](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
   %r0 = place_cast %p1 as sink E0
   %r1 = access [sink] %r0
@@ -197,7 +180,7 @@ fun E0.deinit(sink %p0: E0, set %p1: Void) {
   %r6 = access [let] %r4
   %r7 = access [sink] %p0
   %r8 = access [set] %r5
-  %r9 = apply Deinitializable.deinit$synthesized<Self: E0>(%r6, %r7) => %r8
+  %r9 = apply $synthesized[Deinitializable.deinit for Self: E0](%r6, %r7) => %r8
   %r10 = end %r8
   %r11 = end %r7
   %r12 = end %r6
@@ -205,23 +188,45 @@ fun E0.deinit(sink %p0: E0, set %p1: Void) {
   %r3 = return
 }
 
-fun E2.$<ConformanceDeclaration at synthesized-deinit:32.12>() let <: Deinitializable<E2> {
+fun $synthesized[Deinitializable.deinit for Self: E0](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
-  %r0 = alloca Deinitializable<E2>, #preferred
-  %r1 = witnesstable {Deinitializable.deinit$synthesized<Self: E2>} as Deinitializable<E2>
-  %r2 = access [set] %r0
-  %r3 = store %r1 to %r2
-  %r4 = end %r2
-  %r5 = access [let] %r0
-  %r6 = yield %r5
-  %r7 = end %r5
-  %r8 = access [sink] %r0
-  %r9 = assume_state %r8 uninitialized
-  %r10 = end %r8
-  %r11 = return
+  %r0 = place_cast %p1 as sink E0
+  %r1 = enum_tag %r0
+  %r2 = switch %r1, %b1, %b2
+%b1:
+  %r3 = case "a" of %r0
+  %r4 = place_cast %r3 as sink {Int}
+  %r5 = subfield %r4 at 0 as Int
+  %r6 = access [sink] %r5
+  %r7 = assume_state %r6 uninitialized
+  %r8 = end %r6
+  %r9 = br %b3
+%b2:
+  %r10 = case "b" of %r0
+  %r11 = place_cast %r10 as sink {Int}
+  %r12 = subfield %r11 at 0 as Int
+  %r13 = access [sink] %r12
+  %r14 = assume_state %r13 uninitialized
+  %r15 = end %r13
+  %r16 = br %b3
+%b3:
+  %r17 = access [set] %p2
+  %r18 = assume_state %r17 initialized
+  %r19 = end %r17
+  %r20 = return
 }
 
-fun Deinitializable.deinit$synthesized<Self: E2>(let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
+
+fun E2.$<ConformanceDeclaration at synthesized-deinit:32.12>() let <: Deinitializable<E2> {
+%b0:
+  %r0 = witness_table {$synthesized[Deinitializable.deinit for Self: E2]} as Deinitializable<E2>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r4 = return
+}
+
+fun $synthesized[Deinitializable.deinit for Self: E2](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
   %r0 = access [sink] %p1
   %r1 = assume_state %r0 uninitialized
@@ -234,21 +239,14 @@ fun Deinitializable.deinit$synthesized<Self: E2>(let %p0: Deinitializable<Self>,
 
 fun E3.$<ConformanceDeclaration at synthesized-deinit:34.12>() let <: Deinitializable<E3> {
 %b0:
-  %r0 = alloca Deinitializable<E3>, #preferred
-  %r1 = witnesstable {Deinitializable.deinit$synthesized<Self: E3>} as Deinitializable<E3>
-  %r2 = access [set] %r0
-  %r3 = store %r1 to %r2
-  %r4 = end %r2
-  %r5 = access [let] %r0
-  %r6 = yield %r5
-  %r7 = end %r5
-  %r8 = access [sink] %r0
-  %r9 = assume_state %r8 uninitialized
-  %r10 = end %r8
-  %r11 = return
+  %r0 = witness_table {$synthesized[Deinitializable.deinit for Self: E3]} as Deinitializable<E3>
+  %r1 = access [let] %r0
+  %r2 = yield %r1
+  %r3 = end %r1
+  %r4 = return
 }
 
-fun Deinitializable.deinit$synthesized<Self: E3>(let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
+fun $synthesized[Deinitializable.deinit for Self: E3](let %p0: Deinitializable<Self>, sink %p1: Self, set %p2: Void) {
 %b0:
   %r0 = place_cast %p1 as sink E3
   %r1 = enum_tag %r0

--- a/Tests/FrontEndTests/IR/IRBlockTests.swift
+++ b/Tests/FrontEndTests/IR/IRBlockTests.swift
@@ -10,9 +10,10 @@ final class IRBlockTests: XCTestCase {
     var f = IRFunction(
       name: .lowered(.init(d)),
       anchor: p.anchor(at: p[d].site, in: p.parent(containing: d)),
-      output: .indirect,
-      typeParameters: [],
-      termParameters: [.init(type: .void, access: .set, declaration: nil)])
+      signature: .init(
+        typeParameters: [],
+        termParameters: [.init(type: .void, access: .set, declaration: nil)],
+        output: .indirect))
 
     let entry = f.addBlock()
     let s = IRAlloca(

--- a/Tests/InterpreterTests/TypeLayoutTests.swift
+++ b/Tests/InterpreterTests/TypeLayoutTests.swift
@@ -24,7 +24,7 @@ final class TypeLayoutTests: XCTestCase {
   }
 
   func testTrivialTuples() throws {
-    let void = layout(p.types.tuple(of: []))
+    let void = layout(.void)
     XCTAssertEqual(void.size, 0)
     XCTAssertEqual(void.alignment, 1)
     XCTAssert(void.parts.isEmpty)


### PR DESCRIPTION
This patch implements generic witness tables.

It is probably too large to be reviewed; my apologies. Instead I propose that we walk through the implementation during a team meeting.