### PR TITLE
Interpreter: Interpreting integers independent of host machine

### DIFF
--- a/Sources/Interpreter/Endianness.swift
+++ b/Sources/Interpreter/Endianness.swift
@@ -1,0 +1,9 @@
+/// The order in which the bytes of multi-byte values are arranged in memory.
+public enum Endianness {
+
+  /// Places the least significant byte at the lowest address.
+  case little
+
+  /// Places the most significant byte at the lowest address.
+  case big
+}

--- a/Sources/Interpreter/IntegerPredicate+Extensions.swift
+++ b/Sources/Interpreter/IntegerPredicate+Extensions.swift
@@ -22,19 +22,19 @@ extension IntegerPredicate {
   }
 
   /// Returns whether `lhs` satisfies `self` with respect to `rhs` where `lhs`
-  /// and `rhs` are `w`-bit integers.
+  /// and `rhs` are `w`-bit integers in byte order `o`.
   internal func callAsFunction(
     _ lhs: RuntimeValue, _ rhs: RuntimeValue,
-    bitWidth w: Int
+    bitWidth w: Int, inByteOrder o: Endianness
   ) -> Bool {
     switch w {
     case 8: self(lhs.asI8, rhs.asI8)
-    case 16: self(lhs.asI16, rhs.asI16)
-    case 32: self(lhs.asI32, rhs.asI32)
-    case 64: self(lhs.asI64, rhs.asI64)
+    case 16: self(lhs.asI16(assumingByteOrder: o), rhs.asI16(assumingByteOrder: o))
+    case 32: self(lhs.asI32(assumingByteOrder: o), rhs.asI32(assumingByteOrder: o))
+    case 64: self(lhs.asI64(assumingByteOrder: o), rhs.asI64(assumingByteOrder: o))
     // TODO: uncomment when 128-bit integer is supported.
     //
-    // case 128: self(lhs.i128, rhs.i128)
+    // case 128: self(lhs.i128(assumingByteOrder: o), rhs.i128(assumingByteOrder: o))
     default: fatalError("Unknown builtin integer size \(w)")
     }
   }

--- a/Sources/Interpreter/Interpreter.swift
+++ b/Sources/Interpreter/Interpreter.swift
@@ -177,6 +177,9 @@ public struct Interpreter {
   /// `true` iff the program is still running.
   public var isRunning: Bool { !callStack.isEmpty }
 
+  /// The ABI for which the types will be laid out.
+  public var abi: any TargetABI { memory.abi }
+
   /// Local variables, parameters and return address.
   private var callStack = Stack()
 
@@ -362,7 +365,7 @@ public struct Interpreter {
         return try memory.read(from: topOfStack.parameters[i])
       case .integer(let n, let t):
         let l = memory.layout(t)
-        return .init(integer: n, bitWidth: l.size * 8, alignment: l.alignment)
+        return .init(integer: n, bitWidth: l.size * 8, byteOrder: abi.byteOrder)
       default:
         preconditionFailure("\(program.show(v)) is not a RuntimeValue.")
       }
@@ -419,14 +422,14 @@ public struct Interpreter {
       let w = memory.layout(t).size * 8
       let lhs = try self[arguments[0]]
       let rhs = try self[arguments[1]]
-      let r = p(lhs, rhs, bitWidth: w)
+      let r = p(lhs, rhs, bitWidth: w, inByteOrder: abi.byteOrder)
       return .init(bool: r)
     case .zeroinitializer(let t):
       let l = memory.layout(t)
       let u = program.types[t]
       return switch u {
-      case .i(_): .init(integer: 0, bitWidth: l.size * 8, alignment: l.alignment)
-      case .word: .init(integer: 0, bitWidth: l.size * 8, alignment: l.alignment)
+      case .i(_): .init(integer: 0, bitWidth: l.size * 8, byteOrder: abi.byteOrder)
+      case .word: .init(integer: 0, bitWidth: l.size * 8, byteOrder: abi.byteOrder)
       default: unimplemented("zero-initializer is not yet implemented for \(program.show(u)).")
       }
     default: unimplemented("\(program.show(f)) is not implemented yet.")

--- a/Sources/Interpreter/Memory.swift
+++ b/Sources/Interpreter/Memory.swift
@@ -101,46 +101,6 @@ struct Memory {
       }
     }
 
-    /// Returns the result of calling `body` on the storage for a `T` instance at `a`.
-    ///
-    /// - Precondition: the storage exists and is properly aligned.
-    internal mutating func withUnsafeMutablePointer<T, R>(
-      to _: T.Type, at a: Offset, _ body: (UnsafeMutablePointer<T>) -> R
-    ) -> R {
-      precondition(a + MemoryLayout<T>.size <= size)
-      precondition(offset(a, hasAlignment: MemoryLayout<T>.alignment))
-      return storage.withUnsafeMutableBytes { p in
-        body((p.baseAddress! + baseOffset + a).assumingMemoryBound(to: T.self))
-      }
-    }
-
-    /// Returns the result of calling `body` on the storage for a `T` instance at `a`.
-    ///
-    /// - Precondition: the storage exists and is properly aligned.
-    internal func withUnsafePointer<T, R>(
-      to _: T.Type, at a: Offset, _ body: (UnsafePointer<T>) -> R
-    ) -> R {
-      precondition(a + MemoryLayout<T>.size <= size)
-      return storage.withUnsafeBytes { p in
-        body((p.baseAddress! + baseOffset + a).assumingMemoryBound(to: T.self))
-      }
-    }
-
-    /// Returns the unsigned interpretation of `t` at `a`.
-    internal func unsignedIntValue(at a: Offset, ofType t: MachineType) -> UInt {
-      if case .i(let n) = t {
-        return switch n {
-        case 8: UInt(withUnsafePointer(to: UInt8.self, at: a) { $0.pointee })
-        case 16: UInt(withUnsafePointer(to: UInt16.self, at: a) { $0.pointee })
-        case 32: UInt(withUnsafePointer(to: UInt32.self, at: a) { $0.pointee })
-        case 64: UInt(withUnsafePointer(to: UInt64.self, at: a) { $0.pointee })
-        default: fatalError("Unknown builtin integer size \(n)")
-        }
-      } else {
-        preconditionFailure("Unrecognized builtin integer type \(t)")
-      }
-    }
-
     /// Returns `true` iff `o` is aligned to an `n` byte boundary.
     public func offset(_ o: Offset, hasAlignment n: Int) -> Bool {
       storage.withUnsafeBytes {
@@ -227,7 +187,7 @@ struct Memory {
   }
 
   /// The value stored at `p`.
-  fileprivate subscript(_ p: Memory.TypedAddress) -> RuntimeValue {
+  public subscript(_ p: Memory.TypedAddress) -> RuntimeValue {
     mutating get {
       let l = layout(p.type)
       let bs = self[p.allocation].storage[p.offset..<p.offset + l.size]
@@ -238,6 +198,37 @@ struct Memory {
       precondition(newValue.bytes.count == l.size)
       self[p.allocation].storage[p.offset..<p.offset + l.size]
         .copyElements(from: newValue.bytes)
+    }
+  }
+
+  /// The value of integer type `t` stored at `p`.
+  private subscript(_ p: Memory.Address, ofIntegerType t: MachineType) -> RuntimeValue {
+    get {
+      let n = abi.size(t)
+      let bs = self[p.allocation].storage[p.offset..<p.offset + n]
+      return RuntimeValue(bytes: bs)
+    }
+    set {
+      let n = abi.size(t)
+      precondition(newValue.bytes.count == n)
+      self[p.allocation].storage[p.offset..<p.offset + n]
+        .copyElements(from: newValue.bytes)
+    }
+  }
+
+  /// Returns the unsigned interpretation of `t` at `a`.
+  public func unsignedIntValue(at a: Memory.Address, ofType t: MachineType) -> UInt {
+    if case .i(let n) = t {
+      let o = abi.byteOrder
+      return switch n {
+      case 8: UInt(self[a, ofIntegerType: .i(8)].asI8)
+      case 16: UInt(self[a, ofIntegerType: .i(16)].asI16(assumingByteOrder: o))
+      case 32: UInt(self[a, ofIntegerType: .i(32)].asI32(assumingByteOrder: o))
+      case 64: UInt(self[a, ofIntegerType: .i(64)].asI64(assumingByteOrder: o))
+      default: fatalError("Unknown builtin integer size \(n)")
+      }
+    } else {
+      preconditionFailure("Unrecognized builtin integer type \(t)")
     }
   }
 }

--- a/Sources/Interpreter/Memory.swift
+++ b/Sources/Interpreter/Memory.swift
@@ -10,6 +10,9 @@ struct Memory {
   /// The type layouts computed so far.
   internal var typeLayouts: TypeLayoutCache
 
+  /// The ABI for which the types will be laid out.
+  public var abi: any TargetABI { typeLayouts.abi }
+
   /// The ID of the next block to be allocated.
   private var nextAllocation = 0
 
@@ -222,6 +225,21 @@ struct Memory {
       yield &allocation[i]!
     }
   }
+
+  /// The value stored at `p`.
+  fileprivate subscript(_ p: Memory.TypedAddress) -> RuntimeValue {
+    mutating get {
+      let l = layout(p.type)
+      let bs = self[p.allocation].storage[p.offset..<p.offset + l.size]
+      return RuntimeValue(bytes: bs)
+    }
+    set {
+      let l = layout(p.type)
+      precondition(newValue.bytes.count == l.size)
+      self[p.allocation].storage[p.offset..<p.offset + l.size]
+        .copyElements(from: newValue.bytes)
+    }
+  }
 }
 
 extension Memory.Address {
@@ -317,28 +335,12 @@ extension Memory {
     return .init(allocation: whole.allocation, offset: o + whole.offset, type: t)
   }
 
-  /// Returns the value stored at `p`.
-  private mutating func read(from p: Memory.TypedAddress) -> RuntimeValue {
-    let l = layout(p.type)
-    let bs = self[p.allocation].storage[p.offset..<p.offset + l.size]
-    return RuntimeValue(bytes: Array(bs), havingAlignment: l.alignment)
-  }
-
   /// Returns the value stored at `p`, using the permissions and obligations
   /// associated with `p`.
   public mutating func read(from p: Access<Memory.TypedAddress>) throws -> RuntimeValue {
     // TODO: throw if it is illegal to read from `p` using its permissions.
     // TODO: throw if location pointed by `p` is uninitialized.
-    read(from: p.location)
-  }
-
-  /// Stores `v` at `p`.
-  ///
-  /// - Precondition: `v` is an instance of type `p.type`.
-  private mutating func store(_ v: RuntimeValue, at p: Memory.TypedAddress) {
-    let n = v.bytes.count
-    let o = p.offset
-    self[p.allocation].storage[o..<o + n] = v.bytes
+    self[p.location]
   }
 
   /// Stores `v` at `p`.
@@ -347,7 +349,7 @@ extension Memory {
   public mutating func store(_ v: RuntimeValue, at p: Access<Memory.TypedAddress>) throws {
     // TODO: throw if it is illegal to write to `p` using its permissions.
     // TODO: throw if location pointed by `p` is not fully uninitialized.
-    store(v, at: p.location)
+    self[p.location] = v
   }
 
 }

--- a/Sources/Interpreter/Memory.swift
+++ b/Sources/Interpreter/Memory.swift
@@ -202,7 +202,9 @@ struct Memory {
   }
 
   /// The value of integer type `t` stored at `p`.
-  private subscript(_ p: Memory.Address, ofIntegerType t: MachineType) -> RuntimeValue {
+  ///
+  /// - Precondition `t` is a builtin integer type.
+  public subscript(_ p: Memory.Address, ofIntegerType t: MachineType) -> RuntimeValue {
     get {
       let n = abi.size(t)
       let bs = self[p.allocation].storage[p.offset..<p.offset + n]

--- a/Sources/Interpreter/MonomorphicTypeIdentity.swift
+++ b/Sources/Interpreter/MonomorphicTypeIdentity.swift
@@ -2,7 +2,7 @@ import FrontEnd
 import Utilities
 
 /// The identity of a monomorphic type.
-struct MonomorphicTypeIdentity: Regular {
+public struct MonomorphicTypeIdentity: Regular {
 
   /// The underlying type identity having no generic parameters or
   /// unification variables.

--- a/Sources/Interpreter/RuntimeValue.swift
+++ b/Sources/Interpreter/RuntimeValue.swift
@@ -5,130 +5,87 @@ import Utilities
 /// A value occurring during program execution.
 struct RuntimeValue {
 
-  /// The bytes of the value preceded by zero or more bytes of padding to satisfy
-  /// its alignment.
-  private let storage: [UInt8]
-
-  /// The number of bytes before the value logically begins.
-  private let baseOffset: Int
-
-  /// Creates an instance having bytes `bs` and alignment `a`.
-  public init(bytes bs: [UInt8], havingAlignment a: Int) {
-    var (s, o) = Array.aligned(
-      repeating: 0 as UInt8,
-      count: bs.count,
-      alignment: a
-    )
-    s[o...] = bs[...]
-    baseOffset = o
-    storage = s
-  }
-
   /// Raw bytes of the value.
-  public var bytes: ArraySlice<UInt8> { storage[baseOffset...] }
+  public let bytes: ArraySlice<UInt8>
+
 }
 
 extension RuntimeValue {
 
-  /// Creates a `w`-bit integer having value `n` and alignment `a`.
-  public init(integer n: BigInt, bitWidth w: Int, alignment a: Int) {
+  /// Creates a `w`-bit integer having value `n` and the given byte order.
+  public init(integer n: BigInt, bitWidth w: Int, byteOrder: Endianness) {
     precondition(w == 8 || w == 16 || w == 32 || w == 64 || w == 128)
-    precondition(a > 0)
 
     let r = twosComplementRepresentation(n)
-    self.init(bytes: byteRepresentation(r, bitWidth: w), havingAlignment: a)
+    self.init(bytes: byteRepresentation(r, bitWidth: w, inByteOrder: byteOrder)[...])
   }
 
-  /// Creates an instance of `MachineType.i(1)` having value `b` and layout `l`.
+  /// Creates an instance of `MachineType.i(1)` having value `b`.
   public init(bool b: Bool) {
-    self.init(integer: b ? 1 : 0, bitWidth: 8, alignment: 1)
-  }
-
-  /// Returns the result of calling `body` on a pointer to the value's bytes
-  /// interpreted as a `T` instance.
-  ///
-  /// - Precondition: `self` is aligned for `T`.
-  internal func withUnsafePointer<T, R>(
-    to _: T.Type, _ body: (UnsafePointer<T>) -> R
-  ) -> R {
-    precondition(MemoryLayout<T>.size <= bytes.count)
-    return bytes.withUnsafeBytes { p in
-      body(p.baseAddress!.assumingMemoryBound(to: T.self))
-    }
+    // Byte order doesn't matter for single-byte types.
+    self.init(integer: b ? 1 : 0, bitWidth: 8, byteOrder: .little)
   }
 
   /// The boolean value.
   ///
   /// - Precondition: `self` is an instance of `MachineType.i(1)`.
   public var asBool: Bool {
-    withUnsafePointer(to: UInt8.self) { $0.pointee != 0 }
+    bytes.first! != 0
   }
 
   /// The 8-bit unsigned value.
   ///
   /// - Precondition: `self` is an instance of `MachineType.i(8)`.
   public var asI8: UInt8 {
-    withUnsafePointer(to: UInt8.self) { $0.pointee }
+    bytes.first!
   }
 
-  /// The 16-bit unsigned value.
+  /// The 16-bit unsigned value, assuming byte order `o`.
   ///
   /// - Precondition: `self` is an instance of `MachineType.i(16)`.
-  public var asI16: UInt16 {
-    withUnsafePointer(to: UInt16.self) { $0.pointee }
+  public func asI16(assumingByteOrder o: Endianness) -> UInt16 {
+    integerValue(as: UInt16.self, assumingByteOrder: o)
   }
 
-  /// The 32-bit unsigned value.
+  /// The 32-bit unsigned value, assuming byte order `o`.
   ///
   /// - Precondition: `self` is an instance of `MachineType.i(32)`.
-  public var asI32: UInt32 {
-    withUnsafePointer(to: UInt32.self) { $0.pointee }
+  public func asI32(assumingByteOrder o: Endianness) -> UInt32 {
+    integerValue(as: UInt32.self, assumingByteOrder: o)
   }
 
-  /// The 64-bit unsigned value.
+  /// The 64-bit unsigned value, assuming byte order `o`.
   ///
   /// - Precondition: `self` is an instance of `MachineType.i(64)`.
-  public var asI64: UInt64 {
-    withUnsafePointer(to: UInt64.self) { $0.pointee }
+  public func asI64(assumingByteOrder o: Endianness) -> UInt64 {
+    integerValue(as: UInt64.self, assumingByteOrder: o)
   }
 
   // TODO: uncomment when 128-bit integer is supported.
   //
-  // /// The 128-bit unsigned value.
+  // /// The 128-bit unsigned value, assuming byte order `o`.
   // ///
   // /// - Precondition: `self` is an instance of `MachineType.i(128)`.
-  // public var asI128: UInt128 {
-  //   withUnsafePointer(to: UInt128.self) { $0.pointee }
+  // public func asI128(assumingByteOrder o: Endianness) -> UInt128 {
+  //   integerValue(as: UInt128.self, assumingByteOrder: o)
   // }
 
-}
+  /// Returns the bytes of `self` interpreted as an integer of type `t`, assuming
+  /// they are arranged in byte order `o`.
+  private func integerValue<T: FixedWidthInteger>(
+    as t: T.Type, assumingByteOrder o: Endianness
+  ) -> T {
+    precondition(bytes.count == T.bitWidth / 8)
 
-/// Returns an in-memory byte representation of the low-order `w` bits of `n`.
-internal func byteRepresentation(_ n: UInt128, bitWidth w: Int) -> [UInt8] {
-  precondition(w == 8 || w == 16 || w == 32 || w == 64 || w == 128)
-  switch w {
-  case 8:
-    let value = UInt8(truncatingIfNeeded: n)
-    return withUnsafeBytes(of: value, Array.init)
-
-  case 16:
-    let value = UInt16(truncatingIfNeeded: n)
-    return withUnsafeBytes(of: value, Array.init)
-
-  case 32:
-    let value = UInt32(truncatingIfNeeded: n)
-    return withUnsafeBytes(of: value, Array.init)
-
-  case 64:
-    let value = UInt64(truncatingIfNeeded: n)
-    return withUnsafeBytes(of: value, Array.init)
-
-  case 128:
-    return withUnsafeBytes(of: n, Array.init)
-
-  default:
-    unreachable()
+    return (0..<bytes.count).reduce(0) { result, i in
+      let j = byteIndex(
+        forLeastSignificantByte: i,
+        byteCount: bytes.count,
+        inByteOrder: o)
+      return result | T(bytes[j]) << (i * 8)
+    }
   }
+
 }
 
 /// Returns 128-bit two's-complement representation of `n`.
@@ -140,4 +97,38 @@ internal func twosComplementRepresentation(_ n: BigInt) -> UInt128 {
   }
 
   return UInt128.max - UInt128(n.magnitude) + 1
+}
+
+/// Returns the in-memory byte representation of the low-order `w` bits of `n`,
+/// arranged in `byteOrder`.
+internal func byteRepresentation(
+  _ n: UInt128,
+  bitWidth w: Int,
+  inByteOrder byteOrder: Endianness
+) -> [UInt8] {
+  precondition(w == 8 || w == 16 || w == 32 || w == 64 || w == 128)
+
+  let byteCount = w / 8
+  return (0..<byteCount).map { i in
+    let j = byteIndex(
+      forLeastSignificantByte: i,
+      byteCount: byteCount,
+      inByteOrder: byteOrder)
+    return UInt8(truncatingIfNeeded: n >> (j * 8))
+  }
+}
+
+/// Returns the index at which the `i`th least-significant byte is arranged in
+/// `byteOrder`.
+private func byteIndex(
+  forLeastSignificantByte i: Int,
+  byteCount: Int,
+  inByteOrder byteOrder: Endianness
+) -> Int {
+  switch byteOrder {
+  case .little:
+    return i
+  case .big:
+    return byteCount - 1 - i
+  }
 }

--- a/Sources/Interpreter/TargetABI.swift
+++ b/Sources/Interpreter/TargetABI.swift
@@ -9,6 +9,10 @@ protocol TargetABI {
   /// The number of bits in a pointer type.
   var bitsInAPointer: Int { get }
 
+  /// The order in which the bytes of values of multi-byte machine types are
+  /// arranged.
+  var byteOrder: Endianness { get }
+
 }
 
 extension TargetABI {
@@ -53,6 +57,10 @@ struct UnrealABI: TargetABI {
 
   /// The number of bits in a pointer type.
   var bitsInAPointer: Int { bitsInAWord }
+
+  /// The order in which the bytes of values of multi-byte machine types are
+  /// arranged.
+  var byteOrder: Endianness { .little }
 
 }
 

--- a/Sources/Interpreter/TargetABI.swift
+++ b/Sources/Interpreter/TargetABI.swift
@@ -1,7 +1,7 @@
 import FrontEnd
 
 /// Types that describe the ABI for which we might interpret code.
-protocol TargetABI {
+public protocol TargetABI {
 
   /// Returns the alignment of `t`, which is 1 for `.i(1)` and `.i(8)`.
   func alignment(_ t: MachineType) -> Int

--- a/Sources/Interpreter/TypeLayout.swift
+++ b/Sources/Interpreter/TypeLayout.swift
@@ -2,7 +2,7 @@ import FrontEnd
 import Utilities
 
 /// The layout of a type in memory, including the positions of its parts.
-struct TypeLayout: Regular {
+public struct TypeLayout: Regular {
 
   /// Memory layout of a type, without any detail about parts.
   public struct StorageRequirements: Regular {

--- a/Sources/Interpreter/TypeLayoutCache.swift
+++ b/Sources/Interpreter/TypeLayoutCache.swift
@@ -5,7 +5,7 @@ import Utilities
 struct TypeLayoutCache {
 
   /// The ABI for which the types will be laid out.
-  let abi: any TargetABI
+  public let abi: any TargetABI
 
   /// The memo of layouts computed so far.
   private var storage: [MonomorphicTypeIdentity: TypeLayout] = [:]

--- a/Sources/Utilities/MutableCollection+Extensions.swift
+++ b/Sources/Utilities/MutableCollection+Extensions.swift
@@ -34,7 +34,29 @@ extension MutableCollection where Self: RangeReplaceableCollection {
     let p = index(low, offsetBy: m)
     let q = try compactMapInPlace(count: m, low: low, high: p, transform)
     let r = try compactMapInPlace(count: n - m, low: p, high: high, transform)
-    return rotate(subrange: q ..< r, toStartAt: p)
+    return rotate(subrange: q..<r, toStartAt: p)
+  }
+
+}
+
+extension MutableCollection {
+
+  /// Copies `min(self.count, c.count)` elements from `c` to start of `self`.
+  ///
+  /// - Complexity: O(`min(self.count, c.count)`).
+  public mutating func copyElements<C>(from c: C)
+  where
+    C: Collection,
+    Element == C.Element
+  {
+    var p = self.startIndex
+    for e in c {
+      if p == self.endIndex {
+        break
+      }
+      self[p] = e
+      self.formIndex(after: &p)
+    }
   }
 
 }

--- a/Tests/InterpreterTests/MemoryTests+internal.swift
+++ b/Tests/InterpreterTests/MemoryTests+internal.swift
@@ -5,25 +5,18 @@ import XCTest
 
 final class InterpreterMemoryInternalTests: XCTestCase {
 
-  func testFormingPointerToLastByteOfAllocation() throws {
+  func testReadingAndWritingToMemory() throws {
     var m = Memory(forRunning: .init(forTesting: true), on: UnrealABI())
-    let a = m.allocate(.init(m.program.id(MachineType.i(8))))
 
-    m[a.allocation].withUnsafeMutablePointer(to: UInt8.self, at: 0) { p in
-      p.pointee = 2
-    }
-    m[a.allocation].withUnsafePointer(to: UInt8.self, at: 0) { p in
-      XCTAssertEqual(p.pointee, 2)
-    }
+    let i1 = m.program.id(MachineType.i(1))
+    var a = m.allocate(storageFor: i1).asTypedAddress(i1)
+    m[a] = RuntimeValue(bool: true)
+    XCTAssertEqual(m[a].asBool, true)
 
-  }
-
-  func testFormingPointerToOneByteLaterThanLastByteOfAllocation() throws {
-    var m = Memory(forRunning: .init(forTesting: true), on: UnrealABI())
-    let a = m.allocate(.init(m.program.id(MachineType.i(8))))
-
-    m[a.allocation].withUnsafeMutablePointer(to: Void.self, at: 1) { _ = $0 }
-    m[a.allocation].withUnsafePointer(to: Void.self, at: 1) { _ = $0 }
+    let i16 = m.program.id(MachineType.i(16))
+    a = m.allocate(storageFor: i16).asTypedAddress(i16)
+    m[a] = RuntimeValue(integer: 16, bitWidth: 16, byteOrder: .little)
+    XCTAssertEqual(m[a].asI16(assumingByteOrder: .little), 16)
   }
 
   func testCheckAlignmentAndAllocationBounds() throws {
@@ -39,30 +32,6 @@ final class InterpreterMemoryInternalTests: XCTestCase {
     check(throws: Memory.Error.bounds(a + 30, for: l, allocationSize: 31)) {
       try m[a.allocation].checkAlignmentAndAllocationBounds(at: 30, for: l)
     }
-  }
-
-  func testUnsignnedIntValue() throws {
-    var m = Memory(forRunning: .init(forTesting: true), on: UnrealABI())
-    let a = m.allocate(.init(m.program.id(MachineType.i(8))), count: 64)
-    m[a.allocation].withUnsafeMutablePointer(to: UInt8.self, at: 0) { p in
-      p.pointee = 8
-    }
-    XCTAssertEqual(m[a.allocation].unsignedIntValue(at: 0, ofType: .i(8)), 8)
-
-    m[a.allocation].withUnsafeMutablePointer(to: UInt16.self, at: 0) { p in
-      p.pointee = 16
-    }
-    XCTAssertEqual(m[a.allocation].unsignedIntValue(at: 0, ofType: .i(16)), 16)
-
-    m[a.allocation].withUnsafeMutablePointer(to: UInt32.self, at: 0) { p in
-      p.pointee = 32
-    }
-    XCTAssertEqual(m[a.allocation].unsignedIntValue(at: 0, ofType: .i(32)), 32)
-
-    m[a.allocation].withUnsafeMutablePointer(to: UInt64.self, at: 0) { p in
-      p.pointee = 64
-    }
-    XCTAssertEqual(m[a.allocation].unsignedIntValue(at: 0, ofType: .i(64)), 64)
   }
 
 }

--- a/Tests/InterpreterTests/MemoryTests.swift
+++ b/Tests/InterpreterTests/MemoryTests.swift
@@ -74,6 +74,27 @@ final class InterpreterMemoryTests: XCTestCase {
       .init(allocation: a.allocation, offset: a.offset + 4, type: .init(i32)))
   }
 
+  func testUnsignnedIntValue() throws {
+    let i8 = id(MachineType.i(8))
+    let i16 = id(MachineType.i(16))
+    let i32 = id(MachineType.i(32))
+    let i64 = id(MachineType.i(64))
+
+    let a = m.allocate(storageFor: i8, count: 64)
+
+    m[a.asTypedAddress(i8)] = .init(integer: 8, bitWidth: 8, byteOrder: .little)
+    XCTAssertEqual(m.unsignedIntValue(at: a, ofType: .i(8)), 8)
+
+    m[a.asTypedAddress(i16)] = .init(integer: 16, bitWidth: 16, byteOrder: .little)
+    XCTAssertEqual(m.unsignedIntValue(at: a, ofType: .i(16)), 16)
+
+    m[a.asTypedAddress(i32)] = .init(integer: 32, bitWidth: 32, byteOrder: .little)
+    XCTAssertEqual(m.unsignedIntValue(at: a, ofType: .i(32)), 32)
+
+    m[a.asTypedAddress(i64)] = .init(integer: 64, bitWidth: 64, byteOrder: .little)
+    XCTAssertEqual(m.unsignedIntValue(at: a, ofType: .i(64)), 64)
+  }
+
   /// Returns the type erased identity of `t`.
   private func id<T: TypeTree>(_ t: T) -> AnyTypeIdentity {
     m.program.id(t)

--- a/Tests/InterpreterTests/RuntimeValueTests.swift
+++ b/Tests/InterpreterTests/RuntimeValueTests.swift
@@ -14,29 +14,42 @@ final class RuntimeValueTests: XCTestCase {
   }
 
   func testRuntimeValueIntegerInitializer() {
-    XCTAssertEqual(RuntimeValue(integer: 0, bitWidth: 8, alignment: 1).bytes, [0])
-    XCTAssertEqual(RuntimeValue(integer: 1, bitWidth: 8, alignment: 1).bytes, [1])
-    XCTAssertEqual(RuntimeValue(integer: -1, bitWidth: 8, alignment: 1).bytes, [255])
-    XCTAssertEqual(RuntimeValue(integer: -2, bitWidth: 8, alignment: 1).bytes, [254])
+    for b in [.little, .big] as [Endianness] {
+      XCTAssertEqual(RuntimeValue(integer: 0, bitWidth: 8, byteOrder: b).asI8, 0)
+      XCTAssertEqual(RuntimeValue(integer: 1, bitWidth: 8, byteOrder: b).asI8, 1)
+      XCTAssertEqual(RuntimeValue(integer: -1, bitWidth: 8, byteOrder: b).asI8, 255)
+      XCTAssertEqual(RuntimeValue(integer: -2, bitWidth: 8, byteOrder: b).asI8, 254)
+
+      XCTAssertEqual(
+        RuntimeValue(integer: 1, bitWidth: 16, byteOrder: b)
+          .asI16(assumingByteOrder: b), 1)
+      XCTAssertEqual(
+        RuntimeValue(integer: -1, bitWidth: 16, byteOrder: b)
+          .asI16(assumingByteOrder: b), UInt16.max)
+
+      XCTAssertEqual(
+        RuntimeValue(integer: 1, bitWidth: 32, byteOrder: b)
+          .asI32(assumingByteOrder: b), 1)
+      XCTAssertEqual(
+        RuntimeValue(integer: -1, bitWidth: 32, byteOrder: b)
+          .asI32(assumingByteOrder: b), UInt32.max)
+
+      XCTAssertEqual(
+        RuntimeValue(integer: 1, bitWidth: 64, byteOrder: b)
+          .asI64(assumingByteOrder: b), 1)
+      XCTAssertEqual(
+        RuntimeValue(integer: -1, bitWidth: 64, byteOrder: b)
+          .asI64(assumingByteOrder: b), UInt64.max)
+    }
+  }
+
+  func testRuntimeValueInitializerFollowsByteOrder() {
+    XCTAssertEqual(RuntimeValue(integer: 0, bitWidth: 8, byteOrder: .little).bytes, [0])
 
     XCTAssertEqual(
-      RuntimeValue(integer: 1, bitWidth: 16, alignment: 2).bytes,
-      withUnsafeBytes(of: UInt16(1), Array.init)[...])
+      RuntimeValue(integer: 0xff01, bitWidth: 16, byteOrder: .little).bytes, [0x01, 0xff])
     XCTAssertEqual(
-      RuntimeValue(integer: -1, bitWidth: 16, alignment: 2).bytes,
-      withUnsafeBytes(of: UInt16(65535), Array.init)[...])
-
-    XCTAssertEqual(
-      RuntimeValue(integer: 1, bitWidth: 32, alignment: 4).bytes,
-      withUnsafeBytes(of: UInt32(1), Array.init)[...])
-
-    XCTAssertEqual(
-      RuntimeValue(integer: 1, bitWidth: 64, alignment: 8).bytes,
-      withUnsafeBytes(of: UInt64(1), Array.init)[...])
-
-    XCTAssertEqual(
-      RuntimeValue(integer: 1, bitWidth: 128, alignment: 8).bytes,
-      withUnsafeBytes(of: UInt128(1), Array.init)[...])
+      RuntimeValue(integer: 0xff01, bitWidth: 16, byteOrder: .big).bytes, [0xff, 0x01])
   }
 
   func testRuntimeValueBoolInitializer() {
@@ -47,16 +60,6 @@ final class RuntimeValueTests: XCTestCase {
     let t = RuntimeValue(bool: true)
     XCTAssertTrue(t.asBool)
     XCTAssertEqual(t.bytes, [1])
-  }
-
-  func testRuntimeValueAlignment() {
-    for i in 1...10 {
-      let b = Array(repeating: UInt8(0), count: i)
-      let a = UInt(
-        bitPattern: RuntimeValue(bytes: b, havingAlignment: i).bytes.withUnsafeBytes(\.baseAddress)!
-      )
-      XCTAssert(a % UInt(i) == 0)
-    }
   }
 
 }

--- a/Tests/UtilitiesTests/MutableCollectionTests.swift
+++ b/Tests/UtilitiesTests/MutableCollectionTests.swift
@@ -20,4 +20,20 @@ final class MutableCollectionTests: XCTestCase {
     }
   }
 
+  func testCopyElements() {
+    let source = Array(0..<10)
+
+    var destination = Array(10..<20)
+    destination.copyElements(from: source)
+    XCTAssertEqual(destination, Array(0..<10))
+
+    destination = Array(10..<15)
+    destination.copyElements(from: source)
+    XCTAssertEqual(destination, Array(0..<5))
+
+    destination = Array(10..<30)
+    destination.copyElements(from: source)
+    XCTAssertEqual(destination, Array(0..<10) + Array(20..<30))
+  }
+
 }


### PR DESCRIPTION
Currently, while reading or writing integers in memory we relied on `assumingMemoryBound(to:)`. However, host alignment might be different than ABI alignment. So, this is an machine dependent UB.

Also, endianness is a property of ABI that was currently missing and is important for reading or writing integers independent of host machine.

The PR fixes the above issues, by providing endianness as an ABI property and doing host independent interpretation of integers.